### PR TITLE
Fix macOS protobuf install

### DIFF
--- a/scripts/setup/install-protobuf
+++ b/scripts/setup/install-protobuf
@@ -38,9 +38,9 @@ amd64|386)
 	elif [ "$GOOS" = linux ]; then
 		wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-linux-x86_64.zip"
     elif [ "$GOOS" = darwin ]; then
-        wget -O $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-osx-x86_64.zip"
+        curl -Lo $PROTOBUF_DIR/protobuf "https://github.com/google/protobuf/releases/download/v$PROTOBUF_VERSION/protoc-$PROTOBUF_VERSION-osx-x86_64.zip"
 	fi
-	unzip $PROTOBUF_DIR/protobuf -d /usr/local
+	unzip $PROTOBUF_DIR/protobuf -x readme.txt -d /usr/local
 	;;
 
 ppc64le)


### PR DESCRIPTION
* Replace wget with curl for macOS
* Exclude readme.txt as there are permissions errors extracting this on macOS