### PR TITLE
E2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: Continuous integration
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
-
+  [push]
+  
 jobs:
   build:
     name: Build
@@ -28,3 +25,6 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: E2E Test
+        run: make e2e-local

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ cli: ## Compile the cli
 	--build-arg TARGET_ARCH=${GOARCH} \
 	--target cli
 
+e2e-local: ## Run End to end local tests
+	go run ./tests/e2e/e2e.go
+
 cross: ## Compile the CLI for linux, darwin and windows
 	@docker build . \
 	--output type=local,dest=./bin \

--- a/cli/main.go
+++ b/cli/main.go
@@ -34,7 +34,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	// Backend registrations
 	_ "github.com/docker/api/azure"
@@ -148,9 +147,7 @@ func main() {
 	ctx = store.WithContextStore(ctx, s)
 
 	if err = root.ExecuteContext(ctx); err != nil {
-		if strings.Contains(err.Error(), "unknown command") {
-			execMoby(ctx)
-		}
+		execMoby(ctx)
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,11 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/onsi/gomega v1.9.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1 // indirect
+	github.com/robpike/filter v0.0.0-20150108201509-2984852a2183
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -119,6 +120,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
+github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -153,6 +156,10 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
+github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
+github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -183,6 +190,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/robpike/filter v0.0.0-20150108201509-2984852a2183 h1:qDhD/wJDGyWrXKLIKmEKpKK/ejaZlguyeEaLZzmrtzo=
+github.com/robpike/filter v0.0.0-20150108201509-2984852a2183/go.mod h1:3dvYi47BCPInRb2ILlNnrXfl++XpwTWLbIxPyJsUvCw=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -232,6 +241,7 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -249,6 +259,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -269,6 +280,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -294,7 +306,11 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
+gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/robpike/filter"
+
+	f "github.com/docker/api/tests/framework"
+	g "github.com/onsi/gomega"
+)
+
+func main() {
+	setup()
+
+	It("ensures context command includes azure-login and aci-create", func() {
+		output := f.NewDockerCommand("context", "create", "--help").ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("docker context create CONTEXT BACKEND [OPTIONS] [flags]"))
+		g.Expect(output).To(g.ContainSubstring("--aci-location"))
+		g.Expect(output).To(g.ContainSubstring("--aci-subscription-id"))
+		g.Expect(output).To(g.ContainSubstring("--aci-resource-group"))
+	})
+
+	It("should be initialized with default context", func() {
+		f.NewCommand("docker", "context", "use", "default").ExecOrDie()
+		output := f.NewCommand("docker", "context", "ls").ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("default *"))
+	})
+
+	It("should list all legacy commands", func() {
+		output := f.NewDockerCommand("--help").ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("swarm"))
+	})
+
+	It("should execute legacy commands", func() {
+		output, _ := f.NewDockerCommand("swarm", "join").Exec()
+		g.Expect(output).To(g.ContainSubstring("\"docker swarm join\" requires exactly 1 argument."))
+	})
+
+	It("should run local container in less than 2 secs", func() {
+		f.NewDockerCommand("pull", "hello-world").ExecOrDie()
+		output := f.NewDockerCommand("run", "hello-world").WithTimeout(time.NewTimer(2 * time.Second).C).ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("Hello from Docker!"))
+	})
+
+	It("should list local container", func() {
+		output := f.NewDockerCommand("ps", "-a").ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("hello-world"))
+	})
+
+	It("creates a new test context to hardcoded example backend", func() {
+		f.NewDockerCommand("context", "create", "test-example", "example").ExecOrDie()
+		//g.Expect(output).To(g.ContainSubstring("test-example context acitest created"))
+	})
+	defer f.NewCommand("docker", "context", "rm", "test-example", "-f").ExecOrDie()
+
+	It("uses the test context", func() {
+		currentContext := f.NewCommand("docker", "context", "use", "test-example").ExecOrDie()
+		g.Expect(currentContext).To(g.ContainSubstring("test-example"))
+		output := f.NewCommand("docker", "context", "ls").ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("test-example *"))
+	})
+
+	It("can run ps command", func() {
+		output := f.NewDockerCommand("ps").ExecOrDie()
+		lines := lines(output)
+		g.Expect(len(lines)).To(g.Equal(3))
+		g.Expect(lines[2]).To(g.ContainSubstring("1234  alpine"))
+	})
+
+	It("can run 'run' command", func() {
+		output := f.NewDockerCommand("run", "nginx", "-p", "80:80").ExecOrDie()
+		g.Expect(output).To(g.ContainSubstring("Running container \"nginx\" with name"))
+	})
+}
+
+func nonEmptyString(s string) bool {
+	return strings.TrimSpace(s) != ""
+}
+
+func lines(output string) []string {
+	return filter.Choose(strings.Split(output, "\n"), nonEmptyString).([]string)
+}
+
+// It runs func
+func It(description string, test func()) {
+	test()
+	log.Print("Passed: ", description)
+}
+
+func gomegaFailHandler(message string, callerSkip ...int) {
+	log.Fatal(message)
+}
+
+func setup() {
+	g.RegisterFailHandler(gomegaFailHandler)
+}

--- a/tests/framework/exec.go
+++ b/tests/framework/exec.go
@@ -1,0 +1,177 @@
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+)
+
+func (b CmdContext) makeCmd() *exec.Cmd {
+	return exec.Command(b.command, b.args...)
+}
+
+// CmdContext is used to build, customize and execute a command.
+// Add more functions to customize the context as needed.
+type CmdContext struct {
+	command string
+	args    []string
+	envs    []string
+	dir     string
+	stdin   io.Reader
+	timeout <-chan time.Time
+	retries RetriesContext
+}
+
+// RetriesContext is used to tweak retry loop.
+type RetriesContext struct {
+	count    int
+	interval time.Duration
+}
+
+// NewCommand creates a command context.
+func NewCommand(command string, args ...string) *CmdContext {
+	return &CmdContext{
+		command: command,
+		args:    args,
+		retries: RetriesContext{interval: time.Second},
+	}
+}
+
+func dockerExecutable() string {
+	if runtime.GOOS == "windows" {
+		return "./bin/windows/docker.exe"
+	}
+	return "./bin/docker"
+}
+
+// NewDockerCommand creates a docker builder.
+func NewDockerCommand(args ...string) *CmdContext {
+	return NewCommand(dockerExecutable(), args...)
+}
+
+// WithinDirectory tells Docker the cwd.
+func (b *CmdContext) WithinDirectory(path string) *CmdContext {
+	b.dir = path
+	return b
+}
+
+// WithEnvs set envs in context.
+func (b *CmdContext) WithEnvs(envs []string) *CmdContext {
+	b.envs = envs
+	return b
+}
+
+// WithTimeout controls maximum duration.
+func (b *CmdContext) WithTimeout(t <-chan time.Time) *CmdContext {
+	b.timeout = t
+	return b
+}
+
+// WithRetries sets how many times to retry the command before issuing an error
+func (b *CmdContext) WithRetries(count int) *CmdContext {
+	b.retries.count = count
+	return b
+}
+
+// Every interval between 2 retries
+func (b *CmdContext) Every(interval time.Duration) *CmdContext {
+	b.retries.interval = interval
+	return b
+}
+
+// WithStdinData feeds via stdin.
+func (b CmdContext) WithStdinData(data string) *CmdContext {
+	b.stdin = strings.NewReader(data)
+	return &b
+}
+
+// WithStdinReader feeds via stdin.
+func (b CmdContext) WithStdinReader(reader io.Reader) *CmdContext {
+	b.stdin = reader
+	return &b
+}
+
+// ExecOrDie runs a docker command.
+func (b CmdContext) ExecOrDie() string {
+	str, err := b.Exec()
+	log.Debugf("stdout: %s", str)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return str
+}
+
+// Exec runs a docker command.
+func (b CmdContext) Exec() (string, error) {
+	retry := b.retries.count
+	for ; ; retry-- {
+		cmd := b.makeCmd()
+		cmd.Dir = b.dir
+		cmd.Stdin = b.stdin
+		if b.envs != nil {
+			cmd.Env = b.envs
+		}
+		stdout, err := Execute(cmd, b.timeout)
+		if err == nil || retry < 1 {
+			return stdout, err
+		}
+		time.Sleep(b.retries.interval)
+	}
+}
+
+// Execute executes a command.
+// The command cannot be re-used afterwards.
+func Execute(cmd *exec.Cmd, timeout <-chan time.Time) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = mergeWriter(cmd.Stdout, &stdout)
+	cmd.Stderr = mergeWriter(cmd.Stderr, &stderr)
+
+	log.Infof("Execute '%s %s'", cmd.Path, strings.Join(cmd.Args[1:], " ")) // skip arg[0] as it is printed separately
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("error starting %v:\nCommand stdout:\n%v\nstderr:\n%v\nerror:\n%v", cmd, stdout.String(), stderr.String(), err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cmd.Wait()
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			log.Debugf("%s %s failed: %v", cmd.Path, strings.Join(cmd.Args[1:], " "), err)
+			return stderr.String(), fmt.Errorf("error running %v:\nCommand stdout:\n%v\nstderr:\n%v\nerror:\n%v", cmd, stdout.String(), stderr.String(), err)
+		}
+	case <-timeout:
+		log.Debugf("%s %s timed-out", cmd.Path, strings.Join(cmd.Args[1:], " "))
+		if err := cmd.Process.Kill(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf(
+			"timed out waiting for command %v:\nCommand stdout:\n%v\nstderr:\n%v",
+			cmd.Args, stdout.String(), stderr.String())
+	}
+	if stderr.String() != "" {
+		log.Debugf("stderr: %s", stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+func mergeWriter(other io.Writer, buf io.Writer) io.Writer {
+	if other != nil {
+		return io.MultiWriter(other, buf)
+	}
+	return buf
+}
+
+// Powershell runs a powershell command.
+func Powershell(input string) (string, error) {
+	output, err := Execute(exec.Command("powershell", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Unrestricted", "-Command", input), nil)
+	if err != nil {
+		return "", fmt.Errorf("fail to execute %s: %s", input, err)
+	}
+	return strings.TrimSpace(output), nil
+}


### PR DESCRIPTION
Run local e2e tests, using example backend. 
* Some context commands are not yet available in ./bin/docker, using the default docker command to switch context
* not running the `make e2E` in a docker yet, as it requires docker to test switching to moby when on default context

Current e2e tests : 3 secs

```
 $ make e2e-local
go run ./tests/e2e/e2e.go
INFO[0000] Execute './bin/docker context create --help' 
2020/05/04 16:37:59 Passed: ensures context command includes azure-login and aci-create
INFO[0000] Execute '/usr/local/bin/docker context use default' 
INFO[0000] Execute '/usr/local/bin/docker context ls'   
2020/05/04 16:37:59 Passed: should be initialized with default context
INFO[0000] Execute './bin/docker --help'                
2020/05/04 16:38:00 Passed: should list all legacy commands
INFO[0000] Execute './bin/docker swarm join'            
2020/05/04 16:38:00 Passed: should execute legacy commands
INFO[0000] Execute './bin/docker pull hello-world'      
INFO[0002] Execute './bin/docker run hello-world'       
2020/05/04 16:38:03 Passed: should run local container in less than 2 secs
INFO[0003] Execute './bin/docker ps -a'                 
2020/05/04 16:38:03 Passed: should list local container
INFO[0003] Execute './bin/docker context create test-example example' 
2020/05/04 16:38:03 Passed: creates a new test context to hardcoded example backend
INFO[0003] Execute '/usr/local/bin/docker context use test-example' 
INFO[0003] Execute '/usr/local/bin/docker context ls'   
2020/05/04 16:38:03 Passed: uses the test context
INFO[0003] Execute './bin/docker ps'                    
2020/05/04 16:38:03 Passed: can run ps command
INFO[0003] Execute './bin/docker run nginx -p 80:80'    
2020/05/04 16:38:03 Passed: can run 'run' command
INFO[0003] Execute '/usr/local/bin/docker context rm test-example -f' 
```