### PR TITLE
Cleanup Makefiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,13 @@ ADD . ${PWD}
 FROM fs AS make-protos
 RUN make -f builder.Makefile protos
 
-FROM make-protos AS make-cli
+FROM fs AS make-cli
 RUN --mount=type=cache,target=/root/.cache/go-build \
     GOOS=${TARGET_OS} \
     GOARCH=${TARGET_ARCH} \
     make -f  builder.Makefile cli
 
-FROM make-protos AS make-cross
+FROM fs AS make-cross
 RUN --mount=type=cache,target=/root/.cache/go-build \
     make -f builder.Makefile cross
 

--- a/Makefile
+++ b/Makefile
@@ -23,39 +23,38 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH
 # THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-GIT_COMMIT=$(shell git rev-parse --short HEAD)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-
-PROTOS=$(shell find . -name \*.proto)
 
 export DOCKER_BUILDKIT=1
 
 all: cli
 
-protos:
+protos: ## Generate go code from .proto files
 	@docker build . \
 	--target protos
 
-cli:
+cli: ## Compile the cli
 	@docker build . \
 	--output type=local,dest=./bin \
 	--build-arg TARGET_OS=${GOOS} \
 	--build-arg TARGET_ARCH=${GOARCH} \
 	--target cli
 
-cross:
+cross: ## Compile the CLI for linux, darwin and windows
 	@docker build . \
 	--output type=local,dest=./bin \
 	--target cross
 
-test:
+test: ## Run unit tests
 	@docker build . \
 	--target test
 
-cache-clear:
+cache-clear: # Clear the builder cache
 	@docker builder prune --force --filter type=exec.cachemount --filter=unused-for=24h
 
-FORCE:
+help: ## Show help
+	@echo Please specify a build target. The choices are:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: all protos cli cross
+.PHONY: all protos cli cross test cache-clear help

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 ## Dev Setup
 
-To setup a development machine to update the API protobufs, first run the  `./setup-dev.sh` script to install the correct version of protobufs on your system and get the protobuild binary.
+Make sure you have Docker installed and running.
 
-## Building the API Project
+## Building the project
 
 ```bash
-> make
+$ make
 ```
+
+If you make changes to the `.proto` files, make sure to `make protos` to generate go code.


### PR DESCRIPTION
* add `make help` target
* remove unused variables
* add .exe to the binary name when on windows
* add ldflags to go build to strip the binary (smaller binary size)
* `make protos` must be executed manually when proto files change