### PR TITLE
Refactor example/backend

### DIFF
--- a/azure/backend.go
+++ b/azure/backend.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	backend.Register("aci", "aci", func(ctx context.Context) (interface{}, error) {
+	backend.Register("aci", "aci", func(ctx context.Context) (backend.Service, error) {
 		return New(ctx)
 	})
 }
@@ -53,11 +53,11 @@ func New(ctx context.Context) (backend.Service, error) {
 
 func getAciAPIService(cgc containerinstance.ContainerGroupsClient, aciCtx store.AciContext) *aciAPIService {
 	return &aciAPIService{
-		container: aciContainerService{
+		aciContainerService: aciContainerService{
 			containerGroupsClient: cgc,
 			ctx:                   aciCtx,
 		},
-		compose: aciComposeService{
+		aciComposeService: aciComposeService{
 			containerGroupsClient: cgc,
 			ctx:                   aciCtx,
 		},
@@ -65,21 +65,21 @@ func getAciAPIService(cgc containerinstance.ContainerGroupsClient, aciCtx store.
 }
 
 type aciAPIService struct {
-	container aciContainerService
-	compose   aciComposeService
+	aciContainerService
+	aciComposeService
 }
 
 func (a *aciAPIService) ContainerService() containers.Service {
 	return &aciContainerService{
-		containerGroupsClient: a.container.containerGroupsClient,
-		ctx:                   a.container.ctx,
+		containerGroupsClient: a.aciContainerService.containerGroupsClient,
+		ctx:                   a.aciContainerService.ctx,
 	}
 }
 
 func (a *aciAPIService) ComposeService() compose.Service {
 	return &aciComposeService{
-		containerGroupsClient: a.compose.containerGroupsClient,
-		ctx:                   a.compose.ctx,
+		containerGroupsClient: a.aciComposeService.containerGroupsClient,
+		ctx:                   a.aciComposeService.ctx,
 	}
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -17,7 +17,7 @@ var (
 	errTypeRegistered = errors.New("backend: already registered")
 )
 
-type initFunc func(context.Context) (interface{}, error)
+type initFunc func(context.Context) (Service, error)
 
 type registeredBackend struct {
 	name        string
@@ -58,7 +58,7 @@ func Register(name string, backendType string, init initFunc) {
 
 // Get returns the backend registered for a particular type, it returns
 // an error if there is no registered backends for the given type.
-func Get(ctx context.Context, backendType string) (interface{}, error) {
+func Get(ctx context.Context, backendType string) (Service, error) {
 	for _, b := range backends.r {
 		if b.backendType == backendType {
 			return b.init(ctx)

--- a/client/client.go
+++ b/client/client.go
@@ -29,7 +29,6 @@ package client
 
 import (
 	"context"
-	"errors"
 
 	"github.com/docker/api/backend"
 	backendv1 "github.com/docker/api/backend/v1"
@@ -53,15 +52,11 @@ func New(ctx context.Context) (*Client, error) {
 	}
 	contextType := s.GetType(cc)
 
-	b, err := backend.Get(ctx, contextType)
+	service, err := backend.Get(ctx, contextType)
 	if err != nil {
 		return nil, err
 	}
 
-	service, ok := b.(backend.Service)
-	if !ok {
-		return nil, errors.New("backend not found")
-	}
 	return &Client{
 		backendType: contextType,
 		bs:          service,


### PR DESCRIPTION
Also promote init function from returning
interface{} to backend.Service to avoid typecasting