### PR TITLE
Faster build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,25 @@
 name: Continuous integration
 
-on:
-  [push]
-  
+on: [push]
+
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run golangci-lint
+        env:
+          GO111MODULE: "on"
+          GOROOT: ""
+        uses: actions-contrib/golangci-lint@v1
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      GO111MODULE: "on"
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -17,14 +30,18 @@ jobs:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Lint
-        run: make lint
-
-      - name: Build
-        run: make cli
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Test
-        run: make test
+        run: make -f builder.Makefile test
+
+      - name: Build
+        run: make -f builder.Makefile cli
 
       - name: E2E Test
         run: make e2e-local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,47 @@
 # syntax = docker/dockerfile:experimental
 ARG GO_VERSION=1.14.2
 
-FROM golang:${GO_VERSION} AS fs
+FROM golang:${GO_VERSION} AS base
+ARG TARGET_OS=unknown
+ARG TARGET_ARCH=unknown
+ARG PWD=/api
+ENV GO111MODULE=on
+
+RUN go get github.com/golang/protobuf/protoc-gen-go@v1.4.1
+
+WORKDIR ${PWD}
+ADD go.* ${PWD}
+ADD . ${PWD}
+
+FROM golang:${GO_VERSION} AS protos-base
 ARG TARGET_OS=unknown
 ARG TARGET_ARCH=unknown
 ARG PWD=/api
 ENV GO111MODULE=on
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    make \
-    git \
     protobuf-compiler \
     libprotobuf-dev
 
-RUN go get github.com/golang/protobuf/protoc-gen-go@v1.4.1 && \
-    go get golang.org/x/tools/cmd/goimports && \
-    go get gotest.tools/gotestsum@v0.4.2 && \
-    go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.26.0
+RUN go get github.com/golang/protobuf/protoc-gen-go@v1.4.1
 
 WORKDIR ${PWD}
 ADD go.* ${PWD}
-RUN go mod download
 ADD . ${PWD}
 
-FROM fs AS make-protos
+FROM golang:${GO_VERSION} AS lint-base
+RUN go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.26.0
+
+FROM protos-base AS make-protos
 RUN make -f builder.Makefile protos
 
-FROM fs AS make-cli
+FROM base AS make-cli
 RUN --mount=type=cache,target=/root/.cache/go-build \
     GOOS=${TARGET_OS} \
     GOARCH=${TARGET_ARCH} \
     make -f  builder.Makefile cli
 
-FROM fs AS make-cross
+FROM base AS make-cross
 RUN --mount=type=cache,target=/root/.cache/go-build \
     make -f builder.Makefile cross
 
@@ -45,8 +54,8 @@ COPY --from=make-cli /api/bin/* .
 FROM scratch AS cross
 COPY --from=make-cross /api/bin/* .
 
-FROM fs as test
+FROM base as test
 RUN make -f builder.Makefile test
 
-FROM fs AS lint
+FROM lint-base AS lint
 RUN make -f builder.Makefile lint

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -55,11 +55,10 @@ cross:
 	@GOOS=windows GOARCH=amd64 $(GO_BUILD) -o $(BINARY)-windows-amd64.exe ./cli
 
 test:
-	@gotestsum ./...
+	@go test ./...
 
 lint:
 	golangci-lint run --timeout 10m0s ./...
-
 
 FORCE:
 

--- a/context/store/store.go
+++ b/context/store/store.go
@@ -105,6 +105,11 @@ func New(opts ...Opt) (Store, error) {
 	s := &store{
 		root: filepath.Join(home, ".docker"),
 	}
+	if _, err := os.Stat(s.root); os.IsNotExist(err) {
+		if err = os.Mkdir(s.root, 0755); err != nil {
+			return nil, err
+		}
+	}
 	for _, opt := range opts {
 		opt(s)
 	}


### PR DESCRIPTION
* Run  in parallel
  * lint
  * test/build/e2e test
* use cache for go
* do not use docker for building
* remove useless dependencies from the base image

Build time passes from 5 minutes to 1 minute 30 seconds