### PR TITLE
Fix `make protos`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ ARG TARGET_ARCH=unknown
 ARG PWD=/api
 ENV GO111MODULE=on
 
-RUN go get github.com/golang/protobuf/protoc-gen-go@v1.4.1
-
 WORKDIR ${PWD}
 ADD go.* ${PWD}
 ADD . ${PWD}
@@ -23,7 +21,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     protobuf-compiler \
     libprotobuf-dev
 
-RUN go get github.com/golang/protobuf/protoc-gen-go@v1.4.1
+RUN go get github.com/golang/protobuf/protoc-gen-go@v1.4.1 && \
+    go get golang.org/x/tools/cmd/goimports
 
 WORKDIR ${PWD}
 ADD go.* ${PWD}

--- a/context/store/store_test.go
+++ b/context/store/store_test.go
@@ -33,9 +33,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/api/errdefs"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/docker/api/errdefs"
 )
 
 type StoreTestSuite struct {


### PR DESCRIPTION
The base target for protos was missing goimports, which we run after
making protos so that the linter doesn't fail on generated code