### PR TITLE
Release CI config

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: releaser
+
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  upload-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+        id: go
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: make -f builder.Makefile cross
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "bin/*"
+          prerelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Upload windows, mac & linux artifacts & create release on tag 'v*' creation. 
tested at https://github.com/gtardif/api/releases/tag/v0.0.5.
FYI @rumpl I tried a bit goreleaser, for some reason it didn't build/upload windows binary. And thinking about it, I preferred building ourselves using the same process as the rest of the CI, using our makefile, and uploading the results. 