### PR TITLE
Use docker build for lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax = docker/dockerfile:experimental
 ARG GO_VERSION=1.14.3-alpine
+ARG GOLANGCI_LINT_VERSION=1.27.0
 
 FROM golang:${GO_VERSION} AS base
 ARG TARGET_OS=unknown
@@ -32,14 +33,23 @@ ADD . ${PWD}
 FROM protos-base AS make-protos
 RUN make -f builder.Makefile protos
 
+FROM golangci/golangci-lint:v${GOLANGCI_LINT_VERSION}-alpine AS lint-base
+
+FROM base AS lint
+COPY --from=lint-base /usr/bin/golangci-lint /usr/bin/golangci-lint
+ENV CGO_ENABLED=0
+RUN --mount=id=build,type=cache,target=/root/.cache/go-build \
+    --mount=id=lint,type=cache,target=/root/.cache/golangci-lint \
+    make -f builder.Makefile lint
+
 FROM base AS make-cli
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=id=build,type=cache,target=/root/.cache/go-build \
     GOOS=${TARGET_OS} \
     GOARCH=${TARGET_ARCH} \
-    make -f  builder.Makefile cli
+    make -f builder.Makefile cli
 
 FROM base AS make-cross
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=id=build,type=cache,target=/root/.cache/go-build \
     make -f builder.Makefile cross
 
 FROM scratch AS protos

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ cache-clear: ## Clear the builder cache
 	@docker builder prune --force --filter type=exec.cachemount --filter=unused-for=24h
 
 lint: ## run linter(s)
-	docker run --rm -t -v $(PWD):/app -w /app golangci/golangci-lint:v1.27-alpine golangci-lint run --timeout 10m0s ./...
+	@docker build . \
+	--target lint
 
 classic-link: ## create docker-classic symlink if does not already exist
 	ln -s /usr/local/bin/docker-classic /Applications/Docker.app/Contents/Resources/bin/docker
@@ -73,4 +74,4 @@ help: ## Show help
 
 FORCE:
 
-.PHONY: all protos cli e2e-local cross test cache-clear lint help classic-link
+.PHONY: all protos cli e2e-local cross test cache-clear lint classic-link help


### PR DESCRIPTION
**What I did**
Made the linter faster using docker build instead of bind mounts.

Benchmarks on my machine (2017 MacBook Pro 13"):
* bind mount lint: 2m 38s
* new lint (after docker builder prune): 1m 35s
* old lint (rerun no changes): 2m 38s
* new lint (rerun added println in random Go file): 9s

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
