### PR TITLE
Add buildkit cache when running unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,5 @@ COPY --from=make-cross /api/bin/* .
 
 FROM base as test
 ENV CGO_ENABLED=0
-RUN make -f builder.Makefile test
+RUN --mount=id=build,type=cache,target=/root/.cache/go-build \
+    make -f builder.Makefile test


### PR DESCRIPTION
**What I did**
Since running `go test` downloads dependencies we want to have them in the builder cache

