### PR TITLE
Ensure we have a clear error message in case of wrong setup for docker-classic 

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -192,8 +192,10 @@ func execMoby(ctx context.Context) {
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			if exiterr, ok := err.(*exec.ExitError); ok {
+				fmt.Fprintln(os.Stderr, exiterr.Error())
 				os.Exit(exiterr.ExitCode())
 			}
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -62,6 +63,19 @@ func (s *E2eSuite) TestContextDefault() {
 		output = s.NewCommand("docker", "context", "ls").ExecOrDie()
 		Expect(output).To(Not(ContainSubstring("test-example")))
 		Expect(output).To(ContainSubstring("default *"))
+	})
+}
+
+func (s *E2eSuite) TestSetupError() {
+	It("should display an error if cannot shell out to docker-classic", func() {
+		err := os.Setenv("PATH", s.BinDir)
+		Expect(err).To(BeNil())
+		err = os.Remove(filepath.Join(s.BinDir, "docker-classic"))
+		Expect(err).To(BeNil())
+		output, err := s.NewDockerCommand("ps").Exec()
+		Expect(output).To(ContainSubstring("docker-classic"))
+		Expect(output).To(ContainSubstring("not found"))
+		Expect(err).NotTo(BeNil())
 	})
 }
 


### PR DESCRIPTION
**What I did**
* Added error display before exiting if error while invoking `docker-classic` (especially "not found in PATH")
* Added e2e tests removing `docker-classic` from PATH

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://images.pexels.com/photos/39317/chihuahua-dog-puppy-cute-39317.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940)