### PR TITLE
Fix Azure login : no need for ACI context first

### DIFF
--- a/azure/backend_test.go
+++ b/azure/backend_test.go
@@ -3,13 +3,16 @@ package azure
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	. "github.com/onsi/gomega"
 )
 
-// TestGetContainerName ensures we can read container group name / container name from a containerID
-func TestGetContainerName(t *testing.T) {
-	RegisterTestingT(t)
+type BackendSuiteTest struct {
+	suite.Suite
+}
 
+func (suite *BackendSuiteTest) TestGetContainerName() {
 	group, container := getGroupAndContainerName("docker1234")
 	Expect(group).To(Equal("docker1234"))
 	Expect(container).To(Equal(singleContainerName))
@@ -21,4 +24,9 @@ func TestGetContainerName(t *testing.T) {
 	group, container = getGroupAndContainerName("compose_stack_service1")
 	Expect(group).To(Equal("compose_stack"))
 	Expect(container).To(Equal("service1"))
+}
+
+func TestBackendSuite(t *testing.T) {
+	RegisterTestingT(t)
+	suite.Run(t, new(BackendSuiteTest))
 }

--- a/cli/cmd/context/login/login.go
+++ b/cli/cmd/context/login/login.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/api/client"
-	apicontext "github.com/docker/api/context"
 )
 
 // Command returns the compose command with its child commands
@@ -24,12 +23,12 @@ func azureLoginCommand() *cobra.Command {
 	azureLoginCmd := &cobra.Command{
 		Use: "azure",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := apicontext.WithCurrentContext(cmd.Context(), "aci")
-			c, err := client.New(ctx)
+			ctx := cmd.Context()
+			cs, err := client.GetCloudService(ctx, "aci")
 			if err != nil {
 				return errors.Wrap(err, "cannot connect to backend")
 			}
-			return c.CloudService().Login(ctx, nil)
+			return cs.Login(ctx, nil)
 		},
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ import (
 	"github.com/docker/api/context/store"
 )
 
-// New returns a backend client
+// New returns a backend client associated with current context
 func New(ctx context.Context) (*Client, error) {
 	currentContext := apicontext.CurrentContext(ctx)
 	s := store.ContextStore(ctx)
@@ -58,7 +58,11 @@ func New(ctx context.Context) (*Client, error) {
 		backendType: cc.Type,
 		bs:          service,
 	}, nil
+}
 
+// GetCloudService returns a backend CloudService (typically login, create context)
+func GetCloudService(ctx context.Context, backendType string) (cloud.Service, error) {
+	return backend.GetCloudService(ctx, backendType)
 }
 
 // Client is a multi-backend client
@@ -75,9 +79,4 @@ func (c *Client) ContainerService() containers.Service {
 // ComposeService returns the backend service for the current context
 func (c *Client) ComposeService() compose.Service {
 	return c.bs.ComposeService()
-}
-
-// CloudService returns the backend service for the current context
-func (c *Client) CloudService() cloud.Service {
-	return c.bs.CloudService()
 }

--- a/context/cloud/api.go
+++ b/context/cloud/api.go
@@ -1,9 +1,25 @@
 package cloud
 
-import "context"
+import (
+	"context"
+
+	"github.com/docker/api/errdefs"
+)
 
 // Service cloud specific services
 type Service interface {
 	// Login login to cloud provider
 	Login(ctx context.Context, params map[string]string) error
+}
+
+// NotImplementedCloudService to use for backend that don't provide cloud services
+func NotImplementedCloudService() (Service, error) {
+	return notImplementedCloudService{}, nil
+}
+
+type notImplementedCloudService struct {
+}
+
+func (cs notImplementedCloudService) Login(ctx context.Context, params map[string]string) error {
+	return errdefs.ErrNotImplemented
 }

--- a/example/backend.go
+++ b/example/backend.go
@@ -26,14 +26,12 @@ func (a *apiService) ComposeService() compose.Service {
 	return &a.composeService
 }
 
-func (a *apiService) CloudService() cloud.Service {
-	return nil
+func init() {
+	backend.Register("example", "example", service, cloud.NotImplementedCloudService)
 }
 
-func init() {
-	backend.Register("example", "example", func(ctx context.Context) (backend.Service, error) {
-		return &apiService{}, nil
-	})
+func service(ctx context.Context) (backend.Service, error) {
+	return &apiService{}, nil
 }
 
 type containerService struct{}

--- a/moby/backend.go
+++ b/moby/backend.go
@@ -27,13 +27,10 @@ type mobyService struct {
 }
 
 func init() {
-	backend.Register("moby", "moby", func(ctx context.Context) (backend.Service, error) {
-		return New()
-	})
+	backend.Register("moby", "moby", service, cloud.NotImplementedCloudService)
 }
 
-// New returns a moby backend implementation
-func New() (backend.Service, error) {
+func service(ctx context.Context) (backend.Service, error) {
 	apiClient, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
@@ -49,10 +46,6 @@ func (ms *mobyService) ContainerService() containers.Service {
 }
 
 func (ms *mobyService) ComposeService() compose.Service {
-	return nil
-}
-
-func (ms *mobyService) CloudService() cloud.Service {
 	return nil
 }
 


### PR DESCRIPTION
**What I did**
allow getting a backend when no corresponding context already exists, with an explicit call from the login command. Will be useful next for context creation with azure interactive things

**Related issue**
Found while preparing DockerCon demo, cannot log into azure without an existing aci context 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://images.unsplash.com/photo-1585772966934-4384f1f933a0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1350&q=80)