### PR TITLE
Do not truncate ACI container IDs

### DIFF
--- a/cli/cmd/ps.go
+++ b/cli/cmd/ps.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -58,7 +57,7 @@ func runPs(ctx context.Context, opts psOpts) error {
 	fmt.Fprintf(w, "CONTAINER ID\tIMAGE\tCOMMAND\tSTATUS\tPORTS\n")
 	format := "%s\t%s\t%s\t%s\t%s\n"
 	for _, c := range containers {
-		fmt.Fprintf(w, format, stringid.TruncateID(c.ID), c.Image, c.Command, c.Status, formatter.PortsString(c.Ports))
+		fmt.Fprintf(w, format, c.ID, c.Image, c.Command, c.Status, formatter.PortsString(c.Ports))
 	}
 
 	return w.Flush()

--- a/moby/backend.go
+++ b/moby/backend.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/docker/docker/pkg/stringid"
+
 	"github.com/docker/go-connections/nat"
 
 	"github.com/docker/docker/api/types"
@@ -61,7 +63,7 @@ func (ms *mobyService) List(ctx context.Context, all bool) ([]containers.Contain
 	var result []containers.Container
 	for _, container := range css {
 		result = append(result, containers.Container{
-			ID:    container.ID,
+			ID:    stringid.TruncateID(container.ID),
 			Image: container.Image,
 			// TODO: `Status` is a human readable string ("Up 24 minutes"),
 			// we need to return the `State` instead but first we need to

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -116,11 +116,15 @@ func (s *E2eACISuite) TestACIBackend() {
 		Expect(containerFields[1]).To(Equal("nginx"))
 		Expect(containerFields[2]).To(Equal("Running"))
 		exposedIP := containerFields[3]
+		containerID := containerFields[0]
 		Expect(exposedIP).To(ContainSubstring(":80->80/tcp"))
 
 		publishedURL := strings.ReplaceAll(exposedIP, "->80/tcp", "")
 		output = s.NewCommand("curl", publishedURL).ExecOrDie()
 		Expect(output).To(ContainSubstring(testFileContent))
+
+		output = s.NewDockerCommand("logs", containerID).ExecOrDie()
+		Expect(output).To(ContainSubstring("GET"))
 	})
 
 	It("removes container nginx", func() {


### PR DESCRIPTION
 (otherwise we can’t get logs, rm containers from the PS output)

**What I did**
* in ps command, truncate container ids only if they are 64 char long (moby containers). Otherwise let them as is

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://lh3.googleusercontent.com/proxy/BW_Pe8WLGSh3jmXjlPpSVU99Y1sbeSuXKTxz3qscUfH2SjvEQ2d17taVup5_ZxXWHjMYm_fyn0Th0JHMYV8PtfluNVgMYi69pHiwuMode_pA21Ey7FcfTqMDFYslNLYxUvWVHiq183r3okK57cFn8-Y)