### PR TITLE
Fix login error when login to an azure account having no associated tenant.

### DIFF
--- a/azure/login/login.go
+++ b/azure/login/login.go
@@ -127,6 +127,9 @@ func (login AzureLoginService) Login(ctx context.Context) error {
 			if err := json.Unmarshal(bits, &t); err != nil {
 				return errors.Wrapf(errdefs.ErrLoginFailed, "unable to unmarshal tenant: %s", err)
 			}
+			if len(t.Value) < 1 {
+				return errors.Wrap(errdefs.ErrLoginFailed, "could not find azure tenant")
+			}
 			tID := t.Value[0].TenantID
 			tToken, err := login.refreshToken(token.RefreshToken, tID)
 			if err != nil {


### PR DESCRIPTION
This was encountered by @lorenrh with stack : 
```
docker login azure
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
github.com/docker/api/azure/login.AzureLoginService.Login(0xc0004cc2a0, 0x2d, 0xe8b8a0, 0x1476830, 0xe8e4e0, 0xc000498ff0, 0x0, 0x0)
        github.com/docker/api/azure/login/login.go:130 +0x1057
github.com/docker/api/azure.(*aciCloudService).Login(0xc0004888c0, 0xe8e4e0, 0xc000498ff0, 0x0, 0xe82720, 0xc0004888c0)
        github.com/docker/api/azure/backend.go:283 +0x64
github.com/docker/api/cli/cmd/login.cloudLogin(0xc0004eb600, 0xd422a4, 0x3, 0x1, 0xffffffffffffffff)
        github.com/docker/api/cli/cmd/login/login.go:53 +0xae
github.com/docker/api/cli/cmd/login.runLogin(0xc0004eb600, 0xc00049c5f0, 0x1, 0x1, 0x0, 0x0)
        github.com/docker/api/cli/cmd/login/login.go:39 +0x15e
github.com/spf13/cobra.(*Command).execute(0xc0004eb600, 0xc00049c5d0, 0x1, 0x1, 0xc0004eb600, 0xc00049c5d0)
        github.com/spf13/cobra@v1.0.0/command.go:842 +0x45a
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004a8580, 0xc000498fc0, 0xc41160, 0x1476830)
        github.com/spf13/cobra@v1.0.0/command.go:950 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.0.0/command.go:887
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.0.0/command.go:880
main.main()
        github.com/docker/api/cli/main.go:167 +0x68f
```

**What I did**
* Check len() of azure json array containing tenant ID and return error with a proper error message
* unit test it

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcS6QFQrQEdP5vtJVh7hq3lbmXhfllaJ0IWMncMX23-aXQpCu_GM&usqp=CAU)