### PR TITLE
Store context type in metadata to make retrocompatibility with previous contexts easier (potentially switching back and forth)

### DIFF
--- a/cli/cmd/context/ls.go
+++ b/cli/cmd/context/ls.go
@@ -79,7 +79,7 @@ func runList(ctx context.Context) error {
 		fmt.Fprintf(w,
 			format,
 			contextName,
-			c.Type,
+			c.Type(),
 			c.Metadata.Description,
 			getEndpoint("docker", c.Endpoints),
 			getEndpoint("kubernetes", c.Endpoints),

--- a/client/client.go
+++ b/client/client.go
@@ -49,13 +49,13 @@ func New(ctx context.Context) (*Client, error) {
 		return nil, err
 	}
 
-	service, err := backend.Get(ctx, cc.Type)
+	service, err := backend.Get(ctx, cc.Type())
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
-		backendType: cc.Type,
+		backendType: cc.Type(),
 		bs:          service,
 	}, nil
 }

--- a/context/store/contextmetadata.go
+++ b/context/store/contextmetadata.go
@@ -1,0 +1,84 @@
+package store
+
+import "encoding/json"
+
+// DockerContext represents the docker context metadata
+type DockerContext struct {
+	Name      string                 `json:",omitempty"`
+	Metadata  ContextMetadata        `json:",omitempty"`
+	Endpoints map[string]interface{} `json:",omitempty"`
+}
+
+// Type the context type
+func (m *DockerContext) Type() string {
+	if m.Metadata.Type == "" {
+		return defaultContextType
+	}
+	return m.Metadata.Type
+}
+
+// ContextMetadata is represtentation of the data we put in a context
+// metadata
+type ContextMetadata struct {
+	Type              string
+	Description       string
+	StackOrchestrator string
+	AdditionalFields  map[string]interface{}
+}
+
+// AciContext is the context for the ACI backend
+type AciContext struct {
+	SubscriptionID string `json:",omitempty"`
+	Location       string `json:",omitempty"`
+	ResourceGroup  string `json:",omitempty"`
+}
+
+// MobyContext is the context for the moby backend
+type MobyContext struct{}
+
+// ExampleContext is the context for the example backend
+type ExampleContext struct{}
+
+// MarshalJSON implements custom JSON marshalling
+func (dc ContextMetadata) MarshalJSON() ([]byte, error) {
+	s := map[string]interface{}{}
+	if dc.Description != "" {
+		s["Description"] = dc.Description
+	}
+	if dc.StackOrchestrator != "" {
+		s["StackOrchestrator"] = dc.StackOrchestrator
+	}
+	if dc.Type != "" {
+		s["Type"] = dc.Type
+	}
+	if dc.AdditionalFields != nil {
+		for k, v := range dc.AdditionalFields {
+			s[k] = v
+		}
+	}
+	return json.Marshal(s)
+}
+
+// UnmarshalJSON implements custom JSON marshalling
+func (dc *ContextMetadata) UnmarshalJSON(payload []byte) error {
+	var data map[string]interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return err
+	}
+	for k, v := range data {
+		switch k {
+		case "Description":
+			dc.Description = v.(string)
+		case "StackOrchestrator":
+			dc.StackOrchestrator = v.(string)
+		case "Type":
+			dc.Type = v.(string)
+		default:
+			if dc.AdditionalFields == nil {
+				dc.AdditionalFields = make(map[string]interface{})
+			}
+			dc.AdditionalFields[k] = v
+		}
+	}
+	return nil
+}

--- a/context/store/contextmetadata_test.go
+++ b/context/store/contextmetadata_test.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+)
+
+type ContextTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ContextTestSuite) TestDockerContextMetadataKeepAdditionalFields() {
+	c := ContextMetadata{
+		Description:       "test",
+		Type:              "aci",
+		StackOrchestrator: "swarm",
+		AdditionalFields: map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+	jsonBytes, err := json.Marshal(c)
+	Expect(err).To(BeNil())
+	Expect(string(jsonBytes)).To(Equal(`{"Description":"test","StackOrchestrator":"swarm","Type":"aci","foo":"bar"}`))
+
+	var c2 ContextMetadata
+	err = json.Unmarshal(jsonBytes, &c2)
+	Expect(err).To(BeNil())
+	Expect(c2.AdditionalFields["foo"]).To(Equal("bar"))
+	Expect(c2.Type).To(Equal("aci"))
+	Expect(c2.StackOrchestrator).To(Equal("swarm"))
+	Expect(c2.Description).To(Equal("test"))
+}
+
+func TestPs(t *testing.T) {
+	RegisterTestingT(t)
+	suite.Run(t, new(ContextTestSuite))
+}

--- a/context/store/store_test.go
+++ b/context/store/store_test.go
@@ -104,7 +104,7 @@ func (suite *StoreTestSuite) TestGet() {
 	require.Equal(suite.T(), "test", meta.Name)
 
 	require.Equal(suite.T(), "description", meta.Metadata.Description)
-	require.Equal(suite.T(), "type", meta.Type)
+	require.Equal(suite.T(), "type", meta.Type())
 }
 
 func (suite *StoreTestSuite) TestRemoveNotFound() {

--- a/context/store/storedefault.go
+++ b/context/store/storedefault.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const defaultContextType = "docker"
+
 // Represents a context as created by the docker cli
 type defaultContext struct {
 	Metadata  ContextMetadata
@@ -31,7 +33,7 @@ type endpoint struct {
 	DefaultNamespace string
 }
 
-func dockerDefaultContext() (*Metadata, error) {
+func dockerDefaultContext() (*DockerContext, error) {
 	cmd := exec.Command("docker-classic", "context", "inspect", "default")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -52,9 +54,8 @@ func dockerDefaultContext() (*Metadata, error) {
 
 	defaultCtx := ctx[0]
 
-	meta := Metadata{
+	meta := DockerContext{
 		Name: "default",
-		Type: "docker",
 		Endpoints: map[string]interface{}{
 			"docker": Endpoint{
 				Host: defaultCtx.Endpoints.Docker.Host,
@@ -65,6 +66,7 @@ func dockerDefaultContext() (*Metadata, error) {
 			},
 		},
 		Metadata: ContextMetadata{
+			Type:              defaultContextType,
 			Description:       "Current DOCKER_HOST based configuration",
 			StackOrchestrator: defaultCtx.Metadata.StackOrchestrator,
 		},

--- a/server/proxy/contexts.go
+++ b/server/proxy/contexts.go
@@ -36,7 +36,7 @@ func (cp *contextsProxy) List(ctx context.Context, request *contextsv1.ListReque
 	for _, c := range contexts {
 		result.Contexts = append(result.Contexts, &contextsv1.Context{
 			Name:        c.Name,
-			ContextType: c.Type,
+			ContextType: c.Type(),
 			Current:     c.Name == configFile.CurrentContext,
 		})
 	}


### PR DESCRIPTION
**What I did**
* context type is now stored in context metadata, not added at the root of context json storage. 

**Related issue**
Needed to ensure backward compatibility if users switch back and forth, to avoid loosing the type info. 
Also required to ensure context sync between HyperV and WSL2 environments, allowing to use the /docker/cli code to read/write contexts. cc @simonferquel 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://i.pinimg.com/originals/9f/51/3c/9f513c54c422e4bb13265fd99de00087.jpg)