### PR TITLE
Do not delegate to old cli if cobra fails before invoking the PreRun or SetHelp hook.

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -76,6 +76,14 @@ func (s *E2eSuite) TestContextLegacy() {
 	})
 }
 
+func (s *E2eSuite) TestContextCreateParseErrorDoesNotDelegateToLegacy() {
+	It("should dispay new cli error when parsing context create flags", func() {
+		_, err := s.NewDockerCommand("context", "create", "--aci-subscription-id", "titi").Exec()
+		Expect(err.Error()).NotTo(ContainSubstring("unknown flag"))
+		Expect(err.Error()).To(ContainSubstring("accepts 2 arg(s), received 0"))
+	})
+}
+
 func (s *E2eSuite) TestClassicLoginWithparameters() {
 	output, err := s.NewDockerCommand("login", "-u", "nouser", "-p", "wrongpasword").Exec()
 	Expect(output).To(ContainSubstring("Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password"))


### PR DESCRIPTION
These hook allow to check if we need to delegate, based on the command. 

**What I did**
Instead, find the command from root.Find(args).

Tried to use  `cmd, err := root.ExecuteC()` but I can’t pass the context like with `root.ExecuteContext(ctx)`, could not find a way without and explicit call to root.Find(args)

**Related issue**
`docker context create --aci-subscription-id xxx` was delegating to old cli and display `unknown flag : --aci-subscription-id` 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals-2/cute-baby-animals-2-2.jpg)