### PR TITLE
Fix flaky test (subject to running tests in //)

### DIFF
--- a/tests/framework/suite.go
+++ b/tests/framework/suite.go
@@ -132,7 +132,7 @@ func (s *Suite) ListProcessesCommand() *CmdContext {
 	if IsWindows() {
 		return s.NewCommand("tasklist")
 	}
-	return s.NewCommand("ps")
+	return s.NewCommand("ps", "-x")
 }
 
 // NewCommand creates a command context.


### PR DESCRIPTION
**What I did**
* replace check if `ps` contains `docker-classic` by check if it container the image name we are building for a very long time

**Related issue**
red build on master (flaky)

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://lh3.googleusercontent.com/proxy/jMjdWYa1GS-Trl5OqhAt0jA2kTuNGy7BGMvQPRR-GpihIaHsuA2w8NQE35oGELfWjR_MCyn-BGTkphIJnGSqeTLye4s39kIZ0c5x_8Ht-xVf5SUrfkErTojJ9H8XjXPLA4d4iFzzZfzzEg1_avFC3sqepgTo9tc)