### PR TITLE
Strengthen getting default context

### DIFF
--- a/context/store/storedefault.go
+++ b/context/store/storedefault.go
@@ -34,7 +34,8 @@ type endpoint struct {
 }
 
 func dockerDefaultContext() (*DockerContext, error) {
-	cmd := exec.Command("docker-classic", "context", "inspect", "default")
+	// ensure we run this using default context, in current context has been damaged / removed in store
+	cmd := exec.Command("docker-classic", "--context", "default", "context", "inspect", "default")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	err := cmd.Run()


### PR DESCRIPTION
**What I did**
* When shell out `docker context inspect default` to get default context, ensure the command is run using default context, and not any other context.

Following discussion with @simonferquel, this will strengthen the shell out to get default context, in cases the user has damaged his config file current context or in corner cases with context synchronisation between windows host & wsl2. 