### PR TITLE
Wrap error cause so that we can understand why the cli cannot determine current context

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -150,7 +150,7 @@ func main() {
 
 	currentContext, err := determineCurrentContext(opts.Context, configDir)
 	if err != nil {
-		fatal(errors.New("unable to determine current context"))
+		fatal(errors.Wrap(err, "unable to determine current context"))
 	}
 
 	s, err := store.New(store.WithRoot(configDir))

--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,7 @@ func loadFile(path string, dest interface{}) error {
 		return errors.Wrap(err, "unable to read config file")
 	}
 	err = json.Unmarshal(data, dest)
-	return errors.Wrap(err, "unable to unmarshal config")
+	return errors.Wrap(err, "unable to unmarshal config file "+path)
 }
 
 func configFilePath(dir string) string {


### PR DESCRIPTION
This happened in Desktop WSL2 tests, we’re blind here : https://ci-next.docker.com/teams-desktop/blue/organizations/jenkins/desktop%2Fdesktop-test-single-pr-win/detail/desktop-test-single-pr-win/120692/pipeline

**What I did**
* Wrap error cause instead of just returning generic error message when cannot read current context

**Related issue**
https://ci-next.docker.com/teams-desktop/blue/organizations/jenkins/desktop%2Fdesktop-test-single-pr-win/detail/desktop-test-single-pr-win/120692/pipeline

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
