### PR TITLE
When can not load config file, display a WARNING message, but continues with default context

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -148,10 +148,7 @@ func main() {
 	configDir := opts.Config
 	ctx = config.WithDir(ctx, configDir)
 
-	currentContext, err := determineCurrentContext(opts.Context, configDir)
-	if err != nil {
-		fatal(errors.Wrap(err, "unable to determine current context"))
-	}
+	currentContext := determineCurrentContext(opts.Context, configDir)
 
 	s, err := store.New(store.WithRoot(configDir))
 	if err != nil {
@@ -200,19 +197,20 @@ func newSigContext() (context.Context, func()) {
 	return ctx, cancel
 }
 
-func determineCurrentContext(flag string, configDir string) (string, error) {
+func determineCurrentContext(flag string, configDir string) string {
 	res := flag
 	if res == "" {
 		config, err := config.LoadFile(configDir)
 		if err != nil {
-			return "", err
+			fmt.Fprintln(os.Stderr, errors.Wrap(err, "WARNING"))
+			return "default"
 		}
 		res = config.CurrentContext
 	}
 	if res == "" {
 		res = "default"
 	}
-	return res, nil
+	return res
 }
 
 func fatal(err error) {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -56,23 +56,19 @@ func TestDetermineCurrentContext(t *testing.T) {
 	require.NoError(t, err)
 
 	// If nothing set, fallback to default
-	c, err := determineCurrentContext("", "")
-	require.NoError(t, err)
+	c := determineCurrentContext("", "")
 	require.Equal(t, "default", c)
 
 	// If context flag set, use that
-	c, err = determineCurrentContext("other-context", "")
-	require.NoError(t, err)
+	c = determineCurrentContext("other-context", "")
 	require.Equal(t, "other-context", c)
 
 	// If no context flag, use config
-	c, err = determineCurrentContext("", d)
-	require.NoError(t, err)
+	c = determineCurrentContext("", d)
 	require.Equal(t, "some-context", c)
 
 	// Ensure context flag overrides config
-	c, err = determineCurrentContext("other-context", d)
-	require.NoError(t, err)
+	c = determineCurrentContext("other-context", d)
 	require.Equal(t, "other-context", c)
 }
 


### PR DESCRIPTION
Same behavoiour as old cli, we should do the same.

This happened in some desktop e2e tests where the config file is not set properly in WSL2 environment, see 
https://github.com/docker/pinata/pull/14062

**What I did**
when cannot find current context, use default, and display error on stderr, but do not `fatal()`

**Related issue**
https://github.com/docker/pinata/pull/14062

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
