### PR TITLE
Build example and local backend conditionaly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,13 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Test
+        env:
+          BUILD_TAGS: example,local
         run: make -f builder.Makefile test
 
       - name: Build
+        env:
+          BUILD_TAGS: example,local
         run: make -f builder.Makefile cli
 
       - name: E2E Test
@@ -77,9 +81,13 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Test
+        env:
+          BUILD_TAGS: example,local
         run: make -f builder.Makefile test
 
       - name: Build
+        env:
+          BUILD_TAGS: example,local
         run: make -f builder.Makefile cli
 
       - name: E2E Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: releaser
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 jobs:
   upload-release:
     runs-on: ubuntu-latest
@@ -32,4 +32,3 @@ jobs:
           artifacts: "bin/*"
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,19 @@ FROM base AS make-cli
 ENV CGO_ENABLED=0
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILD_TAGS
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
+    BUILD_TAGS=${BUILD_TAGS} \
     make BINARY=/out/docker -f builder.Makefile cli
 
 FROM base AS make-cross
+ARG BUILD_TAGS
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
+    BUILD_TAGS=${BUILD_TAGS} \
     make BINARY=/out/docker  -f builder.Makefile cross
 
 FROM scratch AS protos
@@ -53,7 +57,9 @@ FROM scratch AS cross
 COPY --from=make-cross /out/* .
 
 FROM base as test
+ARG BUILD_TAGS
 ENV CGO_ENABLED=0
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
+    BUILD_TAGS=${BUILD_TAGS} \
     make -f builder.Makefile test

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ protos: ## Generate go code from .proto files
 cli: ## Compile the cli
 	@docker build . --target cli \
 	--platform local \
+	--build-arg BUILD_TAGS=example,local \
 	--output ./bin
 
 e2e-local: ## Run End to end local tests
@@ -55,10 +56,13 @@ e2e-aci: ## Run End to end ACI tests (requires azure login)
 
 cross: ## Compile the CLI for linux, darwin and windows
 	@docker build . --target cross \
+	--build-arg BUILD_TAGS \
 	--output ./bin \
 
 test: ## Run unit tests
-	@docker build . --target test
+	@docker build . \
+	--build-arg BUILD_TAGS=example,local \
+	--target test
 
 cache-clear: ## Clear the builder cache
 	@docker builder prune --force --filter type=exec.cachemount --filter=unused-for=24h
@@ -68,6 +72,7 @@ lint: ## run linter(s)
 
 serve: cli ## start server
 	@./bin/docker serve --address unix:///tmp/backend.sock
+
 classic-link: ## create docker-classic symlink if does not already exist
 	ln -s $(CLASSIC_DOCKER) /usr/local/bin/docker-classic
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ The new CLI delegates to the classic docker for default contexts ; delegation is
 $ make
 ```
 
-If you make changes to the `.proto` files, make sure to `make protos` to generate go code.
+This will make the cli with all backends enabled. `make cross` on the other hand will cross-compile the cli without the
+example and local backend. We use `make cross` to build for our release, hence the exclusion of those backends. You can
+still cross-compile with all backends enabled: `BUILD_TAGS=example,local make cross`.
 
+If you make changes to the `.proto` files, make sure to `make protos` to generate go code.
 
 ## Tests
 

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -40,21 +40,26 @@ GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 BINARY?=bin/docker
 BINARY_WITH_EXTENSION=$(BINARY)$(EXTENSION)
 
+TAGS:=
+ifdef BUILD_TAGS
+  TAGS=-tags $(BUILD_TAGS)
+endif
+
 all: cli
 
 protos:
 	@protoc -I. --go_out=plugins=grpc,paths=source_relative:. ${PROTOS}
 
 cli:
-	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) -o $(BINARY_WITH_EXTENSION) ./cli
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
 cross:
-	@GOOS=linux   GOARCH=amd64 $(GO_BUILD) -o $(BINARY)-linux-amd64 ./cli
-	@GOOS=darwin  GOARCH=amd64 $(GO_BUILD) -o $(BINARY)-darwin-amd64 ./cli
-	@GOOS=windows GOARCH=amd64 $(GO_BUILD) -o $(BINARY)-windows-amd64.exe ./cli
+	@GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-amd64 ./cli
+	@GOOS=darwin  GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-darwin-amd64 ./cli
+	@GOOS=windows GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-windows-amd64.exe ./cli
 
 test:
-	@go test -cover $(shell go list ./... | grep -vE 'e2e')
+	@go test $(TAGS) -cover $(shell go list ./... | grep -vE 'e2e')
 
 lint:
 	golangci-lint run --timeout 10m0s ./...

--- a/example/backend.go
+++ b/example/backend.go
@@ -1,3 +1,5 @@
+// +build example
+
 package example
 
 import (

--- a/example/doc.go
+++ b/example/doc.go
@@ -1,0 +1,1 @@
+package example

--- a/local/backend.go
+++ b/local/backend.go
@@ -1,3 +1,5 @@
+// +build local
+
 package local
 
 import (

--- a/local/doc.go
+++ b/local/doc.go
@@ -1,0 +1,1 @@
+package local


### PR DESCRIPTION
**What I did**

* `make` will build the cli with all backends exnabled
* `make cross` will cross build without the example and local backend

You can still cross compile with all backends by doing

```console
$ BUILD_TAGS=example,local make cross
```

**Related issue**

Fixes #216 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/99933/84678238-0f683500-af30-11ea-8835-4ac782fa7395.png)
