### PR TITLE
Changed compose flag —name to —project-name, -p, aligned with docker-compose flag.

### DIFF
--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -45,7 +45,7 @@ func downCommand() *cobra.Command {
 			return runDown(cmd.Context(), opts)
 		},
 	}
-	downCmd.Flags().StringVar(&opts.Name, "name", "", "Project name")
+	downCmd.Flags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
 	downCmd.Flags().StringVar(&opts.WorkDir, "workdir", ".", "Work dir")
 	downCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -45,7 +45,7 @@ func upCommand() *cobra.Command {
 			return runUp(cmd.Context(), opts)
 		},
 	}
-	upCmd.Flags().StringVar(&opts.Name, "name", "", "Project name")
+	upCmd.Flags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
 	upCmd.Flags().StringVar(&opts.WorkDir, "workdir", ".", "Work dir")
 	upCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	upCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -123,7 +123,7 @@ func (s *E2eACISuite) TestACIBackend() {
 	})
 
 	It("deploys a compose app", func() {
-		s.NewDockerCommand("compose", "up", "-f", "../composefiles/aci-demo/aci_demo_port.yaml", "--name", "acidemo").ExecOrDie()
+		s.NewDockerCommand("compose", "up", "-f", "../composefiles/aci-demo/aci_demo_port.yaml", "--project-name", "acidemo").ExecOrDie()
 		// Expect(output).To(ContainSubstring("Successfully deployed"))
 		output := s.NewDockerCommand("ps").ExecOrDie()
 		Lines := Lines(output)
@@ -155,7 +155,7 @@ func (s *E2eACISuite) TestACIBackend() {
 	})
 
 	It("shutdown compose app", func() {
-		s.NewDockerCommand("compose", "down", "-f", "../composefiles/aci-demo/aci_demo_port.yaml", "--name", "acidemo").ExecOrDie()
+		s.NewDockerCommand("compose", "down", "-f", "../composefiles/aci-demo/aci_demo_port.yaml", "--project-name", "acidemo").ExecOrDie()
 	})
 	It("switches back to default context", func() {
 		output := s.NewCommand("docker", "context", "use", "default").ExecOrDie()


### PR DESCRIPTION
**What I did**
changed compose `--name` to `--project-name-`, shorthand `-p` like docker-compose

**Related issue**
See commment in https://docs.google.com/document/d/1DXL0I6exH-OpLy91F8D-QnwD9ayjXzpYj4pquNO5-Ws/edit#

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
