### PR TITLE
Renamed docker-classic to “com.docker.cli”.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ export DOCKER_BUILDKIT=1
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-	CLASSIC_DOCKER=/usr/bin/docker
+	MOBY_DOCKER=/usr/bin/docker
 endif
 ifeq ($(UNAME_S),Darwin)
-	CLASSIC_DOCKER=/Applications/Docker.app/Contents/Resources/bin/docker
+	MOBY_DOCKER=/Applications/Docker.app/Contents/Resources/bin/docker
 endif
 
 all: cli
@@ -73,8 +73,8 @@ lint: ## run linter(s)
 serve: cli ## start server
 	@./bin/docker serve --address unix:///tmp/backend.sock
 
-classic-link: ## create docker-classic symlink if does not already exist
-	ln -s $(CLASSIC_DOCKER) /usr/local/bin/docker-classic
+moby-cli-link: ## create com.docker.cli symlink if does not already exist
+	ln -s $(MOBY_DOCKER) /usr/local/bin/com.docker.cli
 
 help: ## Show help
 	@echo Please specify a build target. The choices are:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ If you don't have or want to use Docker for building you need to make sure you h
 
 And then you can call the same make targets but you need to pass it the `builder.Makefile` (`make -f builder.Makefile`).
 
-The new CLI delegates to the classic docker for default contexts ; delegation is done to `docker-classic`. 
-* `make classic-link` will create a `docker-classic` link in `/usr/local/bin` if you don't already have it from Docker Desktop
+The new CLI delegates to the classic docker for default contexts ; delegation is done to `com.docker.cli`. 
+* `make moby-cli-link` will create a `com.docker.cli` link in `/usr/local/bin` if you don't already have it from Docker Desktop
 
 ## Building the project
 

--- a/cli/cmd/context/create.go
+++ b/cli/cmd/context/create.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/api/cli/dockerclassic"
+	"github.com/docker/api/cli/mobycli"
 	"github.com/docker/api/context/store"
 )
 
@@ -76,7 +76,7 @@ $ docker context create my-context --description "some description" --docker "ho
 		Use:   "create CONTEXT",
 		Short: "Create new context",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return dockerclassic.ExecCmd(cmd)
+			return mobycli.ExecCmd(cmd)
 		},
 		Long: longHelp,
 	}

--- a/cli/cmd/context/inspect.go
+++ b/cli/cmd/context/inspect.go
@@ -28,7 +28,7 @@
 package context
 
 import (
-	"github.com/docker/api/cli/dockerclassic"
+	"github.com/docker/api/cli/mobycli"
 
 	"github.com/spf13/cobra"
 )
@@ -39,7 +39,7 @@ func inspectCommand() *cobra.Command {
 		Short: "Display detailed information on one or more contexts",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return dockerclassic.ExecCmd(cmd)
+			return mobycli.ExecCmd(cmd)
 		},
 	}
 	return cmd

--- a/cli/cmd/context/rm.go
+++ b/cli/cmd/context/rm.go
@@ -32,10 +32,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	apicontext "github.com/docker/api/context"
 	"github.com/docker/api/context/store"
 	"github.com/docker/api/multierror"
-	"github.com/spf13/cobra"
 )
 
 type removeOpts struct {

--- a/cli/cmd/login/login.go
+++ b/cli/cmd/login/login.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/api/cli/dockerclassic"
+	"github.com/docker/api/cli/mobycli"
 	"github.com/docker/api/client"
 	"github.com/docker/api/errdefs"
 )
@@ -22,7 +22,7 @@ func Command() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  runLogin,
 	}
-	// define flags for backward compatibility with docker-classic
+	// define flags for backward compatibility with com.docker.cli
 	flags := cmd.Flags()
 	flags.StringP("username", "u", "", "Username")
 	flags.StringP("password", "p", "", "Password")
@@ -41,7 +41,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 			return errors.New("unknown backend type for cloud login: " + backend)
 		}
 	}
-	return dockerclassic.ExecCmd(cmd)
+	return mobycli.ExecCmd(cmd)
 }
 
 func cloudLogin(cmd *cobra.Command, backendType string) error {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/api/cli/dockerclassic"
+	"github.com/docker/api/cli/mobycli"
 )
 
 const cliVersion = "0.1.0"
@@ -19,7 +19,7 @@ func VersionCommand() *cobra.Command {
 		Args:  cobra.MaximumNArgs(0),
 		RunE:  runVersion,
 	}
-	// define flags for backward compatibility with docker-classic
+	// define flags for backward compatibility with com.docker.cli
 	flags := cmd.Flags()
 	flags.String("format", "", "Format the output using the given Go template")
 	flags.String("kubeconfig", "", "Kubernetes config file")
@@ -28,11 +28,11 @@ func VersionCommand() *cobra.Command {
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
-	versionResult, _ := dockerclassic.ExecSilent(cmd.Context())
+	versionResult, _ := mobycli.ExecSilent(cmd.Context())
 	// we don't want to fail on error, there is an error if the engine is not available but it displays client version info
 	// Still, technically the [] byte versionResult could be nil, just let the original command display what it has to display
 	if versionResult == nil {
-		return dockerclassic.ExecCmd(cmd)
+		return mobycli.ExecCmd(cmd)
 	}
 	var s string = string(versionResult)
 	fmt.Print(strings.Replace(s, "\n Version:", "\n Azure integration  "+cliVersion+"\n Version:", 1))

--- a/cli/main.go
+++ b/cli/main.go
@@ -52,7 +52,7 @@ import (
 	contextcmd "github.com/docker/api/cli/cmd/context"
 	"github.com/docker/api/cli/cmd/login"
 	"github.com/docker/api/cli/cmd/run"
-	"github.com/docker/api/cli/dockerclassic"
+	"github.com/docker/api/cli/mobycli"
 	cliopts "github.com/docker/api/cli/options"
 	"github.com/docker/api/config"
 	apicontext "github.com/docker/api/context"
@@ -101,7 +101,7 @@ func main() {
 		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if !isOwnCommand(cmd) {
-				dockerclassic.Exec(cmd.Context())
+				mobycli.Exec(cmd.Context())
 			}
 			return nil
 		},
@@ -127,7 +127,7 @@ func main() {
 	helpFunc := root.HelpFunc()
 	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		if !isOwnCommand(cmd) {
-			dockerclassic.Exec(cmd.Context())
+			mobycli.Exec(cmd.Context())
 		}
 		helpFunc(cmd, args)
 	})
@@ -168,7 +168,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		dockerclassic.Exec(ctx)
+		mobycli.Exec(ctx)
 
 		checkIfUnknownCommandExistInDefaultContext(err, currentContext)
 		fmt.Fprintln(os.Stderr, err)
@@ -182,7 +182,7 @@ func checkIfUnknownCommandExistInDefaultContext(err error, currentContext string
 	if len(submatch) == 2 {
 		dockerCommand := string(submatch[1])
 
-		if dockerclassic.IsDefaultContextCommand(dockerCommand) {
+		if mobycli.IsDefaultContextCommand(dockerCommand) {
 			fmt.Fprintf(os.Stderr, "Command \"%s\" not available in current context (%s), you can use the \"default\" context to run this command\n", dockerCommand, currentContext)
 			os.Exit(1)
 		}

--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -1,4 +1,4 @@
-package dockerclassic
+package mobycli
 
 import (
 	"context"
@@ -13,10 +13,10 @@ import (
 	"github.com/docker/api/context/store"
 )
 
-// ClassicCliName name of the classic cli binary
-const ClassicCliName = "docker-classic"
+// ComDockerCli name of the classic cli binary
+const ComDockerCli = "com.docker.cli"
 
-// Exec delegates to docker-classic
+// Exec delegates to com.docker.cli
 func Exec(ctx context.Context) {
 	currentContext := apicontext.CurrentContext(ctx)
 	s := store.ContextStore(ctx)
@@ -25,7 +25,7 @@ func Exec(ctx context.Context) {
 	// Only run original docker command if the current context is not
 	// ours.
 	if err != nil {
-		cmd := exec.CommandContext(ctx, ClassicCliName, os.Args[1:]...)
+		cmd := exec.CommandContext(ctx, ComDockerCli, os.Args[1:]...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -40,7 +40,7 @@ func Exec(ctx context.Context) {
 	}
 }
 
-// ExecCmd delegates the cli command to docker-classic. The error is never returned (process will exit with docker classic exit code), the return type is to make it easier to use with cobra commands
+// ExecCmd delegates the cli command to com.docker.cli. The error is never returned (process will exit with docker classic exit code), the return type is to make it easier to use with cobra commands
 func ExecCmd(command *cobra.Command) error {
 	Exec(command.Context())
 	return nil
@@ -48,7 +48,7 @@ func ExecCmd(command *cobra.Command) error {
 
 // IsDefaultContextCommand checks if the command exists in the classic cli (issues a shellout --help)
 func IsDefaultContextCommand(dockerCommand string) bool {
-	cmd := exec.Command(ClassicCliName, dockerCommand, "--help")
+	cmd := exec.Command(ComDockerCli, dockerCommand, "--help")
 	b, e := cmd.CombinedOutput()
 	if e != nil {
 		fmt.Println(e)
@@ -60,6 +60,6 @@ func IsDefaultContextCommand(dockerCommand string) bool {
 
 // ExecSilent executes a command and do redirect output to stdOut, return output
 func ExecSilent(ctx context.Context) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, ClassicCliName, os.Args[1:]...)
+	cmd := exec.CommandContext(ctx, ComDockerCli, os.Args[1:]...)
 	return cmd.CombinedOutput()
 }

--- a/cli/mobycli/job_windows.go
+++ b/cli/mobycli/job_windows.go
@@ -1,4 +1,4 @@
-package dockerclassic
+package mobycli
 
 import (
 	"fmt"

--- a/context/store/storedefault.go
+++ b/context/store/storedefault.go
@@ -35,7 +35,7 @@ type endpoint struct {
 
 func dockerDefaultContext() (*DockerContext, error) {
 	// ensure we run this using default context, in current context has been damaged / removed in store
-	cmd := exec.Command("docker-classic", "--context", "default", "context", "inspect", "default")
+	cmd := exec.Command("com.docker.cli", "--context", "default", "context", "inspect", "default")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	err := cmd.Run()

--- a/protos/compose/v1/compose.pb.go
+++ b/protos/compose/v1/compose.pb.go
@@ -34,14 +34,15 @@ package v1
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/protos/containers/v1/containers.pb.go
+++ b/protos/containers/v1/containers.pb.go
@@ -34,14 +34,15 @@ package v1
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/protos/contexts/v1/contexts.pb.go
+++ b/protos/contexts/v1/contexts.pb.go
@@ -34,14 +34,15 @@ package v1
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/protos/streams/v1/streams.pb.go
+++ b/protos/streams/v1/streams.pb.go
@@ -8,6 +8,9 @@ package v1
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	grpc "google.golang.org/grpc"
@@ -15,8 +18,6 @@ import (
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -121,13 +121,13 @@ func (s *E2eSuite) TestCloudLogin() {
 }
 
 func (s *E2eSuite) TestSetupError() {
-	It("should display an error if cannot shell out to docker-classic", func() {
+	It("should display an error if cannot shell out to com.docker.cli", func() {
 		err := os.Setenv("PATH", s.BinDir)
 		Expect(err).To(BeNil())
 		err = os.Remove(filepath.Join(s.BinDir, DockerClassicExecutable()))
 		Expect(err).To(BeNil())
 		output, err := s.NewDockerCommand("ps").Exec()
-		Expect(output).To(ContainSubstring("docker-classic"))
+		Expect(output).To(ContainSubstring("com.docker.cli"))
 		Expect(output).To(ContainSubstring("not found"))
 		Expect(err).NotTo(BeNil())
 	})

--- a/tests/framework/suite.go
+++ b/tests/framework/suite.go
@@ -35,6 +35,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/docker/api/cli/mobycli"
+
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
@@ -154,9 +156,9 @@ func dockerExecutable() string {
 // DockerClassicExecutable binary name based on platform
 func DockerClassicExecutable() string {
 	if IsWindows() {
-		return "docker-classic.exe"
+		return mobycli.ComDockerCli + ".exe"
 	}
-	return "docker-classic"
+	return mobycli.ComDockerCli
 }
 
 // NewDockerCommand creates a docker builder.

--- a/tests/skip-win-ci-e2e/skip_win_ci_test.go
+++ b/tests/skip-win-ci-e2e/skip_win_ci_test.go
@@ -46,7 +46,7 @@ type NonWinCIE2eSuite struct {
 }
 
 func (s *NonWinCIE2eSuite) TestKillChildOnCancel() {
-	It("should kill docker-classic if parent command is cancelled", func() {
+	It("should kill com.docker.cli if parent command is cancelled", func() {
 		imageName := "test-sleep-image"
 		out := s.ListProcessesCommand().ExecOrDie()
 		Expect(out).NotTo(ContainSubstring(imageName))


### PR DESCRIPTION
**What I did**
Rename shell out to moby cli binary "com.docker.cli" 

**Related issue**
https://github.com/docker/api/issues/188

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://www.verywellmind.com/thmb/8quBdAdGoHUYoLON4FDQwPnlZl0=/500x350/filters:no_upscale():max_bytes(150000):strip_icc()/iStock-619961796-edit-59cabaf6845b3400111119b7.jpg)