### PR TITLE
Allow compose updates without having to delete the stack every time.

### DIFF
--- a/azure/aci.go
+++ b/azure/aci.go
@@ -43,6 +43,14 @@ func createACIContainers(ctx context.Context, aciContext store.AciContext, group
 		return fmt.Errorf("container group %q already exists", *groupDefinition.Name)
 	}
 
+	return createOrUpdateACIContainers(ctx, aciContext, groupDefinition)
+}
+
+func createOrUpdateACIContainers(ctx context.Context, aciContext store.AciContext, groupDefinition containerinstance.ContainerGroup) error {
+	containerGroupsClient, err := getContainerGroupsClient(aciContext.SubscriptionID)
+	if err != nil {
+		return errors.Wrapf(err, "cannot get container group client")
+	}
 	future, err := containerGroupsClient.CreateOrUpdate(
 		ctx,
 		aciContext.ResourceGroup,

--- a/azure/backend.go
+++ b/azure/backend.go
@@ -283,7 +283,7 @@ func (cs *aciComposeService) Up(ctx context.Context, opts compose.ProjectOptions
 	if err != nil {
 		return err
 	}
-	return createACIContainers(ctx, cs.ctx, groupDefinition)
+	return createOrUpdateACIContainers(ctx, cs.ctx, groupDefinition)
 }
 
 func (cs *aciComposeService) Down(ctx context.Context, opts compose.ProjectOptions) error {


### PR DESCRIPTION
Update will “typically” keep the same IP, but this isn’t guaranteed by azure
(ACI has limitations on what can be updated, but this does not apply to us for the moment : https://docs.microsoft.com/en-us/azure/container-instances/container-instances-update#properties-that-require-container-delete)
For the moment I check in the test that the IP is keep the same

**What I did**
* in ACI, have separate methods "create" (for single container creation) and "createOrUpdate" (for compose up)
* added e2e test for aci (+ ~20 secs for the compose update, running e2e-aci)

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://lh5.ggpht.com/_hVOW2U7K4-M/TOM_U-H2c6I/AAAAAAABYhI/K4rform8kc0/s800/d17.jpg)