### PR TITLE
CLI version 0.1.0 => 0.1.1

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/api/cli/mobycli"
 )
 
-const cliVersion = "0.1.0"
+const cliVersion = "0.1.1"
 
 // VersionCommand command to display version
 func VersionCommand() *cobra.Command {


### PR DESCRIPTION
**What I did**
update version. 

We'll need to automate this to make it in sync with tags
