### PR TITLE
Use location flag in aci context creation only for group creation

### DIFF
--- a/azure/context.go
+++ b/azure/context.go
@@ -77,10 +77,7 @@ func (helper contextCreateACIHelper) createContextData(ctx context.Context, opts
 		}
 	}
 
-	location := opts["aciLocation"]
-	if location == "" {
-		location = *group.Location
-	}
+	location := *group.Location
 
 	description := fmt.Sprintf("%s@%s", *group.Name, location)
 	if opts["description"] != "" {

--- a/azure/context_test.go
+++ b/azure/context_test.go
@@ -179,6 +179,7 @@ func options(subscriptionID string, resourceGroupName string) map[string]string 
 	return map[string]string{
 		"aciSubscriptionID": subscriptionID,
 		"aciResourceGroup":  resourceGroupName,
+		"aciLocation":       "eastus",
 	}
 }
 


### PR DESCRIPTION
 Flag default eastus. Once group has been created/selected, use group location.

**What I did**
* do not use flag after resource group has been selected
* set test default location opt to eastus, like default behaviour

**Related issue**
https://github.com/docker/desktop-microsoft/issues/18

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://i.chzbgr.com/full/5602343168/h42AE3A52/acting-like-animals-touching-ones-heart)