### PR TITLE
Allow --format on docker context ls. Fixing VS Code extension shellout

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -80,6 +80,12 @@ func (s *E2eSuite) TestInspectContextRegardlessCurrentContext() {
 	Expect(output).To(ContainSubstring(`"Name": "localCtx"`))
 }
 
+func (s *E2eSuite) TestContextLsFormat() {
+	output, err := s.NewDockerCommand("context", "ls", "--format", "{{ json . }}").Exec()
+	Expect(err).To(BeNil())
+	Expect(output).To(ContainSubstring(`"Name":"default"`))
+}
+
 func (s *E2eSuite) TestContextCreateParseErrorDoesNotDelegateToLegacy() {
 	It("should dispay new cli error when parsing context create flags", func() {
 		_, err := s.NewDockerCommand("context", "create", "aci", "--subscription-id", "titi").Exec()


### PR DESCRIPTION
**What I did**
* Added --format flag to context ls
* if format flag specified, shell out to moby cli with it

**Related issue**
https://github.com/docker/desktop-microsoft/issues/25

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
