### PR TITLE
Allow running `docker -v` or `--version` even if context is not default

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -124,6 +124,7 @@ func main() {
 	root.PersistentFlags().StringVarP(&opts.Host, "host", "H", "", "Daemon socket(s) to connect to")
 	opts.AddConfigFlags(root.PersistentFlags())
 	opts.AddContextFlags(root.PersistentFlags())
+	root.Flags().BoolVarP(&opts.Version, "version", "v", false, "Print version information and quit")
 
 	// populate the opts with the global flags
 	_ = root.PersistentFlags().Parse(os.Args[1:])
@@ -135,6 +136,9 @@ func main() {
 	defer cancel()
 
 	if opts.Host != "" {
+		mobycli.ExecRegardlessContext(ctx)
+	}
+	if opts.Version {
 		mobycli.ExecRegardlessContext(ctx)
 	}
 

--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -25,6 +25,7 @@ import (
 type GlobalOpts struct {
 	apicontext.ContextFlags
 	cliconfig.ConfigFlags
-	Debug bool
-	Host  string
+	Debug   bool
+	Version bool
+	Host    string
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -226,6 +226,14 @@ func defaultEndpoint() string {
 	return "unix:///var/run/docker.sock"
 }
 
+func (s *E2eSuite) TestExecMobyIfUsingversionFlag() {
+	s.NewDockerCommand("context", "create", "example", "test-example").ExecOrDie()
+	s.NewDockerCommand("context", "use", "test-example").ExecOrDie()
+	output, err := s.NewDockerCommand("-v").Exec()
+	Expect(err).To(BeNil())
+	Expect(output).To(ContainSubstring("Docker version"))
+}
+
 func (s *E2eSuite) TestDisplaysAdditionalLineInDockerVersion() {
 	output := s.NewDockerCommand("version").ExecOrDie()
 	Expect(output).To(ContainSubstring("Azure integration"))


### PR DESCRIPTION
**What I did**
* Add root flag --version -v 
* if used, shell out to moby

**Related issue**
Similar to https://github.com/docker/desktop-microsoft/issues/25, used in VSCode Docker extension

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
