### PR TITLE
Allow ACI compose to expose several ports

### DIFF
--- a/azure/convert/convert.go
+++ b/azure/convert/convert.go
@@ -81,6 +81,7 @@ func ToContainerGroup(aciContext store.AciContext, p compose.Project) (container
 		},
 	}
 
+	var groupPorts []containerinstance.Port
 	for _, s := range project.Services {
 		service := serviceConfigAciHelper(s)
 		containerDefinition, err := service.getAciContainer(volumesCache)
@@ -89,7 +90,6 @@ func ToContainerGroup(aciContext store.AciContext, p compose.Project) (container
 		}
 		if service.Ports != nil {
 			var containerPorts []containerinstance.ContainerPort
-			var groupPorts []containerinstance.Port
 			for _, portConfig := range service.Ports {
 				if portConfig.Published != 0 && portConfig.Published != portConfig.Target {
 					msg := fmt.Sprintf("Port mapping is not supported with ACI, cannot map port %d to %d for container %s",

--- a/tests/composefiles/aci-demo/aci_demo_multi_port.yaml
+++ b/tests/composefiles/aci-demo/aci_demo_multi_port.yaml
@@ -1,0 +1,17 @@
+version: '3.3'
+
+services:
+  db:
+    build: db
+    image: gtardif/sentences-db
+
+  words:
+    build: words
+    image: gtardif/sentences-api
+    ports:
+      - "8080:8080"
+  web:
+    build: web
+    image: gtardif/sentences-web
+    ports:
+      - "80:80"


### PR DESCRIPTION
**What I did**
* When converting compose project to ACI payload, append all service ports to ACI group properties, instead of keeping the last one
* unit test added, also tested on ACI, PS shows both ports, they are both reachable

**Related issue**
https://github.com/docker/desktop-microsoft/issues/26

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![images](https://i.pinimg.com/originals/1e/1d/34/1e1d34cb36927e1479f3f8bb648ef758.jpg)