### PR TITLE
Add ACI detach flags

### DIFF
--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -39,6 +39,7 @@ func upCommand() *cobra.Command {
 	upCmd.Flags().StringVar(&opts.WorkDir, "workdir", ".", "Work dir")
 	upCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	upCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")
+	upCmd.Flags().BoolP("detach", "d", true, " Detached mode: Run containers in the background")
 
 	return upCmd
 }

--- a/cli/cmd/run/run.go
+++ b/cli/cmd/run/run.go
@@ -43,6 +43,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Assign a name to the container")
 	cmd.Flags().StringArrayVarP(&opts.Labels, "label", "l", []string{}, "Set meta data on a container")
 	cmd.Flags().StringArrayVarP(&opts.Volumes, "volume", "v", []string{}, "Volume. Ex: user:key@my_share:/absolute/path/to/target")
+	cmd.Flags().BoolP("detach", "d", true, "Run container in background and print container ID")
 
 	return cmd
 }

--- a/cli/cmd/run/testdata/run-help.golden
+++ b/cli/cmd/run/testdata/run-help.golden
@@ -4,6 +4,7 @@ Usage:
   run [flags]
 
 Flags:
+  -d, --detach                Run container in background and print container ID (default true)
   -l, --label stringArray     Set meta data on a container
       --name string           Assign a name to the container
   -p, --publish stringArray   Publish a container's port(s). [HOST_PORT:]CONTAINER_PORT


### PR DESCRIPTION
 not used at the moment, but more makes new commands more compatible with previous ones.

**What I did**
* Added --detach -d flag to aci docker run and docker compose up commands. Flag is currently ignored and behaviour is to detach anyway.

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSLH861P_JuWJvROZT6mbb0aPWgyzfQA9crFA&usqp=CAU)