### PR TITLE
Add version in the main package

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -26,15 +26,15 @@ import (
 	"github.com/docker/api/cli/mobycli"
 )
 
-const cliVersion = "0.1.2"
-
 // VersionCommand command to display version
-func VersionCommand() *cobra.Command {
+func VersionCommand(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the Docker version information",
 		Args:  cobra.MaximumNArgs(0),
-		RunE:  runVersion,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVersion(cmd, version)
+		},
 	}
 	// define flags for backward compatibility with com.docker.cli
 	flags := cmd.Flags()
@@ -45,7 +45,7 @@ func VersionCommand() *cobra.Command {
 	return cmd
 }
 
-func runVersion(cmd *cobra.Command, args []string) error {
+func runVersion(cmd *cobra.Command, version string) error {
 	versionResult, _ := mobycli.ExecSilent(cmd.Context())
 	// we don't want to fail on error, there is an error if the engine is not available but it displays client version info
 	// Still, technically the [] byte versionResult could be nil, just let the original command display what it has to display
@@ -53,6 +53,6 @@ func runVersion(cmd *cobra.Command, args []string) error {
 		return mobycli.ExecCmd(cmd)
 	}
 	var s string = string(versionResult)
-	fmt.Print(strings.Replace(s, "\n Version:", "\n Azure integration  "+cliVersion+"\n Version:", 1))
+	fmt.Print(strings.Replace(s, "\n Version:", "\n Azure integration  "+version+"\n Version:", 1))
 	return nil
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -50,6 +50,10 @@ import (
 )
 
 var (
+	version = "dev"
+)
+
+var (
 	ownCommands = map[string]struct{}{
 		"context": {},
 		"login":   {},
@@ -110,7 +114,7 @@ func main() {
 		cmd.InspectCommand(),
 		compose.Command(),
 		login.Command(),
-		cmd.VersionCommand(),
+		cmd.VersionCommand(version),
 	)
 
 	helpFunc := root.HelpFunc()


### PR DESCRIPTION
**What I did**

Added the version in the main package

This way, when we release goreleaser will inject the right version in
the ldflags
