### PR TITLE
Delegate to Moby CLI, to allow executing ecs CLI plugin if user has switched to the AWS context (created by the plugin)

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -32,18 +32,21 @@ import (
 // ComDockerCli name of the classic cli binary
 const ComDockerCli = "com.docker.cli"
 
-// ExecIfDefaultCtxType delegates to com.docker.cli if on moby context
+// ExecIfDefaultCtxType delegates to com.docker.cli if on moby or AWS context (until there is an AWS backend)
 func ExecIfDefaultCtxType(ctx context.Context) {
 	currentContext := apicontext.CurrentContext(ctx)
 
 	s := store.ContextStore(ctx)
 
 	currentCtx, err := s.Get(currentContext)
-	// Only run original docker command if the current context is not
-	// ours.
-	if err != nil || currentCtx.Type() == store.DefaultContextType {
+	// Only run original docker command if the current context is not ours.
+	if err != nil || mustDelegateToMoby(currentCtx.Type()) {
 		ExecRegardlessContext(ctx)
 	}
+}
+
+func mustDelegateToMoby(ctxType string) bool {
+	return ctxType == store.DefaultContextType || ctxType == store.AwsContextType
 }
 
 // ExecRegardlessContext delegates to com.docker.cli if on moby context

--- a/cli/mobycli/exec_test.go
+++ b/cli/mobycli/exec_test.go
@@ -1,0 +1,24 @@
+package mobycli
+
+import (
+	"testing"
+
+	"github.com/docker/api/tests/framework"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+)
+
+type MobyExecSuite struct {
+	framework.CliSuite
+}
+
+func (sut *MobyExecSuite) TestDelegateContextTypeToMoby() {
+	Expect(mustDelegateToMoby("moby")).To(BeTrue())
+	Expect(mustDelegateToMoby("aws")).To(BeTrue())
+	Expect(mustDelegateToMoby("aci")).To(BeFalse())
+}
+
+func TestExec(t *testing.T) {
+	RegisterTestingT(t)
+	suite.Run(t, new(MobyExecSuite))
+}

--- a/context/store/store.go
+++ b/context/store/store.go
@@ -36,6 +36,8 @@ const (
 	DefaultContextName = "default"
 	// DefaultContextType is the type for all moby contexts (not associated with cli backend)
 	DefaultContextType = "moby"
+	// AwsContextType is the type for ecs contexts (currently a CLI plugin, not associated with cli backend)
+	AwsContextType = "aws"
 	// AciContextType is the endpoint key in the context endpoints for an ACI
 	// backend
 	AciContextType = "aci"

--- a/tests/framework/suite.go
+++ b/tests/framework/suite.go
@@ -24,8 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/docker/api/cli/mobycli"
-
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
@@ -144,10 +142,11 @@ func dockerExecutable() string {
 
 // DockerClassicExecutable binary name based on platform
 func DockerClassicExecutable() string {
+	const comDockerCli = "com.docker.cli"
 	if IsWindows() {
-		return mobycli.ComDockerCli + ".exe"
+		return comDockerCli + ".exe"
 	}
-	return mobycli.ComDockerCli
+	return comDockerCli
 }
 
 // NewDockerCommand creates a docker builder.


### PR DESCRIPTION
**What I did**
* add "aws" context type as a specific type that we let delegate to moby cli

**Related issue**
https://github.com/docker/api/issues/286

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
