### PR TITLE
Cleanup entrypoint

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -41,7 +41,7 @@ func ExecIfDefaultCtxType(ctx context.Context) {
 	currentCtx, err := s.Get(currentContext)
 	// Only run original docker command if the current context is not ours.
 	if err != nil || mustDelegateToMoby(currentCtx.Type()) {
-		ExecRegardlessContext(ctx)
+		Exec(ctx)
 	}
 }
 
@@ -49,8 +49,8 @@ func mustDelegateToMoby(ctxType string) bool {
 	return ctxType == store.DefaultContextType || ctxType == store.AwsContextType
 }
 
-// ExecRegardlessContext delegates to com.docker.cli if on moby context
-func ExecRegardlessContext(ctx context.Context) {
+// Exec delegates to com.docker.cli if on moby context
+func Exec(ctx context.Context) {
 	cmd := exec.CommandContext(ctx, ComDockerCli, os.Args[1:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -65,9 +65,11 @@ func ExecRegardlessContext(ctx context.Context) {
 	os.Exit(0)
 }
 
-// ExecCmd delegates the cli command to com.docker.cli. The error is never returned (process will exit with docker classic exit code), the return type is to make it easier to use with cobra commands
+// ExecCmd delegates the cli command to com.docker.cli. The error is never
+// returned (process will exit with docker classic exit code), the return type
+// is to make it easier to use with cobra commands
 func ExecCmd(command *cobra.Command) error {
-	ExecRegardlessContext(command.Context())
+	Exec(command.Context())
 	return nil
 }
 


### PR DESCRIPTION
**What I did**

* use the `fatal` function when we can
* rename moby.ExecRegardlessContext to Exec

