### PR TITLE
Add missing f shorthand for version command

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -38,7 +38,7 @@ func VersionCommand(version string) *cobra.Command {
 	}
 	// define flags for backward compatibility with com.docker.cli
 	flags := cmd.Flags()
-	flags.String("format", "", "Format the output using the given Go template")
+	flags.StringP("format", "f", "", "Format the output using the given Go template")
 	flags.String("kubeconfig", "", "Kubernetes config file")
 	mobyflags.AddMobyFlagsForRetrocompatibility(flags)
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -239,6 +239,11 @@ func (s *E2eSuite) TestDisplaysAdditionalLineInDockerVersion() {
 	Expect(output).To(ContainSubstring("Azure integration"))
 }
 
+func (s *E2eSuite) TestAllowsFormatFlagInVersion() {
+	s.NewDockerCommand("version", "-f", "{{ json . }}").ExecOrDie()
+	s.NewDockerCommand("version", "--format", "{{ json . }}").ExecOrDie()
+}
+
 func (s *E2eSuite) TestMockBackend() {
 	It("creates a new test context to hardcoded example backend", func() {
 		s.NewDockerCommand("context", "create", "example", "test-example").ExecOrDie()


### PR DESCRIPTION
**What I did**
Add missing shorthand for `--format`

**Related issue**
https://github.com/docker/for-win/issues/7444

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
