### PR TITLE
Generate changelog and use it for releases. 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,14 @@ jobs:
 
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+
+      - name: Generate changelog
+        run: make changelog-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/cache@v1
         with:
@@ -31,4 +39,5 @@ jobs:
         with:
           artifacts: "bin/*"
           prerelease: true
+          bodyFile: "CHANGELOG.md"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,15 @@ export DOCKER_BUILDKIT=1
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	MOBY_DOCKER=/usr/bin/docker
+	SED_I=sed -i
 endif
 ifeq ($(UNAME_S),Darwin)
 	MOBY_DOCKER=/Applications/Docker.app/Contents/Resources/bin/docker
+	SED_I=sed -i ''
 endif
+
+GIT_TAG=$(shell git describe --tags --match "v[0-9]*" --abbrev=0 )
+PREVIOUS_TAG=$(shell git describe --tags --match "v[0-9]*" --abbrev=0 ${GIT_TAG}^)
 
 all: cli
 
@@ -65,10 +70,20 @@ serve: cli ## start server
 moby-cli-link: ## create com.docker.cli symlink if does not already exist
 	ln -s $(MOBY_DOCKER) /usr/local/bin/com.docker.cli
 
+changelog-release: ## generate CHNAGELOG.MD for last tagged release
+	rm -f CHANGELOG.md
+	docker --context default  run --rm -v $(shell pwd):/usr/local/src/your-app ferrarimarco/github-changelog-generator --user docker --project api --token ${GITHUB_TOKEN} --no-issues --since-tag ${PREVIOUS_TAG} --no-unreleased --header-label "" --no-compare-link
+	${SED_I} '1,4d' CHANGELOG.md # remove changelog tag header, we should make a PR in github-changelog-generator to add this option
+
+changelog-preview: ## generate CHNAGELOG.MD for all unreleased things since last TAG
+	rm -f CHANGELOG.md
+	docker --context default  run --rm -v $(shell pwd):/usr/local/src/your-app ferrarimarco/github-changelog-generator --user docker --project api --token ${GITHUB_TOKEN} --no-issues --unreleased-only --header-label "" --no-compare-link
+	${SED_I} '1,4d' CHANGELOG.md # remove changelog tag header, we should make a PR in github-changelog-generator to add this option
+
 help: ## Show help
 	@echo Please specify a build target. The choices are:
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 FORCE:
 
-.PHONY: all protos cli e2e-local cross test cache-clear lint serve classic-link help
+.PHONY: all protos cli e2e-local cross test cache-clear lint serve classic-link help changelog-release changelog-preview


### PR DESCRIPTION
Use github-changelog-generator (many options we can use to improve changelog sections with bug fix, security, etc. based on git labels).

We can preview the changelog before tagging a release : `make changelog-preview`

**What I did**
* new makefile target : `make changelog-release` called in the release ci (one liner with some options, we could use a param file if we add more options)
* Added preview target to locally generate changelog with unreleased PRs: `make changelog-preview` 
* Tested on on fork : https://github.com/gtardif/api/releases/tag/v0.1.4

**Related issue**
https://github.com/docker/api/issues/119

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://i.gbc.tw/gb_img/s600x315q80c/3795681.jpg)