### PR TITLE
Let -it go through for aci exec, same as -t flag for the moment.

### DIFF
--- a/cli/cmd/exec.go
+++ b/cli/cmd/exec.go
@@ -45,6 +45,7 @@ func ExecCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&opts.Tty, "tty", "t", false, "Allocate a pseudo-TTY")
+	cmd.Flags().BoolP("interactive", "i", false, "Keep STDIN open even if not attached")
 
 	return cmd
 }


### PR DESCRIPTION
Will need to check how we can implement -I specifically on ACI

**What I did**
* let `exec` allow --interactive or -i flag, no behaviour change

**Related issue**
https://github.com/docker/desktop-microsoft/issues/27

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTTYR-0WE56TY9sr80ehw240An3awe5viBAmA&usqp=CAU)