### PR TITLE
Send the `tail` parameter to ACI if present

### DIFF
--- a/azure/aci.go
+++ b/azure/aci.go
@@ -221,13 +221,13 @@ func exec(ctx context.Context, address string, password string, reader io.Reader
 	}
 }
 
-func getACIContainerLogs(ctx context.Context, aciContext store.AciContext, containerGroupName, containerName string) (string, error) {
+func getACIContainerLogs(ctx context.Context, aciContext store.AciContext, containerGroupName, containerName string, tail *int32) (string, error) {
 	containerClient, err := getContainerClient(aciContext.SubscriptionID)
 	if err != nil {
 		return "", errors.Wrapf(err, "cannot get container client")
 	}
 
-	logs, err := containerClient.ListLogs(ctx, aciContext.ResourceGroup, containerGroupName, containerName, nil)
+	logs, err := containerClient.ListLogs(ctx, aciContext.ResourceGroup, containerGroupName, containerName, tail)
 	if err != nil {
 		return "", fmt.Errorf("cannot get container logs: %v", err)
 	}


### PR DESCRIPTION
**What I did**

Realised the ACI API has a `tail` parameter, so we send it.

**Related issue**

#62 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/99933/86013176-25412400-ba1f-11ea-8e85-ede94d891658.png)
