### PR TITLE
Avoid running build twice on master with master.yml

### DIFF
--- a/.github/workflows/master-ci.yml
+++ b/.github/workflows/master-ci.yml
@@ -6,28 +6,8 @@ on:
       - master
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
-    steps:
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.14
-        id: go
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Run golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b . v1.27.0
-          ./golangci-lint run --timeout 10m0s
-
   build:
-    name: Build
+    name: ACI e2e tests
     runs-on: ubuntu-latest
     env:
       GO111MODULE: "on"
@@ -46,18 +26,10 @@ jobs:
           path: ~/go/pkg/mod
           key: go-${{ hashFiles('**/go.sum') }}
 
-      - name: Test
-        env:
-          BUILD_TAGS: example,local
-        run: make -f builder.Makefile test
-
-      - name: Build
+      - name: Build fro ACI e2e tests
         env:
           BUILD_TAGS: example,local
         run: make -f builder.Makefile cli
-
-      - name: E2E Test
-        run: make e2e-local
 
       - name: ACI e2e Test
         env:


### PR DESCRIPTION
**What I did**
* realise master commits are build twice, once with ci.yml and once with master.yml (example: https://github.com/docker/api/commit/f0ab42e1097daff280874b99af545216b91eab64)
* remove lint, unit test & local e2e tests from master.yml, already done in ci.yml

**Related issue**


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://www.sortra.com/wp-content/uploads/2014/10/cute-animal-twins03.jpg)