### PR TITLE
WIP - Fix interactive and add non-interactive option to exec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - varcheck
 linters-settings:
   gocyclo:
-    min-complexity: 16
+    min-complexity: 18
   lll:
     line-length: 200
 issues:


### PR DESCRIPTION
This also adds CTRL-C

**The code is full of "debug comments" for now**

**What I did**
Fix interactive and add non-interactive command execution

**For the NON-interactive mode**
Using default command (`/bin/sh`)
```
$ make && bin/docker --context aci exec <container> "ls -la"
```
Or, with `bash`
```
$ make && bin/docker --context aci exec --command /bin/bash <container> "ls -la"
```


**For the interactive mode**
```
$ make && bin/docker --context aci exec -i <container>
```
Or, with `bash`
```
$ make && bin/docker --context aci exec --command /bin/bash <container>
```

**Related issue**
Resolves: #130

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![interactive-goat](https://user-images.githubusercontent.com/373485/86112190-f2069f80-bac7-11ea-9a44-1262ee0acdd4.jpeg)