### PR TITLE
In ACI inspect, display memory limit in bytes, like Moby `docker inspect`.

### DIFF
--- a/azure/convert/convert.go
+++ b/azure/convert/convert.go
@@ -309,7 +309,7 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 	if cc.Resources != nil &&
 		cc.Resources.Limits != nil &&
 		cc.Resources.Limits.MemoryInGB != nil {
-		memLimits = *cc.Resources.Limits.MemoryInGB
+		memLimits = *cc.Resources.Limits.MemoryInGB * 1024 * 1024 * 1024
 	}
 
 	cpuLimit := 0.

--- a/azure/convert/convert_test.go
+++ b/azure/convert/convert_test.go
@@ -83,7 +83,7 @@ func (suite *ConvertTestSuite) TestContainerGroupToContainer() {
 			Resources: &containerinstance.ResourceRequirements{
 				Limits: &containerinstance.ResourceLimits{
 					CPU:        to.Float64Ptr(3),
-					MemoryInGB: to.Float64Ptr(9),
+					MemoryInGB: to.Float64Ptr(0.1),
 				},
 			},
 		},
@@ -95,7 +95,7 @@ func (suite *ConvertTestSuite) TestContainerGroupToContainer() {
 		Image:       "sha256:666",
 		Command:     "mycommand",
 		CPULimit:    3,
-		MemoryLimit: 9,
+		MemoryLimit: 107374182,
 		Ports: []containers.Port{{
 			HostPort:      uint32(80),
 			ContainerPort: uint32(80),


### PR DESCRIPTION
Displaying in Gb also was rounding memory to zero if set to 0.xGb

**What I did**
convert ACI `MemoryInGB` into bytes, and test it displays the same value as local `docker inspect` for 0.1 G memory limit

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://static.boredpanda.com/blog/wp-content/uploads/2020/06/animals-being-weighed-fb7-png__700.jpg)