### PR TITLE
Random ACI group name for tests, otherwise we are conflicting with each other + the CI

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -19,13 +19,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/docker/api/azure"
-	"github.com/docker/api/azure/login"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/resources/mgmt/resources"
 	azure_storage "github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/storage/mgmt/storage"
@@ -35,21 +34,26 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/docker/api/azure"
+	"github.com/docker/api/azure/login"
 	"github.com/docker/api/context/store"
 	"github.com/docker/api/tests/aci-e2e/storage"
 	. "github.com/docker/api/tests/framework"
 )
 
 const (
-	resourceGroupName = "resourceGroupTest"
 	location          = "westeurope"
 	contextName       = "acitest"
-
 	testContainerName = "testcontainername"
+	testShareName     = "dockertestshare"
+	testFileContent   = "Volume mounted with success!"
+	testFileName      = "index.html"
 )
 
 var (
-	subscriptionID string
+	subscriptionID         string
+	resourceGroupName      = "resourceGroupTestE2E-" + RandStringBytes(10)
+	testStorageAccountName = "storageteste2e" + RandStringBytes(6) // "between 3 and 24 characters in length and use numbers and lower-case letters only"
 )
 
 type E2eACISuite struct {
@@ -238,13 +242,6 @@ func (s *E2eACISuite) TestACIBackend() {
 	})
 }
 
-const (
-	testStorageAccountName = "dockertestaccount"
-	testShareName          = "dockertestshare"
-	testFileContent        = "Volume mounted with success!"
-	testFileName           = "index.html"
-)
-
 func createStorageAccount(aciContext store.AciContext, accountName string) azure_storage.Account {
 	log.Println("Creating storage account " + accountName)
 	storageAccount, err := storage.CreateStorageAccount(context.TODO(), aciContext, accountName)
@@ -313,4 +310,14 @@ func deleteResourceGroup(groupName string) {
 	Expect(err).To(BeNil())
 	err = helper.Delete(ctx, *models[0].SubscriptionID, groupName)
 	Expect(err).To(BeNil())
+}
+
+func RandStringBytes(n int) string {
+	rand.Seed(time.Now().UnixNano())
+	const digits = "0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = digits[rand.Intn(len(digits))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
**What I did**
* ACI e2e test is now using a random number in the resource group name (still prefixed with `resourceGroupTest-` to make it easy to identify if you ctrl-C tests for some reason and it does not cleans the resource group)

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://compote.slate.com/images/73f0857e-2a1a-4fea-b97a-bd4c241c01f5.jpg)