### PR TITLE
Allow users to specify tenanted when logging into azure (if several tenants for azure account)

### DIFF
--- a/azure/backend.go
+++ b/azure/backend.go
@@ -338,7 +338,7 @@ type aciCloudService struct {
 }
 
 func (cs *aciCloudService) Login(ctx context.Context, params map[string]string) error {
-	return cs.loginService.Login(ctx)
+	return cs.loginService.Login(ctx, params[login.TenantIDLoginParam])
 }
 
 func (cs *aciCloudService) CreateContextData(ctx context.Context, params map[string]string) (interface{}, string, error) {

--- a/cli/cmd/login/azurelogin.go
+++ b/cli/cmd/login/azurelogin.go
@@ -1,0 +1,28 @@
+package login
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/docker/api/azure/login"
+)
+
+type azureLoginOpts struct {
+	tenantID string
+}
+
+// AzureLoginCommand returns the azure login command
+func AzureLoginCommand() *cobra.Command {
+	opts := azureLoginOpts{}
+	cmd := &cobra.Command{
+		Use:   "azure",
+		Short: "Log in to azure",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cloudLogin(cmd, "aci", map[string]string{login.TenantIDLoginParam: opts.tenantID})
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&opts.tenantID, "tenant-id", "", "Specify tenant ID to use from your azure account")
+
+	return cmd
+}


### PR DESCRIPTION
**What I did**
* `docker login azure` is now a subcommand of `login`, with specific optional flag `--tenant-id`. 
* when loging in, if no tenantId specified, continue to take first tenant, otherwise loop through proposed tenant to find requested one

**Related issue**
https://github.com/docker/aci-integration-beta/issues/8

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://c8.alamy.com/comp/2B2MTB7/portrait-of-three-cute-wild-meerkats-on-a-log-in-the-wild-2B2MTB7.jpg)