### PR TITLE
Fix logs replacement when streaming logs on windows

### DIFF
--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -18,8 +18,8 @@ package cmd
 
 import (
 	"context"
-	"os"
 
+	"github.com/containerd/console"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -59,7 +59,7 @@ func runLogs(ctx context.Context, containerName string, opts logsOpts) error {
 	req := containers.LogsRequest{
 		Follow: opts.Follow,
 		Tail:   opts.Tail,
-		Writer: os.Stdout,
+		Writer: console.Current(),
 	}
 
 	return c.ContainerService().Logs(ctx, containerName, req)


### PR DESCRIPTION
**What I did**
* set streaming output to console to make it work in powershell
* also tested in cmd

**Related issue**
https://github.com/docker/api/issues/320

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
