### PR TITLE
Count the lines from the terminal, not from ACI

### DIFF
--- a/azure/aci.go
+++ b/azure/aci.go
@@ -265,21 +265,27 @@ func streamLogs(ctx context.Context, aciContext store.AciContext, containerGroup
 			b = b.Up(uint(numLines))
 			fmt.Fprint(out, b.Column(0).ANSI)
 
+			numLines = getBacktrackLines(logLines, terminalWidth)
+
 			for i := 0; i < currentOutput-1; i++ {
 				fmt.Fprintln(out, logLines[i])
-			}
-
-			numLines = 0
-			for i := 0; i < currentOutput-1; i++ {
-				numLines++
-				if len(logLines[i]) > terminalWidth {
-					numLines += len(logLines[i]) / terminalWidth
-				}
 			}
 
 			time.Sleep(2 * time.Second)
 		}
 	}
+}
+
+func getBacktrackLines(lines []string, terminalWidth int) int {
+	numLines := 0
+	for i := 0; i < len(lines)-1; i++ {
+		numLines++
+		if len(lines[i]) > terminalWidth {
+			numLines += len(lines[i]) / terminalWidth
+		}
+	}
+
+	return numLines
 }
 
 func getContainerGroupsClient(subscriptionID string) (containerinstance.ContainerGroupsClient, error) {

--- a/azure/aci_test.go
+++ b/azure/aci_test.go
@@ -1,0 +1,12 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLinesWritten(t *testing.T) {
+	assert.Equal(t, 0, getBacktrackLines([]string{"Hello"}, 10))
+	assert.Equal(t, 3, getBacktrackLines([]string{"Hello", "world"}, 2))
+}


### PR DESCRIPTION
**What I did**

Count the number of lines output on the terminal wrt the terminal width
so that we can go up the right amount.

**Related issue**
#320 
