### PR TITLE
Specific exit code when command fails because azure login is required

### DIFF
--- a/azure/resourcegroup.go
+++ b/azure/resourcegroup.go
@@ -130,7 +130,7 @@ func getSubscriptionsClient() (subscription.SubscriptionsClient, error) {
 	subc := subscription.NewSubscriptionsClient()
 	err := setupClient(&subc.Client)
 	if err != nil {
-		return subscription.SubscriptionsClient{}, errors.Wrap(errdefs.ErrLoginFailed, err.Error())
+		return subscription.SubscriptionsClient{}, errors.Wrap(errdefs.ErrLoginRequired, err.Error())
 	}
 	return subc, nil
 }

--- a/errdefs/errors.go
+++ b/errdefs/errors.go
@@ -20,6 +20,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	//ExitCodeLoginRequired exit code when command cannot execute because it requires cloud login
+	// This will be used by VSCode to detect when creating context if the user needs to login first
+	ExitCodeLoginRequired = 5
+)
+
 var (
 	// ErrNotFound is returned when an object is not found
 	ErrNotFound = errors.New("not found")
@@ -31,6 +37,8 @@ var (
 	ErrUnknown = errors.New("unknown")
 	// ErrLoginFailed is returned when login failed
 	ErrLoginFailed = errors.New("login failed")
+	// ErrLoginRequired is returned when login is required for a specific action
+	ErrLoginRequired = errors.New("login required")
 	// ErrNotImplemented is returned when a backend doesn't implement
 	// an action
 	ErrNotImplemented = errors.New("not implemented")

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -18,10 +18,13 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/docker/api/errdefs"
 
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
@@ -41,6 +44,14 @@ func (s *E2eSuite) TestContextHelp() {
 	Expect(output).To(ContainSubstring("--location"))
 	Expect(output).To(ContainSubstring("--subscription-id"))
 	Expect(output).To(ContainSubstring("--resource-group"))
+}
+
+func (s *E2eSuite) TestContextCreateAciExitWithErrorCodeIfLoginRequired() {
+	cmd := exec.Command("docker", "context", "create", "aci", "someContext")
+	output, err := cmd.CombinedOutput()
+	Expect(err).NotTo(BeNil())
+	Expect(string(output)).To(ContainSubstring("not logged in to azure, you need to run \"docker login azure\" first"))
+	Expect(cmd.ProcessState.ExitCode()).To(Equal(errdefs.ExitCodeLoginRequired))
 }
 
 func (s *E2eSuite) TestListAndShowDefaultContext() {


### PR DESCRIPTION
**What I did**
* define common error for login required (separate from LoginFailed error)
* change exit code when commands result in this error in main()
* added e2e test checking the explicit error message and the exit code for context create scenario (where VSCode needs the exit code)

**Related issue**
https://github.com/docker/api/issues/299

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://http.cat/431)