### PR TITLE
Run containers and attach to logs by default, detach with -d option

### DIFF
--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -57,9 +57,7 @@ func runLogs(ctx context.Context, containerName string, opts logsOpts) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot connect to backend")
 	}
-	var con io.Writer
-
-	con = os.Stdout
+	var con io.Writer = os.Stdout
 	if c, err := console.ConsoleFromFile(os.Stdout); err == nil {
 		con = c
 	}

--- a/cli/cmd/run/testdata/run-help.golden
+++ b/cli/cmd/run/testdata/run-help.golden
@@ -5,7 +5,7 @@ Usage:
 
 Flags:
       --cpus float            Number of CPUs (default 1)
-  -d, --detach                Run container in background and print container ID (default true)
+  -d, --detach                Run container in background and print container ID
   -l, --label stringArray     Set meta data on a container
   -m, --memory bytes          Memory limit
       --name string           Assign a name to the container

--- a/cli/options/run/opts.go
+++ b/cli/options/run/opts.go
@@ -36,6 +36,7 @@ type Opts struct {
 	Volumes []string
 	Cpus    float64
 	Memory  formatter.MemBytes
+	Detach  bool
 }
 
 // ToContainerConfig convert run options to a container configuration

--- a/local/e2e/backend_test.go
+++ b/local/e2e/backend_test.go
@@ -45,7 +45,7 @@ func (m *LocalBackendTestSuite) TestPs() {
 }
 
 func (m *LocalBackendTestSuite) TestRun() {
-	_, err := m.NewDockerCommand("run", "--name", "nginx", "nginx").Exec()
+	_, err := m.NewDockerCommand("run", "-d", "--name", "nginx", "nginx").Exec()
 	require.Nil(m.T(), err)
 	out := m.NewDockerCommand("ps").ExecOrDie()
 	defer func() {
@@ -55,7 +55,7 @@ func (m *LocalBackendTestSuite) TestRun() {
 }
 
 func (m *LocalBackendTestSuite) TestRunWithPorts() {
-	_, err := m.NewDockerCommand("run", "--name", "nginx", "-p", "8080:80", "nginx").Exec()
+	_, err := m.NewDockerCommand("run", "-d", "--name", "nginx", "-p", "8080:80", "nginx").Exec()
 	require.Nil(m.T(), err)
 	out := m.NewDockerCommand("ps").ExecOrDie()
 	defer func() {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -288,7 +288,7 @@ func (s *E2eSuite) TestMockBackend() {
 	})
 
 	It("can run 'run' command", func() {
-		output := s.NewDockerCommand("run", "nginx", "-p", "80:80").ExecOrDie()
+		output := s.NewDockerCommand("run", "-d", "nginx", "-p", "80:80").ExecOrDie()
 		Expect(output).To(ContainSubstring("Running container \"nginx\" with name"))
 	})
 }


### PR DESCRIPTION
**What I did**
* call FollowLogs from the run command if not -d
* update all e2e tests to add -d and not follow logs everywhere
* added ACI e2e tests running a container and attach logs, also test memory/CPU settings in this test

This adds ~30 secs (on a MB pro) to ACI test... not proud of this

**Related issue**
Follow up on https://github.com/docker/api/issues/320

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**