### PR TITLE
In ACI e2e tests, do not wait for full resource group deletion at the end

### DIFF
--- a/azure/context_test.go
+++ b/azure/context_test.go
@@ -221,7 +221,7 @@ func (s *MockResourceGroupHelper) CreateOrUpdate(ctx context.Context, subscripti
 	return args.Get(0).(resources.Group), args.Error(1)
 }
 
-func (s *MockResourceGroupHelper) Delete(ctx context.Context, subscriptionID string, resourceGroupName string) (err error) {
+func (s *MockResourceGroupHelper) DeleteAsync(ctx context.Context, subscriptionID string, resourceGroupName string) (err error) {
 	args := s.Called(ctx, subscriptionID, resourceGroupName)
 	return args.Error(0)
 }

--- a/azure/resourcegroup.go
+++ b/azure/resourcegroup.go
@@ -32,7 +32,7 @@ type ACIResourceGroupHelper interface {
 	ListGroups(ctx context.Context, subscriptionID string) ([]resources.Group, error)
 	GetGroup(ctx context.Context, subscriptionID string, groupName string) (resources.Group, error)
 	CreateOrUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, parameters resources.Group) (result resources.Group, err error)
-	Delete(ctx context.Context, subscriptionID string, resourceGroupName string) error
+	DeleteAsync(ctx context.Context, subscriptionID string, resourceGroupName string) error
 }
 
 type aciResourceGroupHelperImpl struct {
@@ -87,18 +87,15 @@ func (mgt aciResourceGroupHelperImpl) CreateOrUpdate(ctx context.Context, subscr
 	return gc.CreateOrUpdate(ctx, resourceGroupName, parameters)
 }
 
-// Delete deletes a resource group
-func (mgt aciResourceGroupHelperImpl) Delete(ctx context.Context, subscriptionID string, resourceGroupName string) (err error) {
+// DeleteAsync deletes a resource group. Does not wait for full deletion to return (long operation)
+func (mgt aciResourceGroupHelperImpl) DeleteAsync(ctx context.Context, subscriptionID string, resourceGroupName string) (err error) {
 	gc, err := getGroupsClient(subscriptionID)
 	if err != nil {
 		return err
 	}
 
-	future, err := gc.Delete(ctx, resourceGroupName)
-	if err != nil {
-		return err
-	}
-	return future.WaitForCompletionRef(ctx, gc.Client)
+	_, err = gc.Delete(ctx, resourceGroupName)
+	return err
 }
 
 // GetSubscriptionIDs Return available subscription IDs based on azure login

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -331,7 +331,7 @@ func deleteResourceGroup(groupName string) {
 	helper := azure.NewACIResourceGroupHelper()
 	models, err := helper.GetSubscriptionIDs(ctx)
 	Expect(err).To(BeNil())
-	err = helper.Delete(ctx, *models[0].SubscriptionID, groupName)
+	err = helper.DeleteAsync(ctx, *models[0].SubscriptionID, groupName)
 	Expect(err).To(BeNil())
 }
 


### PR DESCRIPTION
let ACI clean things UP (timeframe ~45 sec or more). This is costing GH Action minutes for nothing, and slows test results a lot.

**What I did**
* Renamed Delete() to DeleteAsync() and do not wait on future

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://i.pinimg.com/originals/8b/b9/2c/8bb92ce824fd2802c1fce02ff3cfec9e.jpg)