### PR TITLE
Make sure the metrics goroutine is scheduled

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -52,12 +52,17 @@ var managementCommands = []string{
 
 // Track sends the tracking analytics to Docker Desktop
 func Track(context string, args []string, flags *flag.FlagSet) {
+	wasIn := make(chan bool)
+
 	// Fire and forget, we don't want to slow down the user waiting for DD
 	// metrics endpoint to respond. We could lose some events but that's ok.
 	go func() {
 		defer func() {
 			_ = recover()
 		}()
+
+		wasIn <- true
+
 		command := getCommand(args, flags)
 		if command != "" {
 			c := NewClient()
@@ -67,6 +72,7 @@ func Track(context string, args []string, flags *flag.FlagSet) {
 			})
 		}
 	}()
+	<-wasIn
 }
 
 func getCommand(args []string, flags *flag.FlagSet) string {


### PR DESCRIPTION
**What I did**

Wait for the goroutine to be scheduled before exiting. We don't wait for
the metrics event to be sent, we only make sure the goroutine is called.

Inpired [by this change](https://github.com/tektoncd/pipeline/pull/2895)
