### PR TITLE
Better error message when trying to remove a container from a compose application

### DIFF
--- a/azure/backend.go
+++ b/azure/backend.go
@@ -267,7 +267,8 @@ func (cs *aciContainerService) Logs(ctx context.Context, containerName string, r
 func (cs *aciContainerService) Delete(ctx context.Context, containerID string, _ bool) error {
 	groupName, containerName := getGroupAndContainerName(containerID)
 	if groupName != containerID {
-		return errors.New(fmt.Sprintf("cannot delete service %q from compose app %q, you must delete the entire compose app with docker compose down", containerName, groupName))
+		msg := "cannot delete service %q from compose application %q, you can delete the entire compose app with docker compose down --project-name %s"
+		return errors.New(fmt.Sprintf(msg, containerName, groupName, groupName))
 	}
 	cg, err := deleteACIContainerGroup(ctx, cs.ctx, groupName)
 	if err != nil {

--- a/azure/backend_test.go
+++ b/azure/backend_test.go
@@ -50,7 +50,7 @@ func (suite *BackendSuiteTest) TestErrorMessageDeletingContainerFromComposeAppli
 	err := service.Delete(context.TODO(), "compose-app_service1", false)
 
 	Expect(err).NotTo(BeNil())
-	Expect(err.Error()).To(Equal("cannot delete service \"service1\" from compose app \"compose-app\", you must delete the entire compose app with docker compose down"))
+	Expect(err.Error()).To(Equal("cannot delete service \"service1\" from compose application \"compose-app\", you can delete the entire compose app with docker compose down --project-name compose-app"))
 }
 
 func (suite *BackendSuiteTest) TestErrorMessageRunSingleContainerNameWithComposeSeparator() {


### PR DESCRIPTION
**What I did**
* Improved error message, with the command the user can copy/paste if they want to delete the entire compose application

**Related issue**
https://github.com/docker/api/issues/330

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
