### PR TITLE
Add ”Platform” in docker inspect result, showing container OS 

### DIFF
--- a/azure/convert/convert.go
+++ b/azure/convert/convert.go
@@ -327,6 +327,7 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 	if cc.InstanceView != nil && cc.InstanceView.CurrentState != nil {
 		status = *cc.InstanceView.CurrentState.State
 	}
+	platform := string(cg.OsType)
 
 	c := containers.Container{
 		ID:          containerID,
@@ -341,6 +342,7 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 		PidsLimit:   0,
 		Labels:      nil,
 		Ports:       ToPorts(cg.IPAddress, *cc.Ports),
+		Platform:    platform,
 	}
 
 	return c, nil

--- a/azure/convert/convert_test.go
+++ b/azure/convert/convert_test.go
@@ -62,6 +62,7 @@ func (suite *ConvertTestSuite) TestContainerGroupToContainer() {
 				}},
 				IP: to.StringPtr("42.42.42.42"),
 			},
+			OsType: "Linux",
 		},
 	}
 	myContainer := containerinstance.Container{
@@ -95,6 +96,7 @@ func (suite *ConvertTestSuite) TestContainerGroupToContainer() {
 		Command:     "mycommand",
 		CPULimit:    3,
 		MemoryLimit: 107374182,
+		Platform:    "Linux",
 		Ports: []containers.Port{{
 			HostPort:      uint32(80),
 			ContainerPort: uint32(80),

--- a/cli/cmd/testdata/inspect-out-id.golden
+++ b/cli/cmd/testdata/inspect-out-id.golden
@@ -10,5 +10,6 @@
     "PidsCurrent": 0,
     "PidsLimit": 0,
     "Labels": null,
-    "Ports": null
+    "Ports": null,
+    "Platform": "Linux"
 }

--- a/containers/api.go
+++ b/containers/api.go
@@ -37,6 +37,7 @@ type Container struct {
 	PidsLimit   uint64
 	Labels      []string
 	Ports       []Port
+	Platform    string
 }
 
 // Port represents a published port of a container

--- a/example/backend.go
+++ b/example/backend.go
@@ -58,8 +58,9 @@ type containerService struct{}
 
 func (cs *containerService) Inspect(ctx context.Context, id string) (containers.Container, error) {
 	return containers.Container{
-		ID:    "id",
-		Image: "nginx",
+		ID:       "id",
+		Image:    "nginx",
+		Platform: "Linux",
 	}, nil
 }
 

--- a/local/backend.go
+++ b/local/backend.go
@@ -88,10 +88,11 @@ func (ms *local) Inspect(ctx context.Context, id string) (containers.Container, 
 	}
 
 	return containers.Container{
-		ID:      stringid.TruncateID(c.ID),
-		Status:  status,
-		Image:   c.Image,
-		Command: command,
+		ID:       stringid.TruncateID(c.ID),
+		Status:   status,
+		Image:    c.Image,
+		Command:  command,
+		Platform: c.Platform,
 	}, nil
 }
 

--- a/tests/e2e/testdata/inspect-id.golden
+++ b/tests/e2e/testdata/inspect-id.golden
@@ -10,5 +10,6 @@
     "PidsCurrent": 0,
     "PidsLimit": 0,
     "Labels": null,
-    "Ports": null
+    "Ports": null,
+    "Platform": "Linux"
 }


### PR DESCRIPTION
this field is used by VSCode

**What I did**
* Added in inspect result field "Platform", same as the moby inspect existing field

**Related issue**
https://github.com/docker/api/issues/345

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://camo.githubusercontent.com/7a06833f1bde62da68a466ad54bf75c9496629f3/687474703a2f2f6864626c61636b77616c6c70617065722e636f6d2f77616c6c70617065722f323031352f31322f637574652d666973682d382d667265652d77616c6c70617065722e6a7067)