### PR TITLE
Exit without error message if user canceled command 

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -173,6 +173,11 @@ func main() {
 	ctx = store.WithContextStore(ctx, s)
 
 	if err = root.ExecuteContext(ctx); err != nil {
+		//if user canceled request, simply exit without any error message
+		if errors.Is(ctx.Err(), context.Canceled) {
+			os.Exit(130)
+		}
+
 		// Context should always be handled by new CLI
 		requiredCmd, _, _ := root.Find(os.Args[1:])
 		if requiredCmd != nil && isOwnCommand(requiredCmd) {


### PR DESCRIPTION
(typical scenario : ACI `logs — follow` and ctrl-C while querying ACI)

**What I did**
* try to get information from ACI error when cancelling an in progress request, but the error type is swallowed by ACI.
* in case of error, check context err (`ctx.Err()` )  to see if it was canceled, exit(1)



**Related issue**
https://github.com/docker/api/issues/331

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQO39pSbI24DwhmR58zwQdHU-GkHewflDOOHA&usqp=CAU)