### PR TITLE
Add check on exec looking for arguments

### DIFF
--- a/azure/backend.go
+++ b/azure/backend.go
@@ -223,6 +223,10 @@ func getGroupAndContainerName(containerID string) (groupName string, containerNa
 }
 
 func (cs *aciContainerService) Exec(ctx context.Context, name string, command string, reader io.Reader, writer io.Writer) error {
+	err := verifyExecCommand(command)
+	if err != nil {
+		return err
+	}
 	groupName, containerAciName := getGroupAndContainerName(name)
 	containerExecResponse, err := execACIContainer(ctx, cs.ctx, command, groupName, containerAciName)
 	if err != nil {
@@ -236,6 +240,15 @@ func (cs *aciContainerService) Exec(ctx context.Context, name string, command st
 		reader,
 		writer,
 	)
+}
+
+func verifyExecCommand(command string) error {
+	tokens := strings.Split(command, " ")
+	if len(tokens) > 1 {
+		return errors.New("ACI exec command does not accept arguments to the command. " +
+			"Only the binary should be specified")
+	}
+	return nil
 }
 
 func (cs *aciContainerService) Logs(ctx context.Context, containerName string, req containers.LogsRequest) error {

--- a/azure/backend_test.go
+++ b/azure/backend_test.go
@@ -61,6 +61,15 @@ func (suite *BackendSuiteTest) TestErrorMessageRunSingleContainerNameWithCompose
 	Expect(err.Error()).To(Equal("invalid container name. ACI container name cannot include \"_\""))
 }
 
+func (suite *BackendSuiteTest) TestVerifyCommand() {
+	err := verifyExecCommand("command") // Command without an argument
+	Expect(err).To(BeNil())
+	err = verifyExecCommand("command argument") // Command with argument
+	Expect(err).NotTo(BeNil())
+	Expect(err.Error()).To(Equal("ACI exec command does not accept arguments to the command. " +
+		"Only the binary should be specified"))
+}
+
 func TestBackendSuite(t *testing.T) {
 	RegisterTestingT(t)
 	suite.Run(t, new(BackendSuiteTest))

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZ
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-sdk-for-go v43.3.0+incompatible h1:o0G4JAsOzeVJEwU0Ud9bh+lUHPUc0GkFENJ02dk51Uo=
 github.com/Azure/azure-sdk-for-go v43.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-storage-file-go v0.7.0 h1:yWoV0MYwzmoSgWACcVkdPolvAULFPNamcQLpIvS/Et4=
-github.com/Azure/azure-storage-file-go v0.7.0/go.mod h1:3w3mufGcMjcOJ3w+4Gs+5wsSgkT7xDwWWqMMIrXtW4c=
 github.com/Azure/azure-storage-file-go v0.8.0 h1:OX8DGsleWLUE6Mw4R/OeWEZMvsTIpwN94J59zqKQnTI=
 github.com/Azure/azure-storage-file-go v0.8.0/go.mod h1:3w3mufGcMjcOJ3w+4Gs+5wsSgkT7xDwWWqMMIrXtW4c=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -150,6 +150,15 @@ func (s *E2eACISuite) TestACIBackend() {
 		Expect(output).To(ContainSubstring("GET"))
 	})
 
+	s.T().Run("exec command", func(t *testing.T) {
+		output := s.NewDockerCommand("exec", testContainerName, "pwd").ExecOrDie()
+		Expect(output).To(ContainSubstring("/"))
+
+		output = s.NewDockerCommand("exec", testContainerName, "echo", "fail_with_argument").ExecOrDie()
+		Expect(output).To(ContainSubstring("ACI exec command does not accept arguments to the command. " +
+			"Only the binary should be specified"))
+	})
+
 	s.T().Run("follow logs from nginx", func(t *testing.T) {
 		timeChan := make(chan time.Time)
 


### PR DESCRIPTION
**What I did**
In the case where the command has arguments
it fails because ACI implementation does not
support commands with arguments

Non interactive:
```
$ make && bin/docker --context aci exec <container> pwd
```

Interactive:
```
$ make && bin/docker --context aci exec -t <container> /bin/sh
```

**Related issue**
Resolves: #130

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![interactive-goat](https://user-images.githubusercontent.com/373485/86738209-2aacf880-c035-11ea-8ba2-7e3f27ee29dd.jpeg)

