### PR TITLE
Allow non-interactive exec on ACI

### DIFF
--- a/azure/backend.go
+++ b/azure/backend.go
@@ -19,7 +19,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -192,13 +191,13 @@ func getGroupAndContainerName(containerID string) (groupName string, containerNa
 	return groupName, containerName
 }
 
-func (cs *aciContainerService) Exec(ctx context.Context, name string, command string, reader io.Reader, writer io.Writer) error {
-	err := verifyExecCommand(command)
+func (cs *aciContainerService) Exec(ctx context.Context, name string, request containers.ExecRequest) error {
+	err := verifyExecCommand(request.Command)
 	if err != nil {
 		return err
 	}
 	groupName, containerAciName := getGroupAndContainerName(name)
-	containerExecResponse, err := execACIContainer(ctx, cs.ctx, command, groupName, containerAciName)
+	containerExecResponse, err := execACIContainer(ctx, cs.ctx, request.Command, groupName, containerAciName)
 	if err != nil {
 		return err
 	}
@@ -207,8 +206,7 @@ func (cs *aciContainerService) Exec(ctx context.Context, name string, command st
 		context.Background(),
 		*containerExecResponse.WebSocketURI,
 		*containerExecResponse.Password,
-		reader,
-		writer,
+		request,
 	)
 }
 

--- a/containers/api.go
+++ b/containers/api.go
@@ -72,6 +72,16 @@ type ContainerConfig struct {
 	Environment []string
 }
 
+// ExecRequest contaiens configuration about an exec request
+type ExecRequest struct {
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Command     string
+	Interactive bool
+	Tty         bool
+}
+
 // LogsRequest contains configuration about a log request
 type LogsRequest struct {
 	Follow bool
@@ -88,7 +98,7 @@ type Service interface {
 	// Run creates and starts a container
 	Run(ctx context.Context, config ContainerConfig) error
 	// Exec executes a command inside a running container
-	Exec(ctx context.Context, containerName string, command string, reader io.Reader, writer io.Writer) error
+	Exec(ctx context.Context, containerName string, request ExecRequest) error
 	// Logs returns all the logs of a container
 	Logs(ctx context.Context, containerName string, request LogsRequest) error
 	// Delete removes containers

--- a/example/backend.go
+++ b/example/backend.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/compose-spec/compose-go/cli"
 
@@ -95,8 +94,8 @@ func (cs *containerService) Stop(ctx context.Context, containerName string, time
 	return errors.New("not implemented")
 }
 
-func (cs *containerService) Exec(ctx context.Context, name string, command string, reader io.Reader, writer io.Writer) error {
-	fmt.Printf("Executing command %q on container %q", command, name)
+func (cs *containerService) Exec(ctx context.Context, name string, request containers.ExecRequest) error {
+	fmt.Printf("Executing command %q on container %q", request.Command, name)
 	return nil
 }
 

--- a/local/backend.go
+++ b/local/backend.go
@@ -179,9 +179,9 @@ func (ms *local) Stop(ctx context.Context, containerID string, timeout *uint32) 
 	return ms.apiClient.ContainerStop(ctx, containerID, t)
 }
 
-func (ms *local) Exec(ctx context.Context, name string, command string, reader io.Reader, writer io.Writer) error {
+func (ms *local) Exec(ctx context.Context, name string, request containers.ExecRequest) error {
 	cec, err := ms.apiClient.ContainerExecCreate(ctx, name, types.ExecConfig{
-		Cmd:          []string{command},
+		Cmd:          []string{request.Command},
 		Tty:          true,
 		AttachStdin:  true,
 		AttachStdout: true,
@@ -202,12 +202,12 @@ func (ms *local) Exec(ctx context.Context, name string, command string, reader i
 	writeChannel := make(chan error, 10)
 
 	go func() {
-		_, err := io.Copy(writer, resp.Reader)
+		_, err := io.Copy(request.Stdout, resp.Reader)
 		readChannel <- err
 	}()
 
 	go func() {
-		_, err := io.Copy(resp.Conn, reader)
+		_, err := io.Copy(resp.Conn, request.Stdin)
 		writeChannel <- err
 	}()
 

--- a/server/proxy/containers.go
+++ b/server/proxy/containers.go
@@ -92,7 +92,12 @@ func (p *proxy) Exec(ctx context.Context, request *containersv1.ExecRequest) (*c
 		Stream: stream,
 	}
 
-	return &containersv1.ExecResponse{}, Client(ctx).ContainerService().Exec(ctx, request.GetId(), request.GetCommand(), io, io)
+	return &containersv1.ExecResponse{}, Client(ctx).ContainerService().Exec(ctx, request.GetId(), containers.ExecRequest{
+		Stdin:   io,
+		Stdout:  io,
+		Command: request.GetCommand(),
+		Tty:     request.GetTty(),
+	})
 }
 
 func (p *proxy) Logs(request *containersv1.LogsRequest, stream containersv1.Containers_LogsServer) error {

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -105,6 +105,9 @@ func (s *E2eACISuite) TestACIRunSingleContainer() {
 	})
 
 	s.Step("exec command", func() {
+		output := s.NewDockerCommand("exec", testContainerName, "pwd").ExecOrDie()
+		Expect(output).To(ContainSubstring("/"))
+
 		_, err := s.NewDockerCommand("exec", testContainerName, "echo", "fail_with_argument").Exec()
 		Expect(err.Error()).To(ContainSubstring("ACI exec command does not accept arguments to the command. " +
 			"Only the binary should be specified"))


### PR DESCRIPTION
**What I did**

Made non-interactive exec work for ACI.

If the request is for a non-interactive exec we don't attach the stdin when executing.

*Note:* the local bakend needs some work but it's not our priority now so I didn't really make sure all different combinations of the flags work.

**Related issue**

Fixes #361 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/99933/86919081-f0705380-c127-11ea-85dd-fa80843622fa.png)
