### PR TITLE
Update guava version to remove security warning

### DIFF
--- a/tests/composefiles/aci-demo/words/pom.xml
+++ b/tests/composefiles/aci-demo/words/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>[24.1.1,)</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>


### PR DESCRIPTION
I put what dependabot told me to put, hopefully the warning will go away.

We should maybe see if we can remove this code from the repo.