### PR TITLE
Aci improvements on tags & single container run

### DIFF
--- a/azure/aci.go
+++ b/azure/aci.go
@@ -71,8 +71,9 @@ func createOrUpdateACIContainers(ctx context.Context, aciContext store.AciContex
 	if err != nil {
 		return errors.Wrapf(err, "cannot get container group client")
 	}
+	groupDisplay := "Group " + *groupDefinition.Name
 	w.Event(progress.Event{
-		ID:         *groupDefinition.Name,
+		ID:         groupDisplay,
 		Status:     progress.Working,
 		StatusText: "Waiting",
 	})
@@ -88,7 +89,7 @@ func createOrUpdateACIContainers(ctx context.Context, aciContext store.AciContex
 	}
 
 	w.Event(progress.Event{
-		ID:         *groupDefinition.Name,
+		ID:         groupDisplay,
 		Status:     progress.Done,
 		StatusText: "Created",
 	})

--- a/azure/backend.go
+++ b/azure/backend.go
@@ -132,7 +132,7 @@ func (cs *aciContainerService) List(ctx context.Context, _ bool) ([]containers.C
 
 		if _, ok := group.Tags[singleContainerTag]; ok {
 			if group.Containers == nil || len(*group.Containers) < 1 {
-				return []containers.Container{}, fmt.Errorf("found no containers in ACI container group %s", *containerGroup.Name)
+				return []containers.Container{}, fmt.Errorf("no containers found in ACI container group %s", *containerGroup.Name)
 			}
 			container := (*group.Containers)[0]
 			c := getContainer(*containerGroup.Name, group.IPAddress, container)


### PR DESCRIPTION
**What I did**
* change ACI tag to `docker-single-container`, added `docker-compose-application` tag for compose apps. This can be useful potentially for metrics on the ACI side, and in general identify docker or non-docker containers 
* fix wrong error message when listing containers
* fix progress display for single container run : separate provisioning progress from container progress. 
```
 $ ./bin/docker --context acitest run nginx
[+] Running 2/2
⠿ Group strange-bartik  Created         4.2s
⠿ strange-bartik        Done            20.6s
strange-bartik
```

**Related issue**
Follow up on https://github.com/docker/api/pull/380

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
