### PR TITLE
Fix logout test on Windows

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -134,7 +134,7 @@ func (s *E2eSuite) TestClassicLogin() {
 	Expect(output).To(ContainSubstring("Cannot perform an interactive login from a non TTY device"))
 	Expect(err).NotTo(BeNil())
 	output, err = s.NewDockerCommand("logout", "someregistry.docker.io").Exec()
-	Expect(output).To(ContainSubstring("Removing login credentials for someregistry.docker.io"))
+	Expect(output).To(ContainSubstring("someregistry.docker.io"))
 	Expect(err).To(BeNil())
 }
 


### PR DESCRIPTION
**What I did**
Made the logout test less strict as the outputs when logging out from a registry that you're not logged into differ between macOS/Linux and Windows.

The login test currently only tests login command parsing so relaxing this should be OK.

**Related issue**
N/A

