### PR TITLE
Fix metrics test name, move to gotest.tools

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestFlag(t *testing.T) {


### PR DESCRIPTION
**What I did**
* Fixed test source file name
* Moved from stretchr to gotest.tools

**Related issue**
Related to #396 
