### PR TITLE
Enable ecs backend

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -34,7 +34,7 @@ func Command() *cobra.Command {
 		Short: "Docker Compose",
 		Use:   "compose",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return runCompose(cmd.Context())
+			return checkComposeSupport(cmd.Context())
 		},
 	}
 
@@ -46,7 +46,7 @@ func Command() *cobra.Command {
 	return command
 }
 
-func runCompose(ctx context.Context) error {
+func checkComposeSupport(ctx context.Context) error {
 	c, err := client.New(ctx)
 	if err == nil {
 		composeService := c.ComposeService()


### PR DESCRIPTION
We have a context check on the compose command that will return a formatted error depending on the context type in use. For example for the default context we wanted to return a "compose command is not implemented" error.
 We forgot to process the ECS type here so it defaults to that error too and stops us from using the ECS backend.

```
$ docker context use ecs
ecs
Current context is now "ecs"
```
**BEFORE**
```
$ docker compose up
compose command not supported on context type "ecs": not implemented
```
**AFTER**
```
$ docker compose up
TestTaskDefinition        ... PENDING 
TestServiceDiscoveryEntry ... PENDING 
TestTCP80TargetGroup      ... CREATE_COMPLETE 
TestTCP80Listener         ... PENDING 
TestService               ... PENDING 
DemoDefaultNetworkIngress ... CREATE_COMPLETE 
CloudMap                  ... CREATE_IN_PROGRESS Resource creation Initiated
TestTaskExecutionRole     ... CREATE_IN_PROGRESS Resource creation Initiated
DemoLoadBalancer          ... CREATE_IN_PROGRESS Resource creation Initiated
Cluster                   ... PENDING 
DemoDefaultNetwork        ... CREATE_COMPLETE 
LogGroup                  ... CREATE_COMPLETE 
demo 
```
