### PR TITLE
Sort parsed ports

### DIFF
--- a/cli/options/run/opts_test.go
+++ b/cli/options/run/opts_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 
@@ -121,7 +122,9 @@ func TestPortParse(t *testing.T) {
 		}
 		result, err := opts.toPorts()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, result, testCase.expected)
+		assert.DeepEqual(t, result, testCase.expected, cmpopts.SortSlices(func(x, y containers.Port) bool {
+			return x.ContainerPort < y.ContainerPort
+		}))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/gobwas/ws v1.0.3
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/protobuf v1.4.2
+	github.com/google/go-cmp v0.5.0
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/hashicorp/go-multierror v1.1.0


### PR DESCRIPTION
**What I did**

Sort test ports when we've parsed them. This fixes CI flakiness introduced with the move to gotest.tools

**Related issue**
CI failure: https://github.com/docker/api/runs/944892019?check_suite_focus=true#step:5:56
