### PR TITLE
Fix flaky nil pointer in signal forwarding to child process

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -69,6 +69,9 @@ func Exec() {
 		for {
 			select {
 			case sig := <-signals:
+				if cmd.Process == nil {
+					continue // can happen if receiving signal before the process is actually started
+				}
 				err := cmd.Process.Signal(sig)
 				if err != nil {
 					fmt.Printf("WARNING could not forward signal %s to %s : %s\n", sig.String(), ComDockerCli, err.Error())


### PR DESCRIPTION
**What I did**
check for nil cmd.Process before forwarding signal

**Related issue**
https://github.com/docker/api/runs/949400778

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://image.shutterstock.com/image-photo/autumn-leaf-texture-animal-leaves-600w-392723773.jpg)