### PR TITLE
ACR autologin

### DIFF
--- a/aci/login/login.go
+++ b/aci/login/login.go
@@ -266,6 +266,15 @@ func newAuthorizerFromLoginStorePath(storeTokenPath string) (autorest.Authorizer
 	return autorest.NewBearerAuthorizer(&token), nil
 }
 
+// GetTenantID returns tenantID for current login
+func (login AzureLoginService) GetTenantID() (string, error) {
+	loginInfo, err := login.tokenStore.readToken()
+	if err != nil {
+		return "", err
+	}
+	return loginInfo.TenantID, err
+}
+
 // GetValidToken returns an access token. Refresh token if needed
 func (login *AzureLoginService) GetValidToken() (oauth2.Token, error) {
 	loginInfo, err := login.tokenStore.readToken()


### PR DESCRIPTION
**What I did**
* when deploying images with ACR repository names (based on ACR suffix), use the azure login to login / renew ACR login 
* Only warn for autologin errors, as ACR registries might not be related to the user azure login, but they might have external credentials to use ACR images.

```
 $ ./bin/docker --context acitest run -d dockerregistrygta.azurecr.io/hello-aci
[+] Running 2/2
 ⠿ Group beautiful-kirch  Created     2.9s
 ⠿ beautiful-kirch        Done               10.7s
beautiful-kirch

Wrong registryname : 
 $ ./bin/docker --context acitest run -d xxxdockerregistrygta.azurecr.io/hello-aci
Could not automatically login to xxxdockerregistrygta.azurecr.io from your Azure login. Assuming you already logged in to the ACR registry
[+] Running 0/1
 ⠹ Group fervent-beaver  Waiting         2.1s
containerinstance.ContainerGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InaccessibleImage" Message="The image 'xxxdockerregistrygta.azurecr.io/hello-aci' in container group 'fervent-beaver' is not accessible. Please check the image and registry credential."
```


**Related issue**
https://github.com/docker/api/issues/250

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://i.insider.com/5be5b9cb8c35ab0df7236f10?width=1100&format=jpeg&auto=webp)