### PR TITLE
Fix e2e tests on Windows

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -259,8 +259,16 @@ func TestMissingExistingCLI(t *testing.T) {
 	err = CopyFile(filepath.Join(binDir, DockerExecutableName), filepath.Join(bin, DockerExecutableName))
 	assert.NilError(t, err)
 
+	env := []string{"PATH=" + bin}
+	if runtime.GOOS == "windows" {
+		env = append(env, "USERPROFILE="+home)
+
+	} else {
+		env = append(env, "HOME="+home)
+	}
+
 	c := icmd.Cmd{
-		Env:     []string{"HOME=" + home, "PATH=" + bin},
+		Env:     env,
 		Command: []string{filepath.Join(bin, "docker")},
 	}
 	res := icmd.RunCmd(c)


### PR DESCRIPTION
**What I did**
* Set `USERPROFILE` on Windows in test

Aim is to fix: https://github.com/docker/api/runs/966587470#step:7:63

