### PR TITLE
Check Windows specific host error in e2e tests

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -315,10 +315,14 @@ func TestLegacy(t *testing.T) {
 
 	t.Run("host flag", func(t *testing.T) {
 		t.Parallel()
+		stderr := "Cannot connect to the Docker daemon at tcp://localhost:123"
+		if runtime.GOOS == "windows" {
+			stderr = "error during connect: Get http://localhost:123"
+		}
 		res := c.RunDockerCmd("-H", "tcp://localhost:123", "version")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      "Cannot connect to the Docker daemon at tcp://localhost:123",
+			Err:      stderr,
 		})
 	})
 


### PR DESCRIPTION
**What I did**
Fix: https://github.com/docker/api/runs/966698505#step:7:166
