### PR TITLE
Fix the rm test without force

### DIFF
--- a/multierror/multierror.go
+++ b/multierror/multierror.go
@@ -95,7 +95,7 @@ func Append(err error, errs ...error) *Error {
 
 func listErrorFunc(errs []error) string {
 	if len(errs) == 1 {
-		return errs[0].Error()
+		return "Error: " + errs[0].Error()
 	}
 
 	messages := make([]string, len(errs))

--- a/multierror/multierror_test.go
+++ b/multierror/multierror_test.go
@@ -61,5 +61,5 @@ func TestErrorOrNil(t *testing.T) {
 
 	err = Append(err, errors.New("error"))
 	e := err.ErrorOrNil()
-	assert.Error(t, e, "error")
+	assert.Error(t, e, "Error: error")
 }

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -268,7 +268,7 @@ func TestContainerRun(t *testing.T) {
 	t.Run("rm a running container", func(t *testing.T) {
 		res := c.RunDockerCmd("rm", container)
 		res.Assert(t, icmd.Expected{
-			Err:      fmt.Sprintf("Error: You cannot remove a running container %s. Stop the container before attempting removal or force remove\n", container),
+			Err:      fmt.Sprintf("Error: you cannot remove a running container %s. Stop the container before attempting removal or force remove", container),
 			ExitCode: 1,
 		})
 	})


### PR DESCRIPTION
mutlierror didn't append an `Error:` if there is only one error...

@test-aci
