### PR TITLE
ACI Stop implementation

### DIFF
--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -1,0 +1,77 @@
+/*
+   Copyright 2020 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/api/errdefs"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/docker/api/client"
+)
+
+type stopOpts struct {
+	timeout uint32
+}
+
+// StopCommand deletes containers
+func StopCommand() *cobra.Command {
+	var opts stopOpts
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop one or more running containers",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStop(cmd.Context(), args, opts)
+		},
+	}
+
+	cmd.Flags().Uint32Var(&opts.timeout, "timeout", 0, "Seconds to wait for stop before killing it (default 0, no timeout)")
+
+	return cmd
+}
+
+func runStop(ctx context.Context, args []string, opts stopOpts) error {
+	c, err := client.New(ctx)
+	if err != nil {
+		return errors.Wrap(err, "cannot connect to backend")
+	}
+
+	var errs *multierror.Error
+	for _, id := range args {
+		err := c.ContainerService().Stop(ctx, id, &opts.timeout)
+		if err != nil {
+			if errdefs.IsNotFoundError(err) {
+				errs = multierror.Append(errs, fmt.Errorf("container %s not found", id))
+			} else {
+				errs = multierror.Append(errs, err)
+			}
+			continue
+		}
+		fmt.Println(id)
+	}
+	if errs != nil {
+		errs.ErrorFormat = formatErrors
+	}
+	return errs.ErrorOrNil()
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -124,6 +124,7 @@ func main() {
 		login.Command(),
 		logout.Command(),
 		cmd.VersionCommand(version),
+		cmd.StopCommand(),
 	)
 
 	helpFunc := root.HelpFunc()

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -360,8 +360,21 @@ func TestContainerRunAttached(t *testing.T) {
 		poll.WaitOn(t, checkLog, poll.WithDelay(1*time.Second), poll.WithTimeout(20*time.Second))
 	})
 
-	t.Run("rm attached", func(t *testing.T) {
-		res := c.RunDockerCmd("rm", "-f", container)
+	t.Run("stop wrong container", func(t *testing.T) {
+		res := c.RunDockerCmd("stop", "unknown-container")
+		res.Assert(t, icmd.Expected{
+			Err:      "Error: container unknown-container not found",
+			ExitCode: 1,
+		})
+	})
+
+	t.Run("stop container", func(t *testing.T) {
+		res := c.RunDockerCmd("stop", container)
+		res.Assert(t, icmd.Expected{Out: container})
+	})
+
+	t.Run("rm stopped container", func(t *testing.T) {
+		res := c.RunDockerCmd("rm", container)
 		res.Assert(t, icmd.Expected{Out: container})
 	})
 }


### PR DESCRIPTION
**What I did**
* Add stop command in the CLI
* Reuse existing Stop API (already implemented in `serve`
* Implement ACI backend for it

**Related issue**
https://github.com/docker/api/issues/441

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
@test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://lh3.googleusercontent.com/proxy/5s13IY1Mjq7nUQHTW2QQtx0Rb3w_VHHG2Uo1T1c9IRHSJFxAmxAU6ly420HH2vvM8vthf9ndWlSXr-79sMkn8Fg4JVksHpD5ZzHs8_lqeXCpO4NsrJgmkoTLexLpreptWDPlb03_6aoNTQ)