### PR TITLE
Change docker login azure redirect to docker ACI integration documentation

### DIFF
--- a/aci/login/local_server.go
+++ b/aci/login/local_server.go
@@ -44,12 +44,12 @@ const successHTML = `
 <html>
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="refresh" content="10;url=https://docs.microsoft.com/cli/azure/">
+	<meta http-equiv="refresh" content="10;url=https://docs.docker.com/engine/context/aci-integration/">
 	<title>Login successfully</title>
 </head>
 <body>
 	<h4>You have logged into Microsoft Azure!</h4>
-	<p>You can close this window, or we will redirect you to the <a href="https://docs.microsoft.com/cli/azure/">Azure CLI documents</a> in 10 seconds.</p>
+	<p>You can close this window, or we will redirect you to the <a href="https://docs.docker.com/engine/context/aci-integration/">Docker ACI integration documentation</a> in 10 seconds.</p>
 </body>
 </html>
 `


### PR DESCRIPTION
**What I did**

**Related issue**
https://github.com/docker/desktop-microsoft/issues/44

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQ0ZRFER4aTX1uaG28Ltkfcc2dE3Vk3WMhWfA&usqp=CAU)