### PR TITLE
Implement `docker ps —all` filter on ACI

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -373,6 +373,18 @@ func TestContainerRunAttached(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: container})
 	})
 
+	t.Run("ps stopped container with --all", func(t *testing.T) {
+		res := c.RunDockerCmd("ps", container)
+		res.Assert(t, icmd.Success)
+		out := strings.Split(strings.TrimSpace(res.Stdout()), "\n")
+		assert.Assert(t, is.Len(out, 1))
+
+		res = c.RunDockerCmd("ps", "--all", container)
+		res.Assert(t, icmd.Success)
+		out = strings.Split(strings.TrimSpace(res.Stdout()), "\n")
+		assert.Assert(t, is.Len(out, 2))
+	})
+
 	t.Run("rm stopped container", func(t *testing.T) {
 		res := c.RunDockerCmd("rm", container)
 		res.Assert(t, icmd.Expected{Out: container})


### PR DESCRIPTION
**What I did**
* Use bool flag that was ignored in ACI implmentation
* add ps & ps --all check in e2e tests where we already had a stopped container

**Related issue**
https://github.com/docker/api/issues/467

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

@test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://c4.wallpaperflare.com/wallpaper/818/135/591/cute-animal-family-wallpaper-preview.jpg)