### PR TITLE
Do not display warning if cannot forward signal to child. 

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -72,10 +72,8 @@ func Exec() {
 				if cmd.Process == nil {
 					continue // can happen if receiving signal before the process is actually started
 				}
-				err := cmd.Process.Signal(sig)
-				if err != nil {
-					fmt.Printf("WARNING could not forward signal %s to %s : %s\n", sig.String(), ComDockerCli, err.Error())
-				}
+				// nolint errcheck
+				cmd.Process.Signal(sig)
 			case <-childExit:
 				return
 			}


### PR DESCRIPTION
See https://github.com/docker/pinata/pull/14327

**What I did**
ignore error when forwarding signal to child

**Related issue**
Desktop integration https://github.com/docker/pinata/pull/14327

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
