### PR TITLE
Redirect user from plugin usage to integrated ECS

### DIFF
--- a/cli/cmd/ecs.go
+++ b/cli/cmd/ecs.go
@@ -1,0 +1,35 @@
+/*
+   Copyright 2020 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+// EcsCommand is a placeholder to drive early users to the integrated form of ecs support instead of its early plugin form
+func EcsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "ecs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("The ECS integration is now part of the CLI. Use `docker compose` with an ECS context.") // nolint
+		},
+	}
+
+	return cmd
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -127,6 +127,9 @@ func main() {
 		cmd.VersionCommand(version),
 		cmd.StopCommand(),
 		cmd.SecretCommand(),
+
+		// Place holders
+		cmd.EcsCommand(),
 	)
 
 	helpFunc := root.HelpFunc()

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -428,3 +428,18 @@ func TestMockBackend(t *testing.T) {
 		})
 	})
 }
+
+func TestFailOnEcsUsageAsPlugin(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+	res := c.RunDockerCmd("context", "create", "local", "local")
+	res.Assert(t, icmd.Expected{})
+
+	t.Run("fail on ecs usage as plugin", func(t *testing.T) {
+		res := c.RunDockerOrExitError("--context", "local", "ecs", "compose", "up")
+		res.Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Out:      "",
+			Err:      "The ECS integration is now part of the CLI. Use `docker compose` with an ECS context.",
+		})
+	})
+}


### PR DESCRIPTION
**What I did**
When trying to use ECS as a plugin, fail with a message driving the user to the correct usage.

Please note that this takes anything that starts with `docker ecs` not only `docker ecs compose`

**Related issue**
Resolves: https://github.com/docker/api/issues/472


Not sure where to put the e2e test though...
@gtardif @rumpl 