### PR TITLE
Slightly update timeout, failing on windows nodes

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -675,5 +675,5 @@ func waitForStatus(t *testing.T, c *E2eCLI, containerID string, status string) {
 		return poll.Continue("Status %s != %s (expected) for container %s", containerInspect.Status, status, containerID)
 	}
 
-	poll.WaitOn(t, checkStopped, poll.WithDelay(5*time.Second), poll.WithTimeout(60*time.Second))
+	poll.WaitOn(t, checkStopped, poll.WithDelay(5*time.Second), poll.WithTimeout(90*time.Second))
 }


### PR DESCRIPTION
 (https://github.com/docker/api/runs/984443961). Didn’t want to make it too long either, avoid waiting 2 mins to see when it’s failing. We’ll update this again if we see it’s not enough.

**What I did**
* aci container status wait changed from 60 to 90 secs

**Related issue**
https://github.com/docker/api/runs/984443961

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
@test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://i.pinimg.com/originals/cb/66/a6/cb66a66f8c562c5a792ef372ae837734.jpg)