### PR TITLE
Ask to recreate context when running on an `aws` type

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -82,6 +82,10 @@ func checkComposeSupport(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if cc.Type() == store.AwsContextType {
+			return errors.Errorf(`%q context type has been renamed. Recreate the context by running: 
+$ docker context create %s <name>`, cc.Type(), store.EcsContextType)
+		}
 		return errors.Wrapf(errdefs.ErrNotImplemented, "compose command not supported on context type %q", cc.Type())
 	}
 	return err


### PR DESCRIPTION
When running a compose command on an 'aws' context, return an error asking user to recreate the context as the `aws` type has changed to `ecs`.
```
$ docker context use aws
aws
Current context is now "aws"

$ docker compose up
"aws" context type has been renamed. Recreate the context by running: 
    $ docker context create ecs <name>
```
Relates to https://github.com/docker/compose-cli/issues/392