### PR TITLE
Check that AZURE creds are defined when running E2E tests

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -590,6 +590,9 @@ func azureLogin(t *testing.T, c *E2eCLI) {
 	clientID := os.Getenv("AZURE_CLIENT_ID")
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 	tenantID := os.Getenv("AZURE_TENANT_ID")
+	assert.Check(t, clientID != "", "AZURE_CLIENT_ID must not be empty")
+	assert.Check(t, clientSecret != "", "AZURE_CLIENT_SECRET must not be empty")
+	assert.Check(t, tenantID != "", "AZURE_TENANT_ID must not be empty")
 	res := c.RunDockerCmd("login", "azure", "--client-id", clientID, "--client-secret", clientSecret, "--tenant-id", tenantID)
 	res.Assert(t, icmd.Success)
 }


### PR DESCRIPTION
**What I did**
* Add checks that AZURE credential env vars are not empty

**Related issue**
if empty, azure login switches to interactive login, and test timeout without a clear error message

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
@test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://atchuup.com/wp-content/uploads/2015/11/hybrid-animals-3.jpg)