### PR TITLE
Acr : do not require refresh token, and work fine with Service Principal Login

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -550,24 +550,6 @@ func TestRunEnvVars(t *testing.T) {
 	})
 }
 
-func TestDeployACRImage(t *testing.T) {
-	c := NewParallelE2eCLI(t, binDir)
-	_, _ = setupTestResourceGroup(t, c, "runAcr")
-
-	t.Run("run", func(t *testing.T) {
-		cmd := c.NewDockerCmd("run", "-d", "dockerregistrygta.azurecr.io/hello-aci")
-		res := icmd.RunCmd(cmd)
-		res.Assert(t, icmd.Success)
-		out := strings.Split(strings.TrimSpace(res.Stdout()), "\n")
-		container := strings.TrimSpace(out[len(out)-1])
-		t.Logf("Container name: %q", container)
-		waitForStatus(t, c, container, "Terminated")
-
-		res = c.RunDockerCmd("logs", container)
-		assert.Assert(t, strings.Contains(res.Stdout(), "Hello from Docker!"))
-	})
-}
-
 func setupTestResourceGroup(t *testing.T, c *E2eCLI, tName string) (string, string) {
 	startTime := strconv.Itoa(int(time.Now().Unix()))
 	rg := "E2E-" + tName + "-" + startTime


### PR DESCRIPTION
**What I did**
* change ACR auto-login parameters to not require a refresh token, only and access token. This make it work with SP Login that does not provide a refresh token
* Now we can add an E2E test, trying with an existing ACR repo & image

**Related issue**
https://github.com/docker/desktop-microsoft/issues/9

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-windows` to run tests & E2E tests on windows
-->


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://c1.wallpaperflare.com/preview/279/242/373/digiart-camel-chameleon-kameleon.jpg)