### PR TITLE
Trigger tests manually with “/“ instead of “@“

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 <!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
 
 <!-- optional tests
-You can add a @ mention to run tests executed by default only on main branch : 
+You can add a / mention to run tests executed by default only on main branch : 
 * `test-aci` to run ACI E2E tests
 * `test-ecs` to run ECS E2E tests
 * `test-windows` to run tests & E2E tests on windows

--- a/.github/workflows/optional-ci.yml
+++ b/.github/workflows/optional-ci.yml
@@ -20,19 +20,19 @@ jobs:
         if: github.event_name == 'pull_request'
         id: runacitest
         with:
-          trigger: '@test-aci'
+          trigger: '/test-aci'
       - uses: khan/pull-request-comment-trigger@master
         name: Check if test Windows
         if: github.event_name == 'pull_request'
         id: runwindowstest
         with:
-          trigger: '@test-windows'
+          trigger: '/test-windows'
       - uses: khan/pull-request-comment-trigger@master
         name: Check if test ECS
         if: github.event_name == 'pull_request'
         id: runecstest
         with:
-          trigger: '@test-ecs'
+          trigger: '/test-ecs'
 
   aci-tests:
     name: ACI e2e tests


### PR DESCRIPTION
**What I did**
change test triggers to /test-aci, etc.

**Related issue**
https://github.com/docker/compose-cli/issues/521

<!-- optional tests
You can add a @ mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://usu.instructure.com/courses/494506/files/70362239/preview?verifier=hC1RTdfuLscErkpeSDnRV7BabtNzArVTKjYG20HA)