### PR TITLE
CI update dependabot PR - Check that the pusher startWith depandabot-…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       # https://github.com/dependabot/dependabot-core/issues/1995
       - name: Update dependabot PR
-        if: github.event.pusher.name == 'dependabot-preview'
+        if: startWith(github.event.pusher.name,'dependabot-preview')
         run: |
           git config --local user.email "compose-cli-ci@docker.com"
           git config --local user.name "CI GitHub Action"
@@ -29,7 +29,7 @@ jobs:
           git commit -sm'Update go.sum after dependabot PR'
 
       - name: Update dependabot PR if needed
-        if: github.event.pusher.name == 'dependabot-preview'
+        if: startWith(github.event.pusher.name,'dependabot-preview')
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…preview

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Change the condition to trigger dependabot PR update step (name seems to be `dependabot-preview[bot]`) 


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/90771681-f1ce9780-e2f3-11ea-806a-d8ce48d5d9ed.png)

