### PR TITLE
Revisit compose API so it uses compose-go Project as parameter

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -386,11 +385,7 @@ type aciComposeService struct {
 	ctx store.AciContext
 }
 
-func (cs *aciComposeService) Up(ctx context.Context, opts *cli.ProjectOptions) error {
-	project, err := cli.ProjectFromOptions(opts)
-	if err != nil {
-		return err
-	}
+func (cs *aciComposeService) Up(ctx context.Context, project *types.Project) error {
 	logrus.Debugf("Up on project with name %q\n", project.Name)
 	groupDefinition, err := convert.ToContainerGroup(ctx, cs.ctx, *project)
 	addTag(&groupDefinition, composeContainerTag)
@@ -401,21 +396,10 @@ func (cs *aciComposeService) Up(ctx context.Context, opts *cli.ProjectOptions) e
 	return createOrUpdateACIContainers(ctx, cs.ctx, groupDefinition)
 }
 
-func (cs *aciComposeService) Down(ctx context.Context, opts *cli.ProjectOptions) error {
-	var project types.Project
+func (cs *aciComposeService) Down(ctx context.Context, project string) error {
+	logrus.Debugf("Down on project with name %q\n", project)
 
-	if opts.Name != "" {
-		project = types.Project{Name: opts.Name}
-	} else {
-		fullProject, err := cli.ProjectFromOptions(opts)
-		if err != nil {
-			return err
-		}
-		project = *fullProject
-	}
-	logrus.Debugf("Down on project with name %q\n", project.Name)
-
-	cg, err := deleteACIContainerGroup(ctx, cs.ctx, project.Name)
+	cg, err := deleteACIContainerGroup(ctx, cs.ctx, project)
 	if err != nil {
 		return err
 	}
@@ -426,15 +410,15 @@ func (cs *aciComposeService) Down(ctx context.Context, opts *cli.ProjectOptions)
 	return err
 }
 
-func (cs *aciComposeService) Ps(ctx context.Context, opts *cli.ProjectOptions) ([]compose.ServiceStatus, error) {
+func (cs *aciComposeService) Ps(ctx context.Context, project string) ([]compose.ServiceStatus, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Logs(ctx context.Context, opts *cli.ProjectOptions, w io.Writer) error {
+func (cs *aciComposeService) Logs(ctx context.Context, project string, w io.Writer) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Convert(ctx context.Context, opts *cli.ProjectOptions) ([]byte, error) {
+func (cs *aciComposeService) Convert(ctx context.Context, project *types.Project) ([]byte, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -34,6 +34,23 @@ type composeOptions struct {
 	Environment []string
 }
 
+func (o *composeOptions) toProjectName() (string, error) {
+	if o.Name != "" {
+		return o.Name, nil
+	}
+
+	options, err := o.toProjectOptions()
+	if err != nil {
+		return "", err
+	}
+
+	project, err := cli.ProjectFromOptions(options)
+	if err != nil {
+		return "", err
+	}
+	return project.Name, nil
+}
+
 func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 	return cli.NewProjectOptions(o.ConfigPaths,
 		cli.WithOsEnv,

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -47,10 +47,10 @@ func runDown(ctx context.Context, opts composeOptions) error {
 	}
 
 	return progress.Run(ctx, func(ctx context.Context) error {
-		options, err := opts.toProjectOptions()
+		projectName, err := opts.toProjectName()
 		if err != nil {
 			return err
 		}
-		return c.ComposeService().Down(ctx, options)
+		return c.ComposeService().Down(ctx, projectName)
 	})
 }

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -46,9 +46,9 @@ func runLogs(ctx context.Context, opts composeOptions) error {
 		return err
 	}
 
-	options, err := opts.toProjectOptions()
+	projectName, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
-	return c.ComposeService().Logs(ctx, options, os.Stdout)
+	return c.ComposeService().Logs(ctx, projectName, os.Stdout)
 }

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -50,14 +50,15 @@ func runPs(ctx context.Context, opts composeOptions) error {
 		return err
 	}
 
-	options, err := opts.toProjectOptions()
+	projectName, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
-	serviceList, err := c.ComposeService().Ps(ctx, options)
+	serviceList, err := c.ComposeService().Ps(ctx, projectName)
 	if err != nil {
 		return err
 	}
+
 	err = printSection(os.Stdout, func(w io.Writer) {
 		for _, service := range serviceList {
 			fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\n", service.ID, service.Name, service.Replicas, service.Desired, strings.Join(service.Ports, ", "))

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -19,6 +19,8 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/cli"
+
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/client"
@@ -53,6 +55,11 @@ func runUp(ctx context.Context, opts composeOptions) error {
 		if err != nil {
 			return err
 		}
-		return c.ComposeService().Up(ctx, options)
+		project, err := cli.ProjectFromOptions(options)
+		if err != nil {
+			return err
+		}
+
+		return c.ComposeService().Up(ctx, project)
 	})
 }

--- a/client/compose.go
+++ b/client/compose.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/compose-spec/compose-go/cli"
+	"github.com/compose-spec/compose-go/types"
 
 	"github.com/docker/compose-cli/compose"
 	"github.com/docker/compose-cli/errdefs"
@@ -30,26 +30,26 @@ type composeService struct {
 }
 
 // Up executes the equivalent to a `compose up`
-func (c *composeService) Up(context.Context, *cli.ProjectOptions) error {
+func (c *composeService) Up(context.Context, *types.Project) error {
 	return errdefs.ErrNotImplemented
 }
 
 // Down executes the equivalent to a `compose down`
-func (c *composeService) Down(context.Context, *cli.ProjectOptions) error {
+func (c *composeService) Down(context.Context, string) error {
 	return errdefs.ErrNotImplemented
 }
 
 // Logs executes the equivalent to a `compose logs`
-func (c *composeService) Logs(context.Context, *cli.ProjectOptions, io.Writer) error {
+func (c *composeService) Logs(context.Context, string, io.Writer) error {
 	return errdefs.ErrNotImplemented
 }
 
 // Ps executes the equivalent to a `compose ps`
-func (c *composeService) Ps(context.Context, *cli.ProjectOptions) ([]compose.ServiceStatus, error) {
+func (c *composeService) Ps(context.Context, string) ([]compose.ServiceStatus, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 
 // Convert translate compose model into backend's native format
-func (c *composeService) Convert(context.Context, *cli.ProjectOptions) ([]byte, error) {
+func (c *composeService) Convert(context.Context, *types.Project) ([]byte, error) {
 	return nil, errdefs.ErrNotImplemented
 }

--- a/compose/api.go
+++ b/compose/api.go
@@ -20,21 +20,21 @@ import (
 	"context"
 	"io"
 
-	"github.com/compose-spec/compose-go/cli"
+	"github.com/compose-spec/compose-go/types"
 )
 
 // Service manages a compose project
 type Service interface {
 	// Up executes the equivalent to a `compose up`
-	Up(ctx context.Context, opts *cli.ProjectOptions) error
+	Up(ctx context.Context, project *types.Project) error
 	// Down executes the equivalent to a `compose down`
-	Down(ctx context.Context, opts *cli.ProjectOptions) error
+	Down(ctx context.Context, projectName string) error
 	// Logs executes the equivalent to a `compose logs`
-	Logs(ctx context.Context, opts *cli.ProjectOptions, w io.Writer) error
+	Logs(ctx context.Context, projectName string, w io.Writer) error
 	// Ps executes the equivalent to a `compose ps`
-	Ps(ctx context.Context, opts *cli.ProjectOptions) ([]ServiceStatus, error)
+	Ps(ctx context.Context, projectName string) ([]ServiceStatus, error)
 	// Convert translate compose model into backend's native format
-	Convert(ctx context.Context, opts *cli.ProjectOptions) ([]byte, error)
+	Convert(ctx context.Context, project *types.Project) ([]byte, error)
 }
 
 // PortPublisher hold status about published port

--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -23,8 +23,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/compose-spec/compose-go/cli"
-
 	"github.com/docker/compose-cli/compose"
 
 	ecsapi "github.com/aws/aws-sdk-go/service/ecs"
@@ -53,11 +51,7 @@ const (
 	parameterLoadBalancerARN = "ParameterLoadBalancerARN"
 )
 
-func (b *ecsAPIService) Convert(ctx context.Context, opts *cli.ProjectOptions) ([]byte, error) {
-	project, err := cli.ProjectFromOptions(opts)
-	if err != nil {
-		return nil, err
-	}
+func (b *ecsAPIService) Convert(ctx context.Context, project *types.Project) ([]byte, error) {
 	template, err := b.convert(project)
 	if err != nil {
 		return nil, err

--- a/ecs/down.go
+++ b/ecs/down.go
@@ -18,31 +18,12 @@ package ecs
 
 import (
 	"context"
-
-	"github.com/compose-spec/compose-go/cli"
 )
 
-func (b *ecsAPIService) Down(ctx context.Context, options *cli.ProjectOptions) error {
-	name, err := b.projectName(options)
+func (b *ecsAPIService) Down(ctx context.Context, project string) error {
+	err := b.SDK.DeleteStack(ctx, project)
 	if err != nil {
 		return err
 	}
-
-	err = b.SDK.DeleteStack(ctx, name)
-	if err != nil {
-		return err
-	}
-	return b.WaitStackCompletion(ctx, name, stackDelete)
-}
-
-func (b *ecsAPIService) projectName(options *cli.ProjectOptions) (string, error) {
-	name := options.Name
-	if name == "" {
-		project, err := cli.ProjectFromOptions(options)
-		if err != nil {
-			return "", err
-		}
-		name = project.Name
-	}
-	return name, nil
+	return b.WaitStackCompletion(ctx, project, stackDelete)
 }

--- a/ecs/list.go
+++ b/ecs/list.go
@@ -22,22 +22,16 @@ import (
 	"strings"
 
 	"github.com/docker/compose-cli/compose"
-
-	"github.com/compose-spec/compose-go/cli"
 )
 
-func (b *ecsAPIService) Ps(ctx context.Context, options *cli.ProjectOptions) ([]compose.ServiceStatus, error) {
-	projectName, err := b.projectName(options)
-	if err != nil {
-		return nil, err
-	}
-	parameters, err := b.SDK.ListStackParameters(ctx, projectName)
+func (b *ecsAPIService) Ps(ctx context.Context, project string) ([]compose.ServiceStatus, error) {
+	parameters, err := b.SDK.ListStackParameters(ctx, project)
 	if err != nil {
 		return nil, err
 	}
 	cluster := parameters[parameterClusterName]
 
-	resources, err := b.SDK.ListStackResources(ctx, projectName)
+	resources, err := b.SDK.ListStackResources(ctx, project)
 	if err != nil {
 		return nil, err
 	}

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -23,26 +23,15 @@ import (
 	"io"
 	"strconv"
 	"strings"
-
-	"github.com/compose-spec/compose-go/cli"
 )
 
-func (b *ecsAPIService) Logs(ctx context.Context, options *cli.ProjectOptions, writer io.Writer) error {
-	name := options.Name
-	if name == "" {
-		project, err := cli.ProjectFromOptions(options)
-		if err != nil {
-			return err
-		}
-		name = project.Name
-	}
-
+func (b *ecsAPIService) Logs(ctx context.Context, project string, w io.Writer) error {
 	consumer := logConsumer{
 		colors: map[string]colorFunc{},
 		width:  0,
-		writer: writer,
+		writer: w,
 	}
-	err := b.SDK.GetLogs(ctx, name, consumer.Log)
+	err := b.SDK.GetLogs(ctx, project, consumer.Log)
 	return err
 }
 

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -23,17 +23,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 )
 
-func (b *ecsAPIService) Up(ctx context.Context, options *cli.ProjectOptions) error {
-	project, err := cli.ProjectFromOptions(options)
-	if err != nil {
-		return err
-	}
-
-	err = b.SDK.CheckRequirements(ctx, b.Region)
+func (b *ecsAPIService) Up(ctx context.Context, project *types.Project) error {
+	err := b.SDK.CheckRequirements(ctx, b.Region)
 	if err != nil {
 		return err
 	}
@@ -101,7 +95,7 @@ func (b *ecsAPIService) Up(ctx context.Context, options *cli.ProjectOptions) err
 	go func() {
 		<-signalChan
 		fmt.Println("user interrupted deployment. Deleting stack...")
-		b.Down(ctx, options) // nolint:errcheck
+		b.Down(ctx, project.Name) // nolint:errcheck
 	}()
 
 	err = b.WaitStackCompletion(ctx, project.Name, operation)

--- a/example/backend.go
+++ b/example/backend.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/compose-spec/compose-go/cli"
+	"github.com/compose-spec/compose-go/types"
 
 	"github.com/docker/compose-cli/backend"
 	"github.com/docker/compose-cli/compose"
@@ -122,32 +122,24 @@ func (cs *containerService) Delete(ctx context.Context, id string, request conta
 
 type composeService struct{}
 
-func (cs *composeService) Up(ctx context.Context, opts *cli.ProjectOptions) error {
-	prj, err := cli.ProjectFromOptions(opts)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Up command on project %q", prj.Name)
+func (cs *composeService) Up(ctx context.Context, project *types.Project) error {
+	fmt.Printf("Up command on project %q", project.Name)
 	return nil
 }
 
-func (cs *composeService) Down(ctx context.Context, opts *cli.ProjectOptions) error {
-	prj, err := cli.ProjectFromOptions(opts)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Down command on project %q", prj.Name)
+func (cs *composeService) Down(ctx context.Context, project string) error {
+	fmt.Printf("Down command on project %q", project)
 	return nil
 }
 
-func (cs *composeService) Ps(ctx context.Context, opts *cli.ProjectOptions) ([]compose.ServiceStatus, error) {
+func (cs *composeService) Ps(ctx context.Context, project string) ([]compose.ServiceStatus, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 
-func (cs *composeService) Logs(ctx context.Context, opts *cli.ProjectOptions, w io.Writer) error {
+func (cs *composeService) Logs(ctx context.Context, project string, w io.Writer) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *composeService) Convert(ctx context.Context, opts *cli.ProjectOptions) ([]byte, error) {
+func (cs *composeService) Convert(ctx context.Context, project *types.Project) ([]byte, error) {
 	return nil, errdefs.ErrNotImplemented
 }


### PR DESCRIPTION
**What I did**
Revisited the compose.api so it uses compose-go `types.Project` as parameter and the parsing from file is kept as a CLI command thing

**Related issue**
none. Just a proposal, to be debated

/test-aci
/test-ecs
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
