### PR TITLE
E2e improvements

### DIFF
--- a/local/e2e/backend_test.go
+++ b/local/e2e/backend_test.go
@@ -43,33 +43,33 @@ func TestMain(m *testing.M) {
 
 func TestLocalBackend(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
-	c.RunDocker("context", "create", "local", "test-context").Assert(t, icmd.Success)
-	c.RunDocker("context", "use", "test-context").Assert(t, icmd.Success)
+	c.RunDockerCmd("context", "create", "local", "test-context").Assert(t, icmd.Success)
+	c.RunDockerCmd("context", "use", "test-context").Assert(t, icmd.Success)
 
 	t.Run("run", func(t *testing.T) {
-		res := c.RunDocker("run", "-d", "nginx")
+		res := c.RunDockerCmd("run", "-d", "nginx")
 		containerName := strings.TrimSpace(res.Combined())
 		t.Cleanup(func() {
-			_ = c.RunDockerOrFail("rm", "-f", containerName)
+			_ = c.RunDockerOrExitError("rm", "-f", containerName)
 		})
-		res = c.RunDocker("inspect", containerName)
+		res = c.RunDockerCmd("inspect", containerName)
 		res.Assert(t, icmd.Expected{Out: `"Status": "running"`})
 	})
 
 	t.Run("run with ports", func(t *testing.T) {
-		res := c.RunDocker("run", "-d", "-p", "8080:80", "nginx")
+		res := c.RunDockerCmd("run", "-d", "-p", "8080:80", "nginx")
 		containerName := strings.TrimSpace(res.Combined())
 		t.Cleanup(func() {
-			_ = c.RunDockerOrFail("rm", "-f", containerName)
+			_ = c.RunDockerOrExitError("rm", "-f", containerName)
 		})
-		res = c.RunDocker("inspect", containerName)
+		res = c.RunDockerCmd("inspect", containerName)
 		res.Assert(t, icmd.Expected{Out: `"Status": "running"`})
-		res = c.RunDocker("ps")
+		res = c.RunDockerCmd("ps")
 		res.Assert(t, icmd.Expected{Out: "0.0.0.0:8080->80/tcp"})
 	})
 
 	t.Run("inspect not found", func(t *testing.T) {
-		res := c.RunDockerOrFail("inspect", "nonexistentcontainer")
+		res := c.RunDockerOrExitError("inspect", "nonexistentcontainer")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "Error: No such container: nonexistentcontainer",

--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -54,25 +54,25 @@ func TestSecrets(t *testing.T) {
 	description := "description " + testID
 
 	t.Run("create secret", func(t *testing.T) {
-		res := cmd.RunDocker("secret", "create", secretName, "-u", "user1", "-p", "pass1", "-d", description)
+		res := cmd.RunDockerCmd("secret", "create", secretName, "-u", "user1", "-p", "pass1", "-d", description)
 		assert.Check(t, strings.Contains(res.Stdout(), "secret:"+secretName))
 	})
 
 	t.Run("list secrets", func(t *testing.T) {
-		res := cmd.RunDocker("secret", "list")
+		res := cmd.RunDockerCmd("secret", "list")
 		assert.Check(t, strings.Contains(res.Stdout(), secretName))
 		assert.Check(t, strings.Contains(res.Stdout(), description))
 	})
 
 	t.Run("inspect secret", func(t *testing.T) {
-		res := cmd.RunDocker("secret", "inspect", secretName)
+		res := cmd.RunDockerCmd("secret", "inspect", secretName)
 		assert.Check(t, strings.Contains(res.Stdout(), `"Name": "`+secretName+`"`))
 		assert.Check(t, strings.Contains(res.Stdout(), `"Description": "`+description+`"`))
 	})
 
 	t.Run("rm secret", func(t *testing.T) {
-		cmd.RunDocker("secret", "rm", secretName)
-		res := cmd.RunDocker("secret", "list")
+		cmd.RunDockerCmd("secret", "rm", secretName)
+		res := cmd.RunDockerCmd("secret", "list")
 		assert.Check(t, !strings.Contains(res.Stdout(), secretName))
 	})
 }
@@ -81,12 +81,12 @@ func TestCompose(t *testing.T) {
 	c, stack := setupTest(t)
 
 	t.Run("compose up", func(t *testing.T) {
-		c.RunDocker("compose", "up", "--project-name", stack, "-f", "../composefiles/nginx.yaml")
+		c.RunDockerCmd("compose", "up", "--project-name", stack, "-f", "../composefiles/nginx.yaml")
 	})
 
 	var url string
 	t.Run("compose ps", func(t *testing.T) {
-		res := c.RunDocker("compose", "ps", "--project-name", stack)
+		res := c.RunDockerCmd("compose", "ps", "--project-name", stack)
 		lines := strings.Split(res.Stdout(), "\n")
 
 		assert.Equal(t, 3, len(lines))
@@ -117,7 +117,7 @@ func TestCompose(t *testing.T) {
 	})
 
 	t.Run("compose down", func(t *testing.T) {
-		c.RunDocker("compose", "down", "--project-name", stack, "-f", "../composefiles/nginx.yaml")
+		c.RunDockerCmd("compose", "down", "--project-name", stack, "-f", "../composefiles/nginx.yaml")
 	})
 }
 
@@ -132,7 +132,7 @@ func setupTest(t *testing.T) (*E2eCLI, string) {
 		if localTestProfile != "" {
 			region := os.Getenv("TEST_AWS_REGION")
 			assert.Check(t, region != "")
-			c.RunDocker("context", "create", "ecs", contextName, "--profile", localTestProfile, "--region", region)
+			c.RunDockerCmd("context", "create", "ecs", contextName, "--profile", localTestProfile, "--region", region)
 		} else {
 			profile := contextName
 			region := os.Getenv("AWS_DEFAULT_REGION")
@@ -141,11 +141,11 @@ func setupTest(t *testing.T) (*E2eCLI, string) {
 			assert.Check(t, keyID != "")
 			assert.Check(t, secretKey != "")
 			assert.Check(t, region != "")
-			c.RunDocker("context", "create", "ecs", contextName, "--profile", profile, "--region", region, "--secret-key", secretKey, "--key-id", keyID)
+			c.RunDockerCmd("context", "create", "ecs", contextName, "--profile", profile, "--region", region, "--secret-key", secretKey, "--key-id", keyID)
 		}
-		res = c.RunDocker("context", "use", contextName)
+		res = c.RunDockerCmd("context", "use", contextName)
 		res.Assert(t, icmd.Expected{Out: contextName})
-		res = c.RunDocker("context", "ls")
+		res = c.RunDockerCmd("context", "ls")
 		res.Assert(t, icmd.Expected{Out: contextName + " *"})
 	})
 	return c, stack

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -161,15 +161,15 @@ func (c *E2eCLI) NewDockerCmd(args ...string) icmd.Cmd {
 	return c.NewCmd(filepath.Join(c.BinDir, DockerExecutableName), args...)
 }
 
-// RunDockerOrFail runs a docker command and returns a result
-func (c *E2eCLI) RunDockerOrFail(args ...string) *icmd.Result {
+// RunDockerOrExitError runs a docker command and returns a result
+func (c *E2eCLI) RunDockerOrExitError(args ...string) *icmd.Result {
 	fmt.Printf("	[%s] docker %s\n", c.test.Name(), strings.Join(args, " "))
 	return icmd.RunCmd(c.NewDockerCmd(args...))
 }
 
-// RunDocker runs a docker command, expects no error and returns a result
-func (c *E2eCLI) RunDocker(args ...string) *icmd.Result {
-	res := c.RunDockerOrFail(args...)
+// RunDockerCmd runs a docker command, expects no error and returns a result
+func (c *E2eCLI) RunDockerCmd(args ...string) *icmd.Result {
+	res := c.RunDockerOrExitError(args...)
 	res.Assert(c.test, icmd.Success)
 	return res
 }


### PR DESCRIPTION
**What I did**
* assume docker commands succeed by default, this removes quite a bunch of `res.assert(success)`
* remove unnecessary calls to t.parallel
* Display executed docker commands (prefixed with test name for readbility with // tests)
* removed magic strings in aci e2e used to differentiate tests, replaced by test name

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://zenitube.com/img/posts/2016/0003animal-photoshop/15-spiderowl.jpg)