### PR TITLE
Remove version in test compose files

### DIFF
--- a/ecs/testdata/input/simple-single-service.yaml
+++ b/ecs/testdata/input/simple-single-service.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   simple:
     image: nginx

--- a/ecs/testdata/invalid_network_mode.yaml
+++ b/ecs/testdata/invalid_network_mode.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   simple:
     image: nginx

--- a/tests/composefiles/aci-demo/aci_demo_multi_port.yaml
+++ b/tests/composefiles/aci-demo/aci_demo_multi_port.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   db:
     build: db

--- a/tests/composefiles/aci-demo/aci_demo_port.yaml
+++ b/tests/composefiles/aci-demo/aci_demo_port.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   db:
     build: db

--- a/tests/composefiles/aci-demo/aci_demo_port_secrets.yaml
+++ b/tests/composefiles/aci-demo/aci_demo_port_secrets.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   db:
     build: db

--- a/tests/composefiles/aci-demo/aci_demo_port_secrets_volumes.yaml
+++ b/tests/composefiles/aci-demo/aci_demo_port_secrets_volumes.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   db:
     build: db

--- a/tests/composefiles/nginx.yaml
+++ b/tests/composefiles/nginx.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   nginx:
     image: nginx


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Remove all the version in the test compose files

**Related issue**
fixes docker/ecs-plugin#172

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-ecs
/test-windows


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/91021325-eb8e3300-e5f3-11ea-8cd3-c89c0f739fab.png)

