### PR TITLE
Fix last references to /docker/api

### DIFF
--- a/ecs/secrets/Dockerfile
+++ b/ecs/secrets/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 
 FROM golang:1.14.4-alpine AS builder
-WORKDIR $GOPATH/src/github.com/docker/api/ecs/secrets
+WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/secrets
 COPY . .
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/secrets main/main.go
 


### PR DESCRIPTION
**What I did**
replaced to /docker/compose-cli in Dockerfile

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/7b/55/19/7b551936284d952482027414e65cfd0d.jpg)