### PR TITLE
Remove dependabot and add a check-dependencies command in make file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "go:modules"
-    directory: "/"
-    update_schedule: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,24 +18,6 @@ jobs:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
 
-      # https://github.com/dependabot/dependabot-core/issues/1995
-      - name: Update dependabot PR
-        if: github.event.pusher.name == 'dependabot-preview[bot]'
-        run: |
-          git config --local user.email "compose-cli-ci@docker.com"
-          git config --local user.name "CI GitHub Action"
-          go mod tidy -v
-          git add .
-          git commit -sm'Update go.sum after dependabot PR'
-
-      - name: Update dependabot PR if needed
-        if: github.event.pusher.name == 'dependabot-preview[bot]'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-          force: false
-
       - name: Validate go-mod is up-to-date and license headers
         run: make validate
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ lint: ## run linter(s)
 	--build-arg GIT_TAG=$(GIT_TAG) \
 	--target lint
 
+check-dependencies: ## check dependency updates
+	go list -u -m -f '{{if not .Indirect}}{{if .Update}}{{.}}{{end}}{{end}}' all
+
 import-restrictions: ## run import-restrictions script
 	@docker build . \
 	--target import-restrictions
@@ -99,4 +102,4 @@ help: ## Show help
 
 FORCE:
 
-.PHONY: all validate protos cli e2e-local cross test cache-clear lint serve classic-link help
+.PHONY: all validate protos cli e2e-local cross test cache-clear lint check-dependencies serve classic-link help


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Because Dependabot did manage correctly `go.mod` and `go.sum` files, we decided to remove it and add a simple command in Makefile.

Now use `make check-dependencies` to get the list of the dependencies to update

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/91277806-9e40cb80-e783-11ea-9c4d-947d1a11035a.png)
