### PR TITLE
Display nice message on context creation (message taken from Moby cli)

### DIFF
--- a/cli/cmd/context/create.go
+++ b/cli/cmd/context/create.go
@@ -135,6 +135,7 @@ func createDockerContext(ctx context.Context, name string, contextType string, d
 		description,
 		data,
 	)
+	fmt.Printf("Successfully created %s context %q\n", contextType, name)
 	return result
 }
 

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -124,7 +124,7 @@ func TestLoginLogout(t *testing.T) {
 	})
 }
 
-func TestContainerRun(t *testing.T) {
+func TestContainerRunVolume(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 	sID, rg := setupTestResourceGroup(t, c)
 
@@ -581,8 +581,9 @@ func createResourceGroup(sID, rgName string) error {
 }
 
 func createAciContextAndUseIt(t *testing.T, c *E2eCLI, sID, rgName string) {
-	c.RunDockerCmd("context", "create", "aci", contextName, "--subscription-id", sID, "--resource-group", rgName, "--location", location)
-	res := c.RunDockerCmd("context", "use", contextName)
+	res := c.RunDockerCmd("context", "create", "aci", contextName, "--subscription-id", sID, "--resource-group", rgName, "--location", location)
+	res.Assert(t, icmd.Expected{Out: "Successfully created aci context \"" + contextName + "\""})
+	res = c.RunDockerCmd("context", "use", contextName)
 	res.Assert(t, icmd.Expected{Out: contextName})
 	res = c.RunDockerCmd("context", "ls")
 	res.Assert(t, icmd.Expected{Out: contextName + " *"})

--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -131,7 +131,7 @@ func setupTest(t *testing.T) (*E2eCLI, string) {
 		if localTestProfile != "" {
 			region := os.Getenv("TEST_AWS_REGION")
 			assert.Check(t, region != "")
-			c.RunDockerCmd("context", "create", "ecs", contextName, "--profile", localTestProfile, "--region", region)
+			res = c.RunDockerCmd("context", "create", "ecs", contextName, "--profile", localTestProfile, "--region", region)
 		} else {
 			profile := contextName
 			region := os.Getenv("AWS_DEFAULT_REGION")
@@ -140,8 +140,9 @@ func setupTest(t *testing.T) (*E2eCLI, string) {
 			assert.Check(t, keyID != "")
 			assert.Check(t, secretKey != "")
 			assert.Check(t, region != "")
-			c.RunDockerCmd("context", "create", "ecs", contextName, "--profile", profile, "--region", region, "--secret-key", secretKey, "--key-id", keyID)
+			res = c.RunDockerCmd("context", "create", "ecs", contextName, "--profile", profile, "--region", region, "--secret-key", secretKey, "--key-id", keyID)
 		}
+		res.Assert(t, icmd.Expected{Out: "Successfully created ecs context \"" + contextName + "\""})
 		res = c.RunDockerCmd("context", "use", contextName)
 		res.Assert(t, icmd.Expected{Out: contextName})
 		res = c.RunDockerCmd("context", "ls")


### PR DESCRIPTION
**What I did**

**Related issue**
https://github.com/docker/compose-cli/issues/281

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSrwq-pUa1eYaPeTbGrQv45JlSES6LQ7g1Elw&usqp=CAU)