### PR TITLE
Implement compose ps on ACI

### DIFF
--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -26,6 +26,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/compose-cli/compose"
+	"github.com/docker/compose-cli/utils/formatter"
+
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
@@ -383,6 +386,21 @@ func getEnvVariables(composeEnv types.MappingWithEquals) *[]containerinstance.En
 func bytesToGb(b types.UnitBytes) float64 {
 	f := float64(b) / 1024 / 1024 / 1024 // from bytes to gigabytes
 	return math.Round(f*100) / 100
+}
+
+// ContainerGroupToServiceStatus convert from an ACI container definition to service status
+func ContainerGroupToServiceStatus(containerID string, group containerinstance.ContainerGroup, container containerinstance.Container) compose.ServiceStatus {
+	var replicas = 1
+	if GetStatus(container, group) != "Running" {
+		replicas = 0
+	}
+	return compose.ServiceStatus{
+		ID:       containerID,
+		Name:     *container.Name,
+		Ports:    formatter.PortsToStrings(ToPorts(group.IPAddress, *container.Ports)),
+		Replicas: replicas,
+		Desired:  1,
+	}
 }
 
 // ContainerGroupToContainer composes a Container from an ACI container definition

--- a/cli/cmd/ps.go
+++ b/cli/cmd/ps.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
+
+	"github.com/docker/compose-cli/utils/formatter"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/client"
 	formatter2 "github.com/docker/compose-cli/formatter"
 )
@@ -97,7 +99,7 @@ func runPs(ctx context.Context, opts psOpts) error {
 	fmt.Fprintf(w, "CONTAINER ID\tIMAGE\tCOMMAND\tSTATUS\tPORTS\n")
 	format := "%s\t%s\t%s\t%s\t%s\n"
 	for _, c := range containers {
-		fmt.Fprintf(w, format, c.ID, c.Image, c.Command, c.Status, formatter.PortsString(c.Ports))
+		fmt.Fprintf(w, format, c.ID, c.Image, c.Command, c.Status, strings.Join(formatter.PortsToStrings(c.Ports), ", "))
 	}
 
 	return w.Flush()

--- a/utils/formatter/container.go
+++ b/utils/formatter/container.go
@@ -30,8 +30,8 @@ type portGroup struct {
 	last  uint32
 }
 
-// PortsString returns a human readable published ports
-func PortsString(ports []containers.Port) string {
+// PortsToStrings returns a human readable published ports
+func PortsToStrings(ports []containers.Port) []string {
 	groupMap := make(map[string]*portGroup)
 	var (
 		result       []string
@@ -82,7 +82,7 @@ func PortsString(ports []containers.Port) string {
 
 	result = append(result, hostMappings...)
 
-	return strings.Join(result, ", ")
+	return result
 }
 
 func formGroup(key string, start uint32, last uint32) string {

--- a/utils/formatter/container_test.go
+++ b/utils/formatter/container_test.go
@@ -28,37 +28,37 @@ func TestDisplayPorts(t *testing.T) {
 	testCases := []struct {
 		name     string
 		in       []string
-		expected string
+		expected []string
 	}{
 		{
 			name:     "simple",
 			in:       []string{"80"},
-			expected: "0.0.0.0:80->80/tcp",
+			expected: []string{"0.0.0.0:80->80/tcp"},
 		},
 		{
 			name:     "different ports",
 			in:       []string{"80:90"},
-			expected: "0.0.0.0:80->90/tcp",
+			expected: []string{"0.0.0.0:80->90/tcp"},
 		},
 		{
 			name:     "host ip",
 			in:       []string{"192.168.0.1:80:90"},
-			expected: "192.168.0.1:80->90/tcp",
+			expected: []string{"192.168.0.1:80->90/tcp"},
 		},
 		{
 			name:     "port range",
 			in:       []string{"80-90:80-90"},
-			expected: "0.0.0.0:80-90->80-90/tcp",
+			expected: []string{"0.0.0.0:80-90->80-90/tcp"},
 		},
 		{
 			name:     "grouping",
 			in:       []string{"80:80", "81:81"},
-			expected: "0.0.0.0:80-81->80-81/tcp",
+			expected: []string{"0.0.0.0:80-81->80-81/tcp"},
 		},
 		{
 			name:     "groups",
 			in:       []string{"80:80", "82:82"},
-			expected: "0.0.0.0:80->80/tcp, 0.0.0.0:82->82/tcp",
+			expected: []string{"0.0.0.0:80->80/tcp", "0.0.0.0:82->82/tcp"},
 		},
 	}
 
@@ -70,8 +70,8 @@ func TestDisplayPorts(t *testing.T) {
 			containerConfig, err := runOpts.ToContainerConfig("test")
 			assert.NilError(t, err)
 
-			out := PortsString(containerConfig.Ports)
-			assert.Equal(t, testCase.expected, out)
+			out := PortsToStrings(containerConfig.Ports)
+			assert.DeepEqual(t, testCase.expected, out)
 		})
 	}
 }


### PR DESCRIPTION
**What I did**
* implement `compose ps` in ACI

**Related issue**
https://github.com/docker/compose-cli/issues/541

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://scontent.fcdg3-1.fna.fbcdn.net/v/t31.0-8/p960x960/14883704_211361645964116_2136445297321757214_o.jpg?_nc_cat=104&_nc_sid=85a577&_nc_ohc=b00VEX_R9MoAX_2Wqu1&_nc_ht=scontent.fcdg3-1.fna&tp=6&oh=d3557e6378ad0d05d4b7c74a79cd4f66&oe=5F706BC1)