### PR TITLE
Wait only for the first “DELETE_COMPLETE” line when running `docker compose down` 

### DIFF
--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -116,7 +116,17 @@ func TestCompose(t *testing.T) {
 	})
 
 	t.Run("compose down", func(t *testing.T) {
-		c.RunDockerCmd("compose", "down", "--project-name", stack, "-f", "../composefiles/nginx.yaml")
+		cmd := c.NewDockerCmd("compose", "down", "--project-name", stack)
+		res := icmd.StartCmd(cmd)
+
+		checkUp := func(t poll.LogT) poll.Result {
+			out := res.Stdout()
+			if !strings.Contains(out, "DELETE_COMPLETE") {
+				return poll.Continue("current status \n%s\n", out)
+			}
+			return poll.Success()
+		}
+		poll.WaitOn(t, checkUp, poll.WithDelay(2*time.Second), poll.WithTimeout(60*time.Second))
 	})
 }
 


### PR DESCRIPTION
(~4 secs, instead of waiting 8-9 mins for the entire aws stack to be deleted), and let aws fully delete stack async.

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Start the down command and check the output to wait for the first "DELETE_COMPLETE" message, happening within ~4 secs. Save 8 mins of tests, out of ~12 in total

**Related issue**
https://github.com/docker/compose-cli/issues/559

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**![](https://www.turkeyshoredistilleries.com/wp-content/uploads/2020/04/201-2011649_zoology-animals.jpg)