### PR TITLE
implement "down" with (yet another) docker-compose hack

### DIFF
--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -27,6 +27,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	types2 "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+
 	"github.com/docker/compose-cli/compose"
 	"github.com/docker/compose-cli/errdefs"
 
@@ -145,7 +148,30 @@ services:
 }
 
 func (e ecsLocalSimulation) Logs(ctx context.Context, projectName string, w io.Writer) error {
-	return errors.Wrap(errdefs.ErrNotImplemented, "use docker-compose logs")
+	list, err := e.moby.ContainerList(ctx, types2.ContainerListOptions{
+		Filters: filters.NewArgs(filters.Arg("label", "com.docker.compose.project="+projectName)),
+	})
+	if err != nil {
+		return err
+	}
+	services := map[string]types.ServiceConfig{}
+	for _, c := range list {
+		services[c.Labels["com.docker.compose.service"]] = types.ServiceConfig{
+			Image: "unused",
+		}
+	}
+
+	marshal, err := yaml.Marshal(map[string]interface{}{
+		"services": services,
+	})
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("docker-compose", "--context", "default", "--project-name", projectName, "-f", "-", "logs", "-f")
+	cmd.Stdin = strings.NewReader(string(marshal))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func (e ecsLocalSimulation) Ps(ctx context.Context, projectName string) ([]compose.ServiceStatus, error) {


### PR DESCRIPTION
**What I did**

Added support for "down" on ecs-local backend using a docker-compose hack : Uses `--remove-orphans` to ensure compose will delete all resources with project's label.

Not strictly required afaik as `up` only supports attached mode and will kill the stack on `SIGTERM`, but who knows ?

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
