### PR TITLE
Fix bug not allowing users to run any context command when set to an aws context type.

### DIFF
--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -61,11 +61,11 @@ func TestDetermineCurrentContext(t *testing.T) {
 }
 
 func TestCheckOwnCommand(t *testing.T) {
-	assert.Assert(t, isOwnCommand(login.Command()))
-	assert.Assert(t, isOwnCommand(context.Command()))
-	assert.Assert(t, isOwnCommand(cmd.ServeCommand()))
-	assert.Assert(t, !isOwnCommand(run.Command()))
-	assert.Assert(t, !isOwnCommand(cmd.ExecCommand()))
-	assert.Assert(t, !isOwnCommand(cmd.LogsCommand()))
-	assert.Assert(t, !isOwnCommand(cmd.PsCommand()))
+	assert.Assert(t, isContextAgnosticCommand(login.Command()))
+	assert.Assert(t, isContextAgnosticCommand(context.Command()))
+	assert.Assert(t, isContextAgnosticCommand(cmd.ServeCommand()))
+	assert.Assert(t, !isContextAgnosticCommand(run.Command()))
+	assert.Assert(t, !isContextAgnosticCommand(cmd.ExecCommand()))
+	assert.Assert(t, !isContextAgnosticCommand(cmd.LogsCommand()))
+	assert.Assert(t, !isContextAgnosticCommand(cmd.PsCommand()))
 }

--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -28,7 +28,7 @@ import (
 	"github.com/docker/compose-cli/context/store"
 )
 
-var delegatedContextTypes = []string{store.DefaultContextType, store.AwsContextType}
+var delegatedContextTypes = []string{store.DefaultContextType}
 
 // ComDockerCli name of the classic cli binary
 const ComDockerCli = "com.docker.cli"


### PR DESCRIPTION
When users have an “aws" context type, we try to exec the command (will execute context ls, context use, etc.) and when it fails because it doesn’t find the aws backend, then display the custom error for aws context type.

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* rename isOwnCommand => isContextAgnosticCommand
* remove aws context type from context we shell our to moby cli. There is no more ECS plugin to delegate to
* move the aws context type check after we try to execute the command to let context commands execute normally

**Related issue**
https://github.com/docker/compose-cli/issues/576

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdn.trendhunterstatic.com/thumbs/hybrid-animals.jpeg)