### PR TITLE
Remove delete alias, no reason to add this (does not exist in Moby)

### DIFF
--- a/cli/cmd/rm.go
+++ b/cli/cmd/rm.go
@@ -38,10 +38,9 @@ type rmOpts struct {
 func RmCommand() *cobra.Command {
 	var opts rmOpts
 	cmd := &cobra.Command{
-		Use:     "rm",
-		Aliases: []string{"delete"},
-		Short:   "Remove containers",
-		Args:    cobra.MinimumNArgs(1),
+		Use:   "rm",
+		Short: "Remove containers",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRm(cmd.Context(), args, opts)
 		},


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
just remove the alias

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/5a/85/e8/5a85e8aab6cb441d96d77d8417b243e7.jpg)