### PR TITLE
ACI : when following logs (actually polling logs), stop polling when the container is not running.

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -48,7 +48,6 @@ const (
 	singleContainerTag        = "docker-single-container"
 	composeContainerTag       = "docker-compose-application"
 	composeContainerSeparator = "_"
-	statusRunning             = "Running"
 )
 
 // ContextParams options for creating ACI context
@@ -183,7 +182,7 @@ func getContainerID(group containerinstance.ContainerGroup, container containeri
 }
 
 func isContainerVisible(container containerinstance.Container, group containerinstance.ContainerGroup, showAll bool) bool {
-	return *container.Name == convert.ComposeDNSSidecarName || (!showAll && convert.GetStatus(container, group) != statusRunning)
+	return *container.Name == convert.ComposeDNSSidecarName || (!showAll && convert.GetStatus(container, group) != convert.StatusRunning)
 }
 
 func (cs *aciContainerService) Run(ctx context.Context, r containers.ContainerConfig) error {
@@ -349,7 +348,7 @@ func (cs *aciContainerService) Delete(ctx context.Context, containerID string, r
 		for _, container := range *cg.Containers {
 			status := convert.GetStatus(container, cg)
 
-			if status == statusRunning {
+			if status == convert.StatusRunning {
 				return errdefs.ErrForbidden
 			}
 		}

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -40,6 +40,8 @@ import (
 )
 
 const (
+	// StatusRunning name of the ACI running status
+	StatusRunning = "Running"
 	// ComposeDNSSidecarName name of the dns sidecar container
 	ComposeDNSSidecarName = "aci--dns--sidecar"
 	dnsSidecarImage       = "busybox:1.31.1"
@@ -391,7 +393,7 @@ func bytesToGb(b types.UnitBytes) float64 {
 // ContainerGroupToServiceStatus convert from an ACI container definition to service status
 func ContainerGroupToServiceStatus(containerID string, group containerinstance.ContainerGroup, container containerinstance.Container) compose.ServiceStatus {
 	var replicas = 1
-	if GetStatus(container, group) != "Running" {
+	if GetStatus(container, group) != StatusRunning {
 		replicas = 0
 	}
 	return compose.ServiceStatus{


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* when logs don't change, fetch the status of the container and stop following logs if not "Running"
* Slightly optimize for short lived container like hello-world, to avoid waiting another 2 secs when running `docker run hello-world`(`run` follows logs by default): check the status of the container after the first log display.
* Add ACI e2e tests

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://www.yourdictionary.com/images/definitions/lg/4736.follow.jpg)