### PR TITLE
Most common scenario is to use `compose ls` without name option, and list all stacks

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -467,7 +467,7 @@ func TestComposeUpUpdate(t *testing.T) {
 	})
 
 	t.Run("compose ls", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ls", "--project-name", composeProjectName)
+		res := c.RunDockerCmd("compose", "ls")
 		lines := strings.Split(strings.TrimSpace(res.Stdout()), "\n")
 
 		assert.Equal(t, 2, len(lines))

--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -99,7 +99,7 @@ func TestCompose(t *testing.T) {
 	})
 
 	t.Run("compose ls", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ls", "--project-name", stack)
+		res := c.RunDockerCmd("compose", "ls")
 		lines := strings.Split(strings.TrimSpace(res.Stdout()), "\n")
 
 		assert.Equal(t, 2, len(lines))


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Just remove `--project-name` from compose ls calls in e2e

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
