### PR TITLE
Properly send env variables containing “=“ in their value in ACI payload. Also properly send quoted values

### DIFF
--- a/aci/convert/container.go
+++ b/aci/convert/container.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/types"
-
 	"github.com/docker/compose-cli/api/containers"
 )
 
@@ -71,7 +70,7 @@ func ContainerToComposeProject(r containers.ContainerConfig) (types.Project, err
 func toComposeEnvs(opts []string) types.MappingWithEquals {
 	result := map[string]*string{}
 	for _, env := range opts {
-		tokens := strings.Split(env, "=")
+		tokens := strings.SplitN(env, "=", 2)
 		if len(tokens) > 1 {
 			result[tokens[0]] = &tokens[1]
 		} else {

--- a/aci/convert/container_test.go
+++ b/aci/convert/container_test.go
@@ -53,3 +53,21 @@ func TestConvertRestartPolicy(t *testing.T) {
 	assert.Equal(t, service1.Name, container.ID)
 	assert.Equal(t, service1.Deploy.RestartPolicy.Condition, "none")
 }
+
+func TestConvertEnvVariables(t *testing.T) {
+	container := containers.ContainerConfig{
+		ID: "container1",
+		Environment: []string{
+			"key=value",
+			"key2=value=with=equal",
+		},
+	}
+	project, err := ContainerToComposeProject(container)
+	assert.NilError(t, err)
+	service1 := project.Services[0]
+	assert.Equal(t, service1.Name, container.ID)
+	assert.DeepEqual(t, service1.Environment, types.MappingWithEquals{
+		"key":  to.StringPtr("value"),
+		"key2": to.StringPtr("value=with=equal"),
+	})
+}

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -429,6 +429,18 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 	status := GetStatus(cc, cg)
 	platform := string(cg.OsType)
 
+	var envVars map[string]string = nil
+	if cc.EnvironmentVariables != nil && len(*cc.EnvironmentVariables) != 0 {
+		envVars = map[string]string{}
+		for _, envVar := range *cc.EnvironmentVariables {
+			envVars[*envVar.Name] = *envVar.Value
+		}
+	}
+
+	var config *containers.RuntimeConfig = nil
+	if envVars != nil {
+		config = &containers.RuntimeConfig{Env: envVars}
+	}
 	c := containers.Container{
 		ID:                     containerID,
 		Status:                 status,
@@ -444,6 +456,7 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 		Ports:                  ToPorts(cg.IPAddress, *cc.Ports),
 		Platform:               platform,
 		RestartPolicyCondition: toContainerRestartPolicy(cg.RestartPolicy),
+		Config:                 config,
 	}
 
 	return c

--- a/api/containers/api.go
+++ b/api/containers/api.go
@@ -47,10 +47,16 @@ type Container struct {
 	MemoryLimit            uint64
 	PidsCurrent            uint64
 	PidsLimit              uint64
-	Labels                 []string
-	Ports                  []Port
+	Config                 *RuntimeConfig `json:",omitempty"`
+	Labels                 []string       `json:",omitempty"`
+	Ports                  []Port         `json:",omitempty"`
 	Platform               string
 	RestartPolicyCondition string
+}
+
+// RuntimeConfig config of a created container
+type RuntimeConfig struct {
+	Env map[string]string `json:",omitempty"`
 }
 
 // Port represents a published port of a container

--- a/cli/cmd/testdata/inspect-out-id.golden
+++ b/cli/cmd/testdata/inspect-out-id.golden
@@ -9,8 +9,6 @@
     "MemoryLimit": 0,
     "PidsCurrent": 0,
     "PidsLimit": 0,
-    "Labels": null,
-    "Ports": null,
     "Platform": "Linux",
     "RestartPolicyCondition": "none"
 }

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -543,6 +543,7 @@ func TestRunEnvVars(t *testing.T) {
 			"-e", "MYSQL_DATABASE=mytestdb",
 			"-e", "MYSQL_USER",
 			"-e", "MYSQL_PASSWORD=userpwd",
+			"-e", "DATASOURCE_URL=jdbc:mysql://mydb.mysql.database.azure.com/db1?useSSL=true&requireSSL=false&serverTimezone=America/Recife",
 			"mysql:5.7",
 		)
 		cmd.Env = append(cmd.Env, "MYSQL_USER=user1")
@@ -555,7 +556,16 @@ func TestRunEnvVars(t *testing.T) {
 
 		containerInspect, err := ParseContainerInspect(res.Stdout())
 		assert.NilError(t, err)
+		assert.Assert(t, containerInspect.Config != nil, "nil container config")
+		assert.Assert(t, containerInspect.Config.Env != nil, "nil container env variables")
 		assert.Equal(t, containerInspect.Image, "mysql:5.7")
+		envVars := containerInspect.Config.Env
+		assert.Equal(t, len(envVars), 5)
+		assert.Equal(t, envVars["MYSQL_ROOT_PASSWORD"], "rootpwd")
+		assert.Equal(t, envVars["MYSQL_DATABASE"], "mytestdb")
+		assert.Equal(t, envVars["MYSQL_USER"], "user1")
+		assert.Equal(t, envVars["MYSQL_PASSWORD"], "userpwd")
+		assert.Equal(t, envVars["DATASOURCE_URL"], "jdbc:mysql://mydb.mysql.database.azure.com/db1?useSSL=true&requireSSL=false&serverTimezone=America/Recife")
 
 		check := func(t poll.LogT) poll.Result {
 			res := c.RunDockerOrExitError("logs", container)

--- a/tests/e2e/testdata/inspect-id.golden
+++ b/tests/e2e/testdata/inspect-id.golden
@@ -9,8 +9,6 @@
     "MemoryLimit": 0,
     "PidsCurrent": 0,
     "PidsLimit": 0,
-    "Labels": null,
-    "Ports": null,
     "Platform": "Linux",
     "RestartPolicyCondition": "none"
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Do not split values with "=" and keep only the first token, keep the entire value
* added env vars in ACI inspect, making it easier to e2e test the user reported error

**Related issue**
https://github.com/docker/cli/issues/2702

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdn.ebaumsworld.com/mediaFiles/picture/2104182/83587131.jpg)