### PR TITLE
Change volume IDs from “storageaccount@fileshare“ to “storageaccount/fileshare”

### DIFF
--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -207,7 +207,7 @@ func (p projectAciHelper) getAciFileVolumes(ctx context.Context, helper login.St
 		if v.Driver == azureFileDriverName {
 			shareName, ok := v.DriverOpts[volumeDriveroptsShareNameKey]
 			if !ok {
-				return nil, nil, fmt.Errorf("cannot retrieve share name for Azurefile")
+				return nil, nil, fmt.Errorf("cannot retrieve fileshare name for Azurefile")
 			}
 			accountName, ok := v.DriverOpts[volumeDriveroptsAccountNameKey]
 			if !ok {

--- a/aci/convert/volume_test.go
+++ b/aci/convert/volume_test.go
@@ -30,9 +30,9 @@ const (
 
 func TestGetRunVolumes(t *testing.T) {
 	volumeStrings := []string{
-		"myuser1@myshare1:/my/path/to/target1",
-		"myuser2@myshare2:/my/path/to/target2",
-		"myuser3@mydefaultsharename", // Use default placement at '/run/volumes/<share_name>'
+		"myuser1/myshare1:/my/path/to/target1",
+		"myuser2/myshare2:/my/path/to/target2",
+		"myuser3/mydefaultsharename", // Use default placement at '/run/volumes/<share_name>'
 	}
 	var goldenVolumeConfigs = map[string]types.VolumeConfig{
 		"volume-0": {
@@ -89,16 +89,16 @@ func TestGetRunVolumes(t *testing.T) {
 }
 
 func TestGetRunVolumesMissingFileShare(t *testing.T) {
-	_, _, err := GetRunVolumes([]string{"myaccount@"})
-	assert.ErrorContains(t, err, "does not include a storage file share after '@'")
+	_, _, err := GetRunVolumes([]string{"myaccount/"})
+	assert.ErrorContains(t, err, "does not include a storage file fileshare after '/'")
 }
 
 func TestGetRunVolumesMissingUser(t *testing.T) {
-	_, _, err := GetRunVolumes([]string{"@myshare"})
-	assert.ErrorContains(t, err, "does not include a storage account before '@'")
+	_, _, err := GetRunVolumes([]string{"/myshare"})
+	assert.ErrorContains(t, err, "does not include a storage account before '/'")
 }
 
 func TestGetRunVolumesNoShare(t *testing.T) {
 	_, _, err := GetRunVolumes([]string{"noshare"})
-	assert.ErrorContains(t, err, "does not include a storage account before '@'")
+	assert.ErrorContains(t, err, "does not include a storage account before '/'")
 }

--- a/aci/volumes.go
+++ b/aci/volumes.go
@@ -167,7 +167,7 @@ func errorEvent(resource string) progress.Event {
 }
 
 func (cs *aciVolumeService) Delete(ctx context.Context, id string, options interface{}) error {
-	tokens := strings.Split(id, "@")
+	tokens := strings.Split(id, "/")
 	if len(tokens) != 2 {
 		return errors.New("wrong format for volume ID : should be storageaccount@fileshare")
 	}
@@ -219,7 +219,7 @@ func toVolume(account storage.Account, fileShareName string) volumes.Volume {
 
 // VolumeID generate volume ID from azure storage accoun & fileshare
 func VolumeID(storageAccount string, fileShareName string) string {
-	return fmt.Sprintf("%s@%s", storageAccount, fileShareName)
+	return fmt.Sprintf("%s/%s", storageAccount, fileShareName)
 }
 
 func defaultStorageAccountParams(aciContext store.AciContext) storage.AccountCreateParameters {

--- a/cli/cmd/volume/list_test.go
+++ b/cli/cmd/volume/list_test.go
@@ -28,7 +28,7 @@ import (
 func TestPrintList(t *testing.T) {
 	secrets := []volumes.Volume{
 		{
-			ID:          "volume@123",
+			ID:          "volume/123",
 			Description: "volume 123",
 		},
 	}

--- a/cli/cmd/volume/testdata/volumes-out.golden
+++ b/cli/cmd/volume/testdata/volumes-out.golden
@@ -1,2 +1,2 @@
 ID                  DESCRIPTION
-volume@123          volume 123
+volume/123          volume 123

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -162,7 +162,7 @@ func TestContainerRunVolume(t *testing.T) {
 	t.Run("create volumes", func(t *testing.T) {
 		c.RunDockerCmd("volume", "create", "--storage-account", accountName, "--fileshare", fileshareName)
 	})
-	volumeID = accountName + "@" + fileshareName
+	volumeID = accountName + "/" + fileshareName
 
 	t.Cleanup(func() {
 		c.RunDockerCmd("volume", "rm", volumeID)
@@ -174,7 +174,7 @@ func TestContainerRunVolume(t *testing.T) {
 	t.Run("create second fileshare", func(t *testing.T) {
 		c.RunDockerCmd("volume", "create", "--storage-account", accountName, "--fileshare", "dockertestshare2")
 	})
-	volumeID2 := accountName + "@dockertestshare2"
+	volumeID2 := accountName + "/dockertestshare2"
 
 	t.Run("list volumes", func(t *testing.T) {
 		res := c.RunDockerCmd("volume", "ls")


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
update volume IDs, visible in 
* output of `docker volume create`
* arg & output of `docker volume rm``
* output of `docker volume ls`
* arg of `docker run -v`

**Related issue**
https://github.com/docker/compose-cli/issues/560

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://files.cults3d.com/uploaders/15783845/illustration-file/5ab8878c-9f32-4f28-a125-b1640df76125/turtleduck_v2.png)