### PR TITLE
Remove duplicated code formatting multi errors

### DIFF
--- a/cli/cmd/context/rm.go
+++ b/cli/cmd/context/rm.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/compose-cli/cli/formatter"
 	apicontext "github.com/docker/compose-cli/context"
 	"github.com/docker/compose-cli/context/store"
 )
@@ -69,18 +69,8 @@ func runRemove(ctx context.Context, args []string, force bool) error {
 			errs = removeContext(s, contextName, errs)
 		}
 	}
-	if errs != nil {
-		errs.ErrorFormat = formatErrors
-	}
+	formatter.SetMultiErrorFormat(errs)
 	return errs.ErrorOrNil()
-}
-
-func formatErrors(errs []error) string {
-	messages := make([]string, len(errs))
-	for i, err := range errs {
-		messages[i] = "Error: " + err.Error()
-	}
-	return strings.Join(messages, "\n")
 }
 
 func removeContext(s store.Store, n string, errs *multierror.Error) *multierror.Error {

--- a/cli/cmd/kill.go
+++ b/cli/cmd/kill.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/errdefs"
 )
 
@@ -69,8 +69,6 @@ func runKill(ctx context.Context, args []string, opts killOpts) error {
 		}
 		fmt.Println(id)
 	}
-	if errs != nil {
-		errs.ErrorFormat = formatErrors
-	}
+	formatter.SetMultiErrorFormat(errs)
 	return errs.ErrorOrNil()
 }

--- a/cli/cmd/rm.go
+++ b/cli/cmd/rm.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/errdefs"
 )
 
@@ -75,16 +75,6 @@ func runRm(ctx context.Context, args []string, opts rmOpts) error {
 
 		fmt.Println(id)
 	}
-	if errs != nil {
-		errs.ErrorFormat = formatErrors
-	}
+	formatter.SetMultiErrorFormat(errs)
 	return errs.ErrorOrNil()
-}
-
-func formatErrors(errs []error) string {
-	messages := make([]string, len(errs))
-	for i, err := range errs {
-		messages[i] = "Error: " + err.Error()
-	}
-	return strings.Join(messages, "\n")
 }

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/compose-cli/errdefs"
-
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/cli/formatter"
+	"github.com/docker/compose-cli/errdefs"
 )
 
 // StartCommand starts containers
@@ -63,9 +62,6 @@ func runStart(ctx context.Context, args []string) error {
 		}
 		fmt.Println(id)
 	}
-	if errs != nil {
-		errs.ErrorFormat = formatErrors
-	}
-
+	formatter.SetMultiErrorFormat(errs)
 	return errs.ErrorOrNil()
 }

--- a/cli/cmd/stop.go
+++ b/cli/cmd/stop.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/compose-cli/errdefs"
-
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/cli/formatter"
+	"github.com/docker/compose-cli/errdefs"
 )
 
 type stopOpts struct {
@@ -70,8 +69,6 @@ func runStop(ctx context.Context, args []string, opts stopOpts) error {
 		}
 		fmt.Println(id)
 	}
-	if errs != nil {
-		errs.ErrorFormat = formatErrors
-	}
+	formatter.SetMultiErrorFormat(errs)
 	return errs.ErrorOrNil()
 }

--- a/cli/cmd/volume/acivolume.go
+++ b/cli/cmd/volume/acivolume.go
@@ -19,14 +19,13 @@ package volume
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
-
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/aci"
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/progress"
 )
 
@@ -97,19 +96,9 @@ func rmVolume() *cobra.Command {
 				}
 				fmt.Println(id)
 			}
-			if errs != nil {
-				errs.ErrorFormat = formatErrors
-			}
+			formatter.SetMultiErrorFormat(errs)
 			return errs.ErrorOrNil()
 		},
 	}
 	return cmd
-}
-
-func formatErrors(errs []error) string {
-	messages := make([]string, len(errs))
-	for i, err := range errs {
-		messages[i] = "Error: " + err.Error()
-	}
-	return strings.Join(messages, "\n")
 }

--- a/cli/formatter/multierrformat.go
+++ b/cli/formatter/multierrformat.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2020 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package formatter
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// SetMultiErrorFormat set cli default format for multi-errors
+func SetMultiErrorFormat(errs *multierror.Error) {
+	if errs != nil {
+		errs.ErrorFormat = formatErrors
+	}
+}
+
+func formatErrors(errs []error) string {
+	messages := make([]string, len(errs))
+	for i, err := range errs {
+		messages[i] = "Error: " + err.Error()
+	}
+	return strings.Join(messages, "\n")
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -27,13 +27,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose-cli/cli/cmd/compose"
 	"github.com/docker/compose-cli/cli/cmd/logout"
 	volume "github.com/docker/compose-cli/cli/cmd/volume"
 	"github.com/docker/compose-cli/errdefs"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 
 	// Backend registrations
 	_ "github.com/docker/compose-cli/aci"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
keep multi error formatting code in one place

**Related issue**
https://github.com/docker/compose-cli/issues/600

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://lh3.googleusercontent.com/proxy/0mCTHQOaIxkIvpHsosYwi1MDTNolEEO1NJ3Y1B7eqFLkiIVhPjLxAN8GaPsS1DTqjMA4GtAw3o-BhjWLTDUdc_oHQ7V2dbbw9IXjxJzcAW8jLXfnpBjuvBECXg8ksJDKAgzjyjnfcg)