### PR TITLE
In version, replace “Azure integration” version info by “Cloud integration"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ $ which docker
 /usr/local/bin/docker
 $ docker version
 ...
- Azure integration  0.1.4
+ Cloud integration  0.1.6
 ...
 ```
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -55,6 +55,6 @@ func runVersion(cmd *cobra.Command, version string) error {
 		return nil
 	}
 	var s string = string(versionResult)
-	fmt.Print(strings.Replace(s, "\n Version:", "\n Azure integration  "+displayedVersion+"\n Version:", 1))
+	fmt.Print(strings.Replace(s, "\n Version:", "\n Cloud integration  "+displayedVersion+"\n Version:", 1))
 	return nil
 }

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -82,7 +82,7 @@ $ which docker
 /usr/local/bin/docker
 $ docker version
 ...
- Azure integration  0.1.4
+ Cloud integration  0.1.6
 ...
 ```
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -370,7 +370,7 @@ func TestVersion(t *testing.T) {
 
 	t.Run("azure version", func(t *testing.T) {
 		res := c.RunDockerCmd("version")
-		res.Assert(t, icmd.Expected{Out: "Azure integration"})
+		res.Assert(t, icmd.Expected{Out: "Cloud integration"})
 	})
 
 	t.Run("format", func(t *testing.T) {


### PR DESCRIPTION


Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
is in the title

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://1mhvqt3xoj4u2otrxo1recge-wpengine.netdna-ssl.com/wp-content/uploads/2014/10/Animal-Hybrid-21.jpg)