### PR TITLE
Progress functions can return a string, that can be used in the caller of progress.Run() to display final result after progress display

### DIFF
--- a/aci/volumes.go
+++ b/aci/volumes.go
@@ -212,13 +212,12 @@ func (cs *aciVolumeService) Delete(ctx context.Context, id string, options inter
 
 func toVolume(account storage.Account, fileShareName string) volumes.Volume {
 	return volumes.Volume{
-		ID:          VolumeID(*account.Name, fileShareName),
+		ID:          volumeID(*account.Name, fileShareName),
 		Description: fmt.Sprintf("Fileshare %s in %s storage account", fileShareName, *account.Name),
 	}
 }
 
-// VolumeID generate volume ID from azure storage accoun & fileshare
-func VolumeID(storageAccount string, fileShareName string) string {
+func volumeID(storageAccount string, fileShareName string) string {
 	return fmt.Sprintf("%s/%s", storageAccount, fileShareName)
 }
 

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -46,11 +46,12 @@ func runDown(ctx context.Context, opts composeOptions) error {
 		return err
 	}
 
-	return progress.Run(ctx, func(ctx context.Context) error {
+	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
 		projectName, err := opts.toProjectName()
 		if err != nil {
-			return err
+			return "", err
 		}
-		return c.ComposeService().Down(ctx, projectName)
+		return projectName, c.ComposeService().Down(ctx, projectName)
 	})
+	return err
 }

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -49,16 +49,17 @@ func runUp(ctx context.Context, opts composeOptions) error {
 		return err
 	}
 
-	return progress.Run(ctx, func(ctx context.Context) error {
+	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
 		options, err := opts.toProjectOptions()
 		if err != nil {
-			return err
+			return "", err
 		}
 		project, err := cli.ProjectFromOptions(options)
 		if err != nil {
-			return err
+			return "", err
 		}
 
-		return c.ComposeService().Up(ctx, project)
+		return "", c.ComposeService().Up(ctx, project)
 	})
+	return err
 }

--- a/cli/cmd/run/run.go
+++ b/cli/cmd/run/run.go
@@ -68,8 +68,8 @@ func runRun(ctx context.Context, image string, opts run.Opts) error {
 		return err
 	}
 
-	err = progress.Run(ctx, func(ctx context.Context) error {
-		return c.ContainerService().Run(ctx, containerConfig)
+	result, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
+		return containerConfig.ID, c.ContainerService().Run(ctx, containerConfig)
 	})
 	if err != nil {
 		return err
@@ -94,7 +94,6 @@ func runRun(ctx context.Context, image string, opts run.Opts) error {
 		return c.ContainerService().Logs(ctx, opts.Name, req)
 	}
 
-	fmt.Println(opts.Name)
-
+	fmt.Println(result)
 	return nil
 }

--- a/cli/cmd/volume/acivolume.go
+++ b/cli/cmd/volume/acivolume.go
@@ -57,16 +57,17 @@ func createVolume() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = progress.Run(ctx, func(ctx context.Context) error {
-				if _, err := c.VolumeService().Create(ctx, aciOpts); err != nil {
-					return err
+			result, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
+				volume, err := c.VolumeService().Create(ctx, aciOpts)
+				if err != nil {
+					return "", err
 				}
-				return nil
+				return volume.ID, nil
 			})
 			if err != nil {
 				return err
 			}
-			fmt.Println(aci.VolumeID(aciOpts.Account, aciOpts.Fileshare))
+			fmt.Println(result)
 			return nil
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* modified progress.Run() signature to get result
* removed dependency on aci to display volume ID after creation, this is returned by the Create method 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
