### PR TITLE
Fix linux install script parsing version 

### DIFF
--- a/scripts/install/install_linux.sh
+++ b/scripts/install/install_linux.sh
@@ -33,10 +33,14 @@ manual_install() {
 }
 
 is_new_cli() {
-	azure_version_str="$($1 version 2>/dev/null | grep 'Azure' || true)"
-	if [ -n "$azure_version_str" ]; then
+	cloud_version_str="$($1 version 2>/dev/null | grep 'Cloud integration' || true)"
+	if [ -n "$cloud_version_str" ]; then
 		echo 1
 	else
+        azure_version_str="$($1 version 2>/dev/null | grep 'Azure' || true)"
+	    if [ -n "$azure_version_str" ]; then
+		    echo 1
+        fi
 		echo 0
 	fi
 }


### PR DESCRIPTION
to check if we have the new CLI already installed or not (need to keep azure check for users who have the previous version installed :/ )

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
grep for "Cloud integration". Keep the check for azure, as many users will have already installed previous versions

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://www.washingtonpost.com/resizer/6_dXV66UNedoEhCXdPqKpSctOmw=/arc-anglerfish-washpost-prod-washpost/public/SCG5YSVXFMI6VGQ52PNRZPQHZY.jpg)