### PR TITLE
Allow running action labeller on PR from forks, using pull_request-target

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: 'Pull Request Labeler'
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
Cf https://github.com/actions/labeler/issues/12#issuecomment-670967607

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
changed action `on` setting to `pull_request_target`

**Related issue**
labeler not working on PR from fork

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
