### PR TITLE
Minor CI changes

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: 'Pull Request Labeler'
+name: 'PR labeler'
 on:
   - pull_request_target
 

--- a/.github/workflows/optional-ci.yml
+++ b/.github/workflows/optional-ci.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Cloud integration tests
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: releaser
+name: Releaser
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Docker Compose CLI
 
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Continuous%20integration/badge.svg)](https://github.com/docker/compose-cli/actions)
+[![Actions Status](https://github.com/docker/compose-cli/workflows/Cloud%20integration%20tests/badge.svg)](https://github.com/docker/compose-cli/actions)
 
 This CLI tool makes it easy to run containers in the cloud using either Amazon
 Elastic Container Service


### PR DESCRIPTION
testing effect of https://github.com/docker/compose-cli/pull/620

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Renamed GH action workflows

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
