### PR TITLE
Prefer external.name over x-aws-securitygroup

### DIFF
--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -524,7 +524,11 @@ func createCloudMap(project *types.Project, template *cloudformation.Template) {
 }
 
 func convertNetwork(project *types.Project, net types.NetworkConfig, vpc string, template *cloudformation.Template) string {
+	if net.External.External {
+		return net.Name
+	}
 	if sg, ok := net.Extensions[extensionSecurityGroup]; ok {
+		logrus.Warn("to use an existing security-group, set `network.external` and `network.name` in your compose file")
 		logrus.Debugf("Security Group for network %q set by user to %q", net.Name, sg)
 		return sg.(string)
 	}


### PR DESCRIPTION
**What I did**
Add support for `networks.external` for users to configure an existing security-group
This reduces the (already too large) set of custom extensions we introduced for AWS support

@nebuk89 shall we drop support for x-aws-securitygroup that is not required then ?

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/93217351-3d485a00-f769-11ea-94af-4a519015319a.png)

```yaml
networks:
  back_tier:
    external: true
    name: "sg-1234acbd"    
````