### PR TITLE
Check specified subscription in context create and if not found, prompt users they might need to login with -—tenant-id.

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -44,14 +44,6 @@ const (
 	composeContainerSeparator = "_"
 )
 
-// ContextParams options for creating ACI context
-type ContextParams struct {
-	Description    string
-	Location       string
-	SubscriptionID string
-	ResourceGroup  string
-}
-
 // LoginParams azure login options
 type LoginParams struct {
 	TenantID     string

--- a/cli/cmd/context/create_aci.go
+++ b/cli/cmd/context/create_aci.go
@@ -62,6 +62,9 @@ func runCreateAci(ctx context.Context, contextName string, opts aci.ContextParam
 	}
 	contextData, description, err := getAciContextData(ctx, opts)
 	if err != nil {
+		if aci.IsSubscriptionNotFoundError(err) {
+			return errors.New("could not find the requested subscription from your Azure login. You might need to specify a tenant ID with docker login azure --tenant-id xxx")
+		}
 		return err
 	}
 	return createDockerContext(ctx, contextName, store.AciContextType, description, contextData)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* when subscription ID is specified, check the required sub is visible from the Azure login. If not, explicitely prompt users they might need to `docker login azure --tenant-id xxx`

**Related issue**
https://github.com/docker/aci-integration-beta/issues/27

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdn.trendhunterstatic.com/thumbs/sarah-deremer-art.jpeg)