### PR TITLE
Fix context store when no home defined

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -169,9 +169,9 @@ func main() {
 
 	currentContext := determineCurrentContext(opts.Context, configDir)
 
-	s, err := store.New(store.WithRoot(configDir))
+	s, err := store.New(configDir)
 	if err != nil {
-		fatal(errors.Wrap(err, "unable to create context store"))
+		mobycli.Exec()
 	}
 
 	ctype := store.DefaultContextType

--- a/context/store/store.go
+++ b/context/store/store.go
@@ -62,7 +62,6 @@ const (
 
 const (
 	dockerEndpointKey = "docker"
-	configDir         = ".docker"
 	contextsDir       = "contexts"
 	metadataDir       = "meta"
 	metaFile          = "meta.json"
@@ -111,34 +110,10 @@ type store struct {
 	root string
 }
 
-// Opt is a functional option for the store
-type Opt func(*store)
-
-// WithRoot sets a new root to the store
-func WithRoot(root string) Opt {
-	return func(s *store) {
-		s.root = root
-	}
-}
-
-// New returns a configured context store with $HOME/.docker as root
-func New(opts ...Opt) (Store, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, err
-	}
-
-	root := filepath.Join(home, configDir)
-	if err := createDirIfNotExist(root); err != nil {
-		return nil, err
-	}
-
+// New returns a configured context store with specified root dir (eg. $HOME/.docker) as root
+func New(rootDir string) (Store, error) {
 	s := &store{
-		root: root,
-	}
-
-	for _, opt := range opts {
-		opt(s)
+		root: rootDir,
 	}
 
 	m := filepath.Join(s.root, contextsDir, metadataDir)

--- a/context/store/store_test.go
+++ b/context/store/store_test.go
@@ -36,7 +36,7 @@ func testStore(t *testing.T) Store {
 		_ = os.RemoveAll(d)
 	})
 
-	s, err := New(WithRoot(d))
+	s, err := New(d)
 	assert.NilError(t, err)
 
 	return s

--- a/server/interceptor.go
+++ b/server/interceptor.go
@@ -117,7 +117,7 @@ func configureContext(ctx context.Context, currentContext string, method string)
 		}
 	}
 
-	s, err := store.New(store.WithRoot(configDir))
+	s, err := store.New(configDir)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -293,6 +293,27 @@ func TestLegacy(t *testing.T) {
 		})
 	})
 
+	t.Run("run without HOME defined", func(t *testing.T) {
+		cmd := c.NewDockerCmd("ps")
+		cmd.Env = []string{"PATH=" + c.BinDir}
+		res := icmd.RunCmd(cmd)
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Out:      "CONTAINER ID",
+		})
+		assert.Equal(t, res.Stderr(), "")
+	})
+
+	t.Run("run without write access to context store", func(t *testing.T) {
+		cmd := c.NewDockerCmd("ps")
+		cmd.Env = []string{"PATH=" + c.BinDir, "HOME=/doesnotexist/"}
+		res := icmd.RunCmd(cmd)
+		res.Assert(t, icmd.Expected{
+			ExitCode: 0,
+			Out:      "CONTAINER ID",
+		})
+	})
+
 	t.Run("host flag", func(t *testing.T) {
 		stderr := "Cannot connect to the Docker daemon at tcp://localhost:123"
 		if runtime.GOOS == "windows" {

--- a/tests/framework/unit.go
+++ b/tests/framework/unit.go
@@ -48,9 +48,7 @@ func NewTestCLI(t *testing.T) *TestCLI {
 		_ = os.RemoveAll(dir)
 	})
 
-	s, err := store.New(
-		store.WithRoot(dir),
-	)
+	s, err := store.New(dir)
 	assert.Check(t, cmp.Nil(err))
 	err = s.Create("example", "example", "", store.ContextMetadata{})
 	assert.Check(t, cmp.Nil(err))


### PR DESCRIPTION
**What I did**
* use docker homedir package, that includes fallback to user.Current(), and if an error, use relative path

**Related issue**
https://github.com/docker/for-mac/issues/4919

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/fc/f4/c0/fcf4c0e400a6bc5473d83e783f88cb6b.jpg)