### PR TITLE
Changing e2e test PATH to make windows tests pass

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -295,7 +295,7 @@ func TestLegacy(t *testing.T) {
 
 	t.Run("run without HOME defined", func(t *testing.T) {
 		cmd := c.NewDockerCmd("ps")
-		cmd.Env = []string{"PATH=" + c.BinDir}
+		cmd.Env = []string{"PATH=" + c.PathEnvVar()}
 		res := icmd.RunCmd(cmd)
 		res.Assert(t, icmd.Expected{
 			ExitCode: 0,
@@ -306,7 +306,7 @@ func TestLegacy(t *testing.T) {
 
 	t.Run("run without write access to context store", func(t *testing.T) {
 		cmd := c.NewDockerCmd("ps")
-		cmd.Env = []string{"PATH=" + c.BinDir, "HOME=/doesnotexist/"}
+		cmd.Env = []string{"PATH=" + c.PathEnvVar(), "HOME=/doesnotexist/"}
 		res := icmd.RunCmd(cmd)
 		res.Assert(t, icmd.Expected{
 			ExitCode: 0,

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -143,14 +143,10 @@ func CopyFile(sourceFile string, destinationFile string) error {
 
 // NewCmd creates a cmd object configured with the test environment set
 func (c *E2eCLI) NewCmd(command string, args ...string) icmd.Cmd {
-	path := c.BinDir + ":" + os.Getenv("PATH")
-	if runtime.GOOS == "windows" {
-		path = c.BinDir + ";" + os.Getenv("PATH")
-	}
 	env := append(os.Environ(),
 		"DOCKER_CONFIG="+c.ConfigDir,
 		"KUBECONFIG=invalid",
-		"PATH="+path,
+		"PATH="+c.PathEnvVar(),
 	)
 	return icmd.Cmd{
 		Command: append([]string{command}, args...),
@@ -174,6 +170,15 @@ func (c *E2eCLI) RunDockerCmd(args ...string) *icmd.Result {
 	res := c.RunDockerOrExitError(args...)
 	res.Assert(c.test, icmd.Success)
 	return res
+}
+
+// PathEnvVar returns path (os sensitive) for running test
+func (c *E2eCLI) PathEnvVar() string {
+	path := c.BinDir + ":" + os.Getenv("PATH")
+	if runtime.GOOS == "windows" {
+		path = c.BinDir + ";" + os.Getenv("PATH")
+	}
+	return path
 }
 
 // GoldenFile golden file specific to platform


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Updated PATH, os dependent

**Related issue**
https://github.com/docker/compose-cli/runs/1127976039

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
