### PR TITLE
Added tests on ACI volume conversion, mock storageLogin required to get storage account keys

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -88,13 +88,11 @@ func getCloudService() (cloud.Service, error) {
 }
 
 func getAciAPIService(aciCtx store.AciContext) *aciAPIService {
+	containerService := newContainerService(aciCtx)
+	composeService := newComposeService(aciCtx)
 	return &aciAPIService{
-		aciContainerService: &aciContainerService{
-			ctx: aciCtx,
-		},
-		aciComposeService: &aciComposeService{
-			ctx: aciCtx,
-		},
+		aciContainerService: &containerService,
+		aciComposeService:   &composeService,
 		aciVolumeService: &aciVolumeService{
 			aciContext: aciCtx,
 		},

--- a/aci/compose.go
+++ b/aci/compose.go
@@ -33,12 +33,20 @@ import (
 )
 
 type aciComposeService struct {
-	ctx store.AciContext
+	ctx          store.AciContext
+	storageLogin login.StorageLoginImpl
+}
+
+func newComposeService(ctx store.AciContext) aciComposeService {
+	return aciComposeService{
+		ctx:          ctx,
+		storageLogin: login.StorageLoginImpl{AciContext: ctx},
+	}
 }
 
 func (cs *aciComposeService) Up(ctx context.Context, project *types.Project) error {
 	logrus.Debugf("Up on project with name %q", project.Name)
-	groupDefinition, err := convert.ToContainerGroup(ctx, cs.ctx, *project)
+	groupDefinition, err := convert.ToContainerGroup(ctx, cs.ctx, *project, cs.storageLogin)
 	addTag(&groupDefinition, composeContainerTag)
 
 	if err != nil {

--- a/aci/containers.go
+++ b/aci/containers.go
@@ -37,7 +37,15 @@ import (
 )
 
 type aciContainerService struct {
-	ctx store.AciContext
+	ctx          store.AciContext
+	storageLogin login.StorageLoginImpl
+}
+
+func newContainerService(ctx store.AciContext) aciContainerService {
+	return aciContainerService{
+		ctx:          ctx,
+		storageLogin: login.StorageLoginImpl{AciContext: ctx},
+	}
 }
 
 func (cs *aciContainerService) List(ctx context.Context, all bool) ([]containers.Container, error) {
@@ -73,7 +81,7 @@ func (cs *aciContainerService) Run(ctx context.Context, r containers.ContainerCo
 	}
 
 	logrus.Debugf("Running container %q with name %q", r.Image, r.ID)
-	groupDefinition, err := convert.ToContainerGroup(ctx, cs.ctx, project)
+	groupDefinition, err := convert.ToContainerGroup(ctx, cs.ctx, project, cs.storageLogin)
 	if err != nil {
 		return err
 	}

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -26,17 +26,16 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/utils/formatter"
-
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/pkg/errors"
 
 	"github.com/docker/compose-cli/aci/login"
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
 	"github.com/docker/compose-cli/context/store"
+	"github.com/docker/compose-cli/utils/formatter"
 )
 
 const (
@@ -54,12 +53,9 @@ const (
 )
 
 // ToContainerGroup converts a compose project into a ACI container group
-func ToContainerGroup(ctx context.Context, aciContext store.AciContext, p types.Project) (containerinstance.ContainerGroup, error) {
+func ToContainerGroup(ctx context.Context, aciContext store.AciContext, p types.Project, storageHelper login.StorageLogin) (containerinstance.ContainerGroup, error) {
 	project := projectAciHelper(p)
 	containerGroupName := strings.ToLower(project.Name)
-	storageHelper := login.StorageLogin{
-		AciContext: aciContext,
-	}
 	volumesCache, volumesSlice, err := project.getAciFileVolumes(ctx, storageHelper)
 	if err != nil {
 		return containerinstance.ContainerGroup{}, err

--- a/aci/login/storagelogin.go
+++ b/aci/login/storagelogin.go
@@ -26,12 +26,18 @@ import (
 )
 
 // StorageLogin helper for Azure Storage Login
-type StorageLogin struct {
+type StorageLogin interface {
+	// GetAzureStorageAccountKey retrieves the storage account ket from the current azure login
+	GetAzureStorageAccountKey(ctx context.Context, accountName string) (string, error)
+}
+
+// StorageLoginImpl implementation of StorageLogin
+type StorageLoginImpl struct {
 	AciContext store.AciContext
 }
 
 // GetAzureStorageAccountKey retrieves the storage account ket from the current azure login
-func (helper StorageLogin) GetAzureStorageAccountKey(ctx context.Context, accountName string) (string, error) {
+func (helper StorageLoginImpl) GetAzureStorageAccountKey(ctx context.Context, accountName string) (string, error) {
 	client, err := NewStorageAccountsClient(helper.AciContext.SubscriptionID)
 	if err != nil {
 		return "", err

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -197,7 +197,7 @@ func TestContainerRunVolume(t *testing.T) {
 	})
 
 	t.Run("upload file", func(t *testing.T) {
-		storageLogin := login.StorageLogin{AciContext: aciContext}
+		storageLogin := login.StorageLoginImpl{AciContext: aciContext}
 
 		key, err := storageLogin.GetAzureStorageAccountKey(context.TODO(), accountName)
 		assert.NilError(t, err)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
is in the title

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://pbs.twimg.com/media/BJE-xuHCQAAtynR.jpg)