### PR TITLE
In metrics, send context type, not context name (metrics for Moby calls)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -209,7 +209,7 @@ $ docker context create %s <name>`, cc.Type(), store.EcsContextType), ctype)
 		}
 		mobycli.ExecIfDefaultCtxType(ctx, root)
 
-		checkIfUnknownCommandExistInDefaultContext(err, currentContext, root)
+		checkIfUnknownCommandExistInDefaultContext(err, currentContext, root, ctype)
 
 		exit(root, currentContext, err, ctype)
 	}
@@ -242,14 +242,14 @@ func fatal(err error) {
 	os.Exit(1)
 }
 
-func checkIfUnknownCommandExistInDefaultContext(err error, currentContext string, root *cobra.Command) {
+func checkIfUnknownCommandExistInDefaultContext(err error, currentContext string, root *cobra.Command, contextType string) {
 	submatch := unknownCommandRegexp.FindSubmatch([]byte(err.Error()))
 	if len(submatch) == 2 {
 		dockerCommand := string(submatch[1])
 
 		if mobycli.IsDefaultContextCommand(dockerCommand) {
 			fmt.Fprintf(os.Stderr, "Command %q not available in current context (%s), you can use the \"default\" context to run this command\n", dockerCommand, currentContext)
-			metrics.Track(currentContext, os.Args[1:], root.PersistentFlags(), metrics.FailureStatus)
+			metrics.Track(contextType, os.Args[1:], root.PersistentFlags(), metrics.FailureStatus)
 			os.Exit(1)
 		}
 	}

--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -86,7 +86,7 @@ func Exec(root *cobra.Command) {
 	err := cmd.Run()
 	childExit <- true
 	if err != nil {
-		metrics.Track(store.DefaultContextName, os.Args[1:], root.PersistentFlags(), metrics.FailureStatus)
+		metrics.Track(store.DefaultContextType, os.Args[1:], root.PersistentFlags(), metrics.FailureStatus)
 
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			os.Exit(exiterr.ExitCode())
@@ -94,7 +94,7 @@ func Exec(root *cobra.Command) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	metrics.Track(store.DefaultContextName, os.Args[1:], root.PersistentFlags(), metrics.SuccessStatus)
+	metrics.Track(store.DefaultContextType, os.Args[1:], root.PersistentFlags(), metrics.SuccessStatus)
 
 	os.Exit(0)
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
fix sending context name instead of context type

**Related issue**
Red Desktop tests in https://github.com/docker/pinata/pull/14594

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://ichef.bbci.co.uk/news/480/cpsprodpb/E968/production/_97525795_hi041230215.jpg)