### PR TITLE
ACI Volumes : create takes one required arg, instead of required flag `--fileshare` 

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -30,7 +30,7 @@ func (c *volumeService) List(ctx context.Context) ([]volumes.Volume, error) {
 	return nil, errdefs.ErrNotImplemented
 }
 
-func (c *volumeService) Create(ctx context.Context, options interface{}) (volumes.Volume, error) {
+func (c *volumeService) Create(ctx context.Context, name string, options interface{}) (volumes.Volume, error) {
 	return volumes.Volume{}, errdefs.ErrNotImplemented
 }
 

--- a/api/volumes/api.go
+++ b/api/volumes/api.go
@@ -31,7 +31,7 @@ type Service interface {
 	// List returns all available volumes
 	List(ctx context.Context) ([]Volume, error)
 	// Create creates a new volume
-	Create(ctx context.Context, options interface{}) (Volume, error)
+	Create(ctx context.Context, name string, options interface{}) (Volume, error)
 	// Delete deletes an existing volume
 	Delete(ctx context.Context, volumeID string, options interface{}) error
 }

--- a/cli/cmd/volume/acivolume.go
+++ b/cli/cmd/volume/acivolume.go
@@ -47,9 +47,9 @@ func ACICommand() *cobra.Command {
 func createVolume() *cobra.Command {
 	aciOpts := aci.VolumeCreateOptions{}
 	cmd := &cobra.Command{
-		Use:   "create --storage-account ACCOUNT --fileshare FILESHARE",
+		Use:   "create --storage-account ACCOUNT VOLUME",
 		Short: "Creates an Azure file share to use as ACI volume.",
-		Args:  cobra.ExactArgs(0),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			c, err := client.New(ctx)
@@ -57,7 +57,7 @@ func createVolume() *cobra.Command {
 				return err
 			}
 			result, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
-				volume, err := c.VolumeService().Create(ctx, aciOpts)
+				volume, err := c.VolumeService().Create(ctx, args[0], aciOpts)
 				if err != nil {
 					return "", err
 				}
@@ -72,8 +72,6 @@ func createVolume() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&aciOpts.Account, "storage-account", "", "Storage account name")
-	cmd.Flags().StringVar(&aciOpts.Fileshare, "fileshare", "", "Fileshare name")
-	_ = cmd.MarkFlagRequired("fileshare")
 	_ = cmd.MarkFlagRequired("storage-account")
 	return cmd
 }

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -152,7 +152,7 @@ func TestContainerRunVolume(t *testing.T) {
 
 	t.Run("check empty volume name validity", func(t *testing.T) {
 		invalidName := ""
-		res := c.RunDockerOrExitError("volume", "create", "--storage-account", invalidName, "--fileshare", fileshareName)
+		res := c.RunDockerOrExitError("volume", "create", "--storage-account", invalidName, fileshareName)
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      `parameter=accountName constraint=MinLength value="" details: value length must be greater than or equal to 3`,
@@ -161,7 +161,7 @@ func TestContainerRunVolume(t *testing.T) {
 
 	t.Run("check volume name validity", func(t *testing.T) {
 		invalidName := "some-storage-123"
-		res := c.RunDockerOrExitError("volume", "create", "--storage-account", invalidName, "--fileshare", fileshareName)
+		res := c.RunDockerOrExitError("volume", "create", "--storage-account", invalidName, fileshareName)
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "some-storage-123 is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
@@ -169,7 +169,7 @@ func TestContainerRunVolume(t *testing.T) {
 	})
 
 	t.Run("create volumes", func(t *testing.T) {
-		c.RunDockerCmd("volume", "create", "--storage-account", accountName, "--fileshare", fileshareName)
+		c.RunDockerCmd("volume", "create", "--storage-account", accountName, fileshareName)
 	})
 	volumeID = accountName + "/" + fileshareName
 
@@ -181,7 +181,7 @@ func TestContainerRunVolume(t *testing.T) {
 	})
 
 	t.Run("create second fileshare", func(t *testing.T) {
-		c.RunDockerCmd("volume", "create", "--storage-account", accountName, "--fileshare", "dockertestshare2")
+		c.RunDockerCmd("volume", "create", "--storage-account", accountName, "dockertestshare2")
 	})
 	volumeID2 := accountName + "/dockertestshare2"
 


### PR DESCRIPTION
we still have required flag `--storage-account` specific to ACI

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* removed required CLI flag fileshare, add 1 required arg
* changed backend API to have a name in addition to ACI specific params, now only containing storage account.

**Related issue**
Following discussion with @rumpl in #640 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://static.boredpanda.com/blog/wp-content/uploads/2014/11/8e8qsBi__880.jpg)