### PR TITLE
Api metrics context: send context type, not contet name, and never fail

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -44,10 +44,16 @@ func New(ctx context.Context) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{
-		backendType: cc.Type(),
+	client := NewClient(cc.Type(), service)
+	return &client, nil
+}
+
+// NewClient returns new client
+func NewClient(backendType string, service backend.Service) Client {
+	return Client{
+		backendType: backendType,
 		bs:          service,
-	}, nil
+	}
 }
 
 // GetCloudService returns a backend CloudService (typically login, create context)
@@ -59,6 +65,11 @@ func GetCloudService(ctx context.Context, backendType string) (cloud.Service, er
 type Client struct {
 	backendType string
 	bs          backend.Service
+}
+
+// ContextType the context type associated with backend
+func (c *Client) ContextType() string {
+	return c.backendType
 }
 
 // ContainerService returns the backend service for the current context

--- a/server/interceptor.go
+++ b/server/interceptor.go
@@ -111,10 +111,7 @@ func configureContext(ctx context.Context, currentContext string, method string)
 			return nil, err
 		}
 
-		ctx, err = proxy.WithClient(ctx, c)
-		if err != nil {
-			return nil, err
-		}
+		ctx = proxy.WithClient(ctx, c)
 	}
 
 	s, err := store.New(configDir)

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -31,8 +31,8 @@ import (
 type clientKey struct{}
 
 // WithClient adds the client to the context
-func WithClient(ctx context.Context, c *client.Client) (context.Context, error) {
-	return context.WithValue(ctx, clientKey{}, c), nil
+func WithClient(ctx context.Context, c *client.Client) context.Context {
+	return context.WithValue(ctx, clientKey{}, c)
 }
 
 // Client returns the client from the context

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,7 @@ func New(ctx context.Context) *grpc.Server {
 	s := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			unaryServerInterceptor(ctx),
-			metricsServerInterceptor(ctx, metrics.NewClient()),
+			metricsServerInterceptor(metrics.NewClient()),
 		),
 		grpc.StreamInterceptor(streamServerInterceptor(ctx)),
 	)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* never fail in metrics interceptor
* send context type, not context name

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
