### PR TITLE
Update CI workflow to build fine on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Continuous integration
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Update workflow to run on PRs, and only on main branch (if on all branches, for every PR that would run one GH Action for the branch push on the fork, and one for the PR opening)

**Related issue**
Seen in #683 : build happens on push on forks, but the build notifications are not propagted to the PR

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://live.staticflickr.com/7253/7736029080_6040929613_n.jpg)