### PR TITLE
Label PRs touching to protos

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,7 @@ cli:
 
 api:
   - api/**/*
+  - protos/**/*
 
 ci:
   - .github/**/*


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Add *api* label to PRs touching to /protos

**Related issue**
noticed #640 did't get this label where I would have expected it

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://hips.hearstapps.com/ame-prod-goodhousekeeping-assets.s3.amazonaws.com/main/galleries/22257/International_hug_day_-_cute_animals_hugging_-_baby_lion_leopard_cub_and_monkey_-_unlikely_friendship_instagram_-_good_housekeeping_uk.jpg)