### PR TITLE
Allow user to set ami/machine by Deploy.Placement.Constraint

### DIFF
--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -88,23 +88,23 @@ type ecsAPIService struct {
 	aws    API
 }
 
-func (a *ecsAPIService) ContainerService() containers.Service {
+func (b *ecsAPIService) ContainerService() containers.Service {
 	return nil
 }
 
-func (a *ecsAPIService) ComposeService() compose.Service {
-	return a
+func (b *ecsAPIService) ComposeService() compose.Service {
+	return b
 }
 
-func (a *ecsAPIService) SecretsService() secrets.Service {
-	return a
+func (b *ecsAPIService) SecretsService() secrets.Service {
+	return b
 }
 
-func (a *ecsAPIService) VolumeService() volumes.Service {
+func (b *ecsAPIService) VolumeService() volumes.Service {
 	return nil
 }
 
-func (a *ecsAPIService) ResourceService() resources.Service {
+func (b *ecsAPIService) ResourceService() resources.Service {
 	return nil
 }
 

--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -23,21 +23,19 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/awslabs/goformation/v4/cloudformation/efs"
-
-	"github.com/golang/mock/gomock"
-
 	"github.com/docker/compose-cli/api/compose"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/awslabs/goformation/v4/cloudformation"
 	"github.com/awslabs/goformation/v4/cloudformation/ec2"
 	"github.com/awslabs/goformation/v4/cloudformation/ecs"
+	"github.com/awslabs/goformation/v4/cloudformation/efs"
 	"github.com/awslabs/goformation/v4/cloudformation/elasticloadbalancingv2"
 	"github.com/awslabs/goformation/v4/cloudformation/iam"
 	"github.com/awslabs/goformation/v4/cloudformation/logs"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
+	"github.com/golang/mock/gomock"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/ecs/compatibility.go
+++ b/ecs/compatibility.go
@@ -54,6 +54,8 @@ var compatibleComposeAttributes = []string{
 	"services.cap_drop",
 	"services.depends_on",
 	"services.deploy",
+	"services.deploy.placement",
+	"services.deploy.placement.constraints",
 	"services.deploy.replicas",
 	"services.deploy.resources.limits",
 	"services.deploy.resources.limits.cpus",

--- a/ecs/ec2_test.go
+++ b/ecs/ec2_test.go
@@ -1,0 +1,49 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
+	"gotest.tools/v3/assert"
+)
+
+func TestUserDefinedAMI(t *testing.T) {
+	template := convertYaml(t, `
+services:
+  test:
+    image: "image"
+    deploy:
+      placement:
+        constraints:
+          - "node.ami == ami123456789"
+          - "node.machine == t0.femto"
+      resources:
+        # devices:
+        #   - capabilities: ["gpu"]
+        reservations:
+          memory: 8Gb
+          generic_resources:
+            - discrete_resource_spec:
+                kind: gpus
+                value: 1                    
+`, useDefaultVPC)
+	lc := template.Resources["LaunchConfiguration"].(*autoscaling.LaunchConfiguration)
+	assert.Check(t, lc.ImageId == "ami123456789")
+	assert.Check(t, lc.InstanceType == "t0.femto")
+}


### PR DESCRIPTION
**What I did**
User can select custom AMI and machine type to configure CapacityProvider by setting `node.ami` and `node.machine` placement constraints

**Related issue**
https://github.com/docker/compose-cli/issues/661

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/94563030-69ce9c80-0266-11eb-9f74-157bad5c4889.png)
