### PR TITLE
Use bake for inner loop

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,77 @@
+variable "GIT_TAG" {
+    default = "dev"
+}
+
+variable "BUILD_TAGS" {
+    default = ""
+}
+
+function "validate-targets" {
+    params = []
+    result = ["validate-headers", "validate-go-mod"]
+}
+
+function "dev-build-args" {
+    params = [tag]
+    result = {
+        BUILD_TAGS = "example,local,ecs"
+        GIT_TAG = "${tag}"
+    }
+}
+
+group "default" {
+	targets = ["cli"]
+}
+
+group "validate" {
+    targets = validate-targets()
+}
+
+group "check" {
+    targets = concat(validate-targets(), ["import-restrictions", "test", "lint"])
+}
+
+target "cli" {
+    output = ["./bin"]
+    target = "cli"
+    platforms = ["local"]
+    args = dev-build-args("${GIT_TAG}")
+}
+
+target "cross" {
+    output = ["./bin"]
+    target = "cross"
+    args = {
+        BUILD_TAGS = "${BUILD_TAGS}"
+        GIT_TAG = "${GIT_TAG}"
+    }
+}
+
+target "test" {
+    target = "test"
+    args = dev-build-args("${GIT_TAG}")
+}
+
+target "lint" {
+    target = "lint"
+    args = {
+        GIT_TAG = "${GIT_TAG}"
+    }
+}
+
+target "import-restrictions" {
+    target = "import-restrictions"
+}
+
+target "validate-headers" {
+    target = "check-license-headers"
+}
+
+target "validate-go-mod" {
+    target = "check-go-mod"
+}
+
+target "protos" {
+    output = ["./protos"]
+    target = "protos"
+}


### PR DESCRIPTION
**What I did**
Added a simple `docker-bake.hcl` file for local development.

To improve performance for targets that don't output anything you can add `export BUILDX_NO_DEFAULT_LOAD=1` to your profile.

`GIT_TAG=$(git describe --tags --match "v[0-9]*") docker buildx bake [cli] == make [cli]`
`GIT_TAG=$(git describe --tags --match "v[0-9]*") docker buildx bake test == make test`
...