### PR TITLE
Regroup azure constants that might be things to switch in order to provide access to other azure clouds

### DIFF
--- a/aci/convert/registry_credentials.go
+++ b/aci/convert/registry_credentials.go
@@ -39,11 +39,10 @@ import (
 	"github.com/docker/compose-cli/aci/login"
 )
 
-// Specific username from ACR docs : https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md#getting-credentials-programatically
 const (
-	tokenUsername     = "00000000-0000-0000-0000-000000000000"
-	dockerHub         = "index.docker.io"
-	acrRegistrySuffix = ".azurecr.io"
+	// Specific username from ACR docs : https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md#getting-credentials-programatically
+	tokenUsername = "00000000-0000-0000-0000-000000000000"
+	dockerHub     = "index.docker.io"
 )
 
 type registryHelper interface {
@@ -128,7 +127,7 @@ func getUsedRegistries(project compose.Project) (map[string]bool, []string) {
 			registry = dockerHub
 		} else if !strings.Contains(registry, ".") {
 			registry = dockerHub
-		} else if strings.HasSuffix(registry, acrRegistrySuffix) {
+		} else if strings.HasSuffix(registry, login.AcrRegistrySuffix) {
 			acrRegistries = append(acrRegistries, registry)
 		}
 		usedRegistries[registry] = true

--- a/aci/login/helper.go
+++ b/aci/login/helper.go
@@ -49,7 +49,7 @@ type azureAPIHelper struct{}
 
 func (helper azureAPIHelper) getDeviceCodeFlowToken() (adal.Token, error) {
 	deviceconfig := auth.NewDeviceFlowConfig(clientID, "common")
-	deviceconfig.Resource = "https://management.core.windows.net/"
+	deviceconfig.Resource = azureManagementURL
 	spToken, err := deviceconfig.ServicePrincipalToken()
 	if err != nil {
 		return adal.Token{}, err

--- a/aci/login/login.go
+++ b/aci/login/login.go
@@ -38,12 +38,18 @@ import (
 
 //go login process, derived from code sample provided by MS at https://github.com/devigned/go-az-cli-stuff
 const (
-	authorizeFormat = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?response_type=code&client_id=%s&redirect_uri=%s&state=%s&prompt=select_account&response_mode=query&scope=%s"
-	tokenEndpoint   = "https://login.microsoftonline.com/%s/oauth2/v2.0/token"
-	getTenantURL    = "https://management.azure.com/tenants?api-version=2019-11-01"
+	// AcrRegistrySuffix suffix for ACR registry images
+	AcrRegistrySuffix         = ".azurecr.io"
+	activeDirectoryURL        = "https://login.microsoftonline.com"
+	azureManagementURL        = "https://management.core.windows.net/"
+	azureResouceManagementURL = "https://management.azure.com/"
+	authorizeFormat           = activeDirectoryURL + "/organizations/oauth2/v2.0/authorize?response_type=code&client_id=%s&redirect_uri=%s&state=%s&prompt=select_account&response_mode=query&scope=%s"
+	tokenEndpoint             = activeDirectoryURL + "/%s/oauth2/v2.0/token"
+	getTenantURL              = azureResouceManagementURL + "tenants?api-version=2019-11-01"
+
 	// scopes for a multi-tenant app works for openid, email, other common scopes, but fails when trying to add a token
 	// v1 scope like "https://management.azure.com/.default" for ARM access
-	scopes   = "offline_access https://management.azure.com/.default"
+	scopes   = "offline_access " + azureResouceManagementURL + ".default"
 	clientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" // Azure CLI client id
 )
 


### PR DESCRIPTION
See `az cloud list` to list endpoints specific to each azure cloud.
See #658 

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* regroup & de-duplicate azure constants

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://c0.wallpaperflare.com/preview/160/25/73/tortoise-water-photoshop-sea.jpg)