### PR TITLE
Fix ACI e2e : now we support passing commands, set `--domainname` before the image in the cmd

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -363,9 +363,9 @@ func TestContainerRunAttached(t *testing.T) {
 			"--restart", "on-failure",
 			"--memory", "0.1G", "--cpus", "0.1",
 			"-p", "80:80",
-			"nginx",
 			"--domainname",
 			dnsLabelName,
+			"nginx",
 		)
 		followLogsProcess = icmd.StartCmd(cmd)
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* changed order of parameters in e2e invocation

**Related issue**
https://github.com/docker/compose-cli/runs/1192523711, container logs show explicit error while ACI is trying to restart container in a loop : `starting container process caused "exec: \"--domainname\": executable file not found in $PATH"`

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://3.bp.blogspot.com/-crQNjQigyAg/Ttd5-MuQBqI/AAAAAAAABIU/2VX8RlbCgiI/s1600/Evil+Cute+Picture+Mouse+Spider+Funny+Photoshop+Hybrid.jpg)