### PR TITLE
Fix regression: let users login to local registry (no ‘.’ In registry name)

### DIFF
--- a/cli/cmd/login/login.go
+++ b/cli/cmd/login/login.go
@@ -19,14 +19,12 @@ package login
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/docker/compose-cli/cli/cmd/mobyflags"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/cli/cmd/mobyflags"
 	"github.com/docker/compose-cli/cli/mobycli"
 	"github.com/docker/compose-cli/errdefs"
 )
@@ -52,10 +50,6 @@ func Command() *cobra.Command {
 }
 
 func runLogin(cmd *cobra.Command, args []string) error {
-	if len(args) == 1 && !strings.Contains(args[0], ".") {
-		backend := args[0]
-		return errors.New("unknown backend type for cloud login: " + backend)
-	}
 	mobycli.Exec(cmd.Root())
 	return nil
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -205,9 +205,30 @@ func TestLoginCommandDelegation(t *testing.T) {
 		})
 	})
 
+	t.Run("localhost registry interactive", func(t *testing.T) {
+		res := c.RunDockerOrExitError("login", "localhost:443")
+		res.Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      "Cannot perform an interactive login from a non TTY device",
+		})
+	})
+
+	t.Run("localhost registry", func(t *testing.T) {
+		res := c.RunDockerOrExitError("login", "localhost", "-u", "user", "-p", "password")
+		res.Assert(t, icmd.Expected{
+			ExitCode: 1,
+			Err:      "http://localhost/v2/",
+		})
+	})
+
 	t.Run("logout", func(t *testing.T) {
 		res := c.RunDockerCmd("logout", "someregistry.docker.io")
-		res.Assert(t, icmd.Expected{Out: "someregistry.docker.io"})
+		res.Assert(t, icmd.Expected{Out: "Removing login credentials for someregistry.docker.io"})
+	})
+
+	t.Run("logout", func(t *testing.T) {
+		res := c.RunDockerCmd("logout", "localhost:443")
+		res.Assert(t, icmd.Expected{Out: "Removing login credentials for localhost:443"})
 	})
 
 	t.Run("existing context", func(t *testing.T) {
@@ -217,18 +238,6 @@ func TestLoginCommandDelegation(t *testing.T) {
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      "unauthorized: incorrect username or password",
-		})
-	})
-}
-
-func TestCloudLogin(t *testing.T) {
-	c := NewParallelE2eCLI(t, binDir)
-
-	t.Run("unknown backend", func(t *testing.T) {
-		res := c.RunDockerOrExitError("login", "mycloudbackend")
-		res.Assert(t, icmd.Expected{
-			ExitCode: 1,
-			Err:      "unknown backend type for cloud login: mycloudbackend",
 		})
 	})
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Removed login arg check since `azure` is now a subcommand and not a code path in the `login` command. 

**Related issue**
https://github.com/docker/compose-cli/issues/712

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://ae01.alicdn.com/kf/HTB1IjMwXOfrK1RjSspbq6A4pFXao.jpg_q50.jpg)