### PR TITLE
Remove CI cache on windows.

### DIFF
--- a/.github/workflows/optional-ci.yml
+++ b/.github/workflows/optional-ci.yml
@@ -118,11 +118,6 @@ jobs:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
-
       - name: Test
         env:
           BUILD_TAGS: example,local


### PR DESCRIPTION
It’s really slow to get ( see https://github.com/docker/compose-cli/runs/1198585654). Seems to download quite quickly, but takes more than 2 mins to untar ??


Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Just remove the cache action in Windows CI job

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/54/a5/c9/54a5c9d4280a0f70ca603d313292b1fb.jpg)