### PR TITLE
delete CapacityProvider before we invoke DeleteStack

### DIFF
--- a/ecs/aws.go
+++ b/ecs/aws.go
@@ -1,0 +1,22 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ecs
+
+const (
+	awsTypeCapacityProvider = "AWS::ECS::CapacityProvider"
+	awsTypeAutoscalingGroup = "AWS::AutoScaling::AutoScalingGroup"
+)

--- a/ecs/wait.go
+++ b/ecs/wait.go
@@ -28,8 +28,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 )
 
-func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, operation int) error { //nolint:gocyclo
+func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, operation int, ignored ...string) error { //nolint:gocyclo
 	knownEvents := map[string]struct{}{}
+	for _, id := range ignored {
+		knownEvents[id] = struct{}{}
+	}
+
 	// progress writer
 	w := progress.ContextWriter(ctx)
 	// Get the unique Stack ID so we can collect events without getting some from previous deployments with same name
@@ -78,7 +82,6 @@ func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, op
 			case "CREATE_COMPLETE":
 				if operation == stackCreate {
 					progressStatus = progress.Done
-
 				}
 			case "UPDATE_COMPLETE":
 				if operation == stackUpdate {


### PR DESCRIPTION
**What I did**
this is a workaround for CloudFormation issue to manage CapacityProvider <-> Cluster reverse dependency
`compose down` on ECS first delete the CapacityProvider and AutoscalingGroup (if present) by imperative API call then run `DeleteStack`. This prevent Cluster deletion by CloudFormation to fail


**Related issue**
https://github.com/docker/docker_aws/issues/43

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/94925750-063fab80-04c0-11eb-9a90-78ada28cf93e.png)

