### PR TITLE
Normalize case of command and flag help

### DIFF
--- a/cli/cmd/context/create.go
+++ b/cli/cmd/context/create.go
@@ -89,9 +89,9 @@ $ docker context create my-context --description "some description" --docker "ho
 	flags.String(
 		"default-stack-orchestrator", "",
 		"Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)")
-	flags.StringToString("docker", nil, "set the docker endpoint")
-	flags.StringToString("kubernetes", nil, "set the kubernetes endpoint")
-	flags.String("from", "", "create context from a named context")
+	flags.StringToString("docker", nil, "Set the docker endpoint")
+	flags.StringToString("kubernetes", nil, "Set the kubernetes endpoint")
+	flags.String("from", "", "Create context from a named context")
 
 	return cmd
 }

--- a/cli/cmd/context/rm.go
+++ b/cli/cmd/context/rm.go
@@ -44,7 +44,7 @@ func removeCommand() *cobra.Command {
 			return runRemove(cmd.Context(), args, opts.force)
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "force removing current context")
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force removing current context")
 
 	return cmd
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -139,11 +139,15 @@ func main() {
 		helpFunc(cmd, args)
 	})
 
-	root.PersistentFlags().BoolVarP(&opts.Debug, "debug", "D", false, "enable debug output in the logs")
+	root.PersistentFlags().BoolVarP(&opts.Debug, "debug", "D", false, "Enable debug output in the logs")
 	root.PersistentFlags().StringVarP(&opts.Host, "host", "H", "", "Daemon socket(s) to connect to")
 	opts.AddConfigFlags(root.PersistentFlags())
 	opts.AddContextFlags(root.PersistentFlags())
 	root.Flags().BoolVarP(&opts.Version, "version", "v", false, "Print version information and quit")
+
+	walk(root, func(c *cobra.Command) {
+		c.Flags().BoolP("help", "h", false, "Help for "+c.Name())
+	})
 
 	// populate the opts with the global flags
 	_ = root.PersistentFlags().Parse(os.Args[1:])
@@ -276,4 +280,11 @@ func determineCurrentContext(flag string, configDir string) string {
 		res = "default"
 	}
 	return res
+}
+
+func walk(c *cobra.Command, f func(*cobra.Command)) {
+	f(c)
+	for _, c := range c.Commands() {
+		walk(c, f)
+	}
 }

--- a/docs/cli/orig/context_create.md
+++ b/docs/cli/orig/context_create.md
@@ -50,9 +50,9 @@ Options:
                                             this context
                                             (swarm|kubernetes|all)
       --description string                  Description of the context
-      --docker stringToString               set the docker endpoint
+      --docker stringToString               Set the docker endpoint
                                             (default [])
-      --kubernetes stringToString           set the kubernetes endpoint
+      --kubernetes stringToString           Set the kubernetes endpoint
                                             (default [])
       --from string                         Create the context from an existing context
 ```


### PR DESCRIPTION
Signed-off-by: Amos Law <ahlaw.dev@gmail.com>

**What I did**
Normalize case of command help messages and add recursive function to override help flags.

**Related issue**
Fixes [#597](https://github.com/docker/compose-cli/issues/597)