### PR TITLE
Allow `docker context ls —formatter {{json.}}` to not delegate to Moby and include context type in the json

### DIFF
--- a/cli/cmd/context/ls.go
+++ b/cli/cmd/context/ls.go
@@ -69,7 +69,8 @@ func runList(cmd *cobra.Command, opts lsOpts) error {
 	if err != nil {
 		return err
 	}
-	if opts.format != "" && opts.format != formatter.JSON && opts.format != formatter.PRETTY {
+	format := strings.ToLower(strings.ReplaceAll(opts.format, " ", ""))
+	if format != "" && format != formatter.JSON && format != formatter.PRETTY && format != formatter.TemplateJSON {
 		mobycli.Exec(cmd.Root())
 		return nil
 	}
@@ -93,7 +94,7 @@ func runList(cmd *cobra.Command, opts lsOpts) error {
 		return nil
 	}
 
-	if opts.json {
+	if opts.json || format == formatter.JSON || format == formatter.TemplateJSON {
 		opts.format = formatter.JSON
 	}
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -58,7 +58,7 @@ func runVersion(cmd *cobra.Command, version string) {
 	case formatter.PRETTY, "":
 		versionString = strings.Replace(getOutFromMoby(cmd, fixedPrettyArgs(os.Args[1:])...),
 			"\n Version:", "\n Cloud integration:  "+displayedVersion+"\n Version:", 1)
-	case formatter.JSON, "{{json.}}": // Try to catch full JSON formats
+	case formatter.JSON, formatter.TemplateJSON: // Try to catch full JSON formats
 		versionString = strings.Replace(getOutFromMoby(cmd, fixedJSONArgs(os.Args[1:])...),
 			`"Version":`, fmt.Sprintf(`"CloudIntegration":%q,"Version":`, displayedVersion), 1)
 	default:

--- a/formatter/consts.go
+++ b/formatter/consts.go
@@ -19,6 +19,8 @@ package formatter
 const (
 	// JSON is the constant for Json formats on list commands
 	JSON = "json"
+	// TemplateJSON the legacy json formatting value using go template
+	TemplateJSON = "{{json.}}"
 	// PRETTY is the constant for default formats on list commands
 	PRETTY = "pretty"
 )

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -81,6 +81,12 @@ func TestContextDefault(t *testing.T) {
 
 		res = c.RunDockerCmd("context", "ls", "--format", "json")
 		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
+
+		res = c.RunDockerCmd("context", "ls", "--json")
+		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
+
+		res = c.RunDockerCmd("context", "ls", "--format", "{{ json . }}")
+		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
 	})
 
 	t.Run("inspect", func(t *testing.T) {
@@ -420,6 +426,13 @@ func TestVersion(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `"Client":`})
 		res = c.RunDockerCmd("version", "--format", "{{ json . }}")
 		res.Assert(t, icmd.Expected{Out: `"Client":`})
+	})
+
+	t.Run("format legacy", func(t *testing.T) {
+		res := c.RunDockerCmd("version", "-f", "{{ json .Client }}")
+		res.Assert(t, icmd.Expected{Out: `"DefaultAPIVersion":`})
+		res = c.RunDockerCmd("version", "--format", "{{ json .Server }}")
+		res.Assert(t, icmd.Expected{Out: `"KernelVersion":`})
 	})
 
 	t.Run("format cloud integration", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* `docker context ls` reads format `{{json.}}`as `json` 

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://www.hapskorea.com/wp-content/uploads/2015/04/Interview-Sarah-DeRemer.jpg)