### PR TITLE
Update Azure regions to deploy tests

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -57,8 +57,9 @@ const (
 )
 
 var (
-	binDir   string
-	location = []string{"eastus2"}
+	binDir string
+
+	location = []string{"westcentralus", "westus2", "eastus2", "southeastasia"}
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
remove region listed as available but rejected when trying to deploy e2e tests

**Related issue**
https://github.com/docker/compose-cli/runs/1208418337

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQv0VNHJGwZE8hLNfOP4qxuWlvd5S5Z1PZKpQ&usqp=CAU)