### PR TITLE
Add windows golden file for `context ls`

### DIFF
--- a/tests/e2e/testdata/ls-out-json-windows.golden
+++ b/tests/e2e/testdata/ls-out-json-windows.golden
@@ -1,0 +1,1 @@
+{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}


### PR DESCRIPTION
**What I did**
Added the windows correspondent golden file for `context ls`

You can add a / mention to run tests executed by default only on main branch : 
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
