### PR TITLE
Add detach flag to `compose up`

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -44,7 +44,7 @@ func newComposeService(ctx store.AciContext) aciComposeService {
 	}
 }
 
-func (cs *aciComposeService) Up(ctx context.Context, project *types.Project) error {
+func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, detach bool) error {
 	logrus.Debugf("Up on project with name %q", project.Name)
 	groupDefinition, err := convert.ToContainerGroup(ctx, cs.ctx, *project, cs.storageLogin)
 	addTag(&groupDefinition, composeContainerTag)

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -30,7 +30,7 @@ type composeService struct {
 }
 
 // Up executes the equivalent to a `compose up`
-func (c *composeService) Up(context.Context, *types.Project) error {
+func (c *composeService) Up(context.Context, *types.Project, bool) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -26,7 +26,7 @@ import (
 // Service manages a compose project
 type Service interface {
 	// Up executes the equivalent to a `compose up`
-	Up(ctx context.Context, project *types.Project) error
+	Up(ctx context.Context, project *types.Project, detach bool) error
 	// Down executes the equivalent to a `compose down`
 	Down(ctx context.Context, projectName string) error
 	// Logs executes the equivalent to a `compose logs`

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -34,6 +34,7 @@ type composeOptions struct {
 	ConfigPaths []string
 	Environment []string
 	Format      string
+	Detach      bool
 }
 
 func (o *composeOptions) toProjectName() (string, error) {

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -40,7 +40,7 @@ func upCommand(contextType string) *cobra.Command {
 	upCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
 	upCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	upCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")
-	upCmd.Flags().BoolP("detach", "d", true, " Detached mode: Run containers in the background")
+	upCmd.Flags().BoolVarP(&opts.Detach, "detach", "d", false, " Detached mode: Run containers in the background")
 
 	if contextType == store.AciContextType {
 		upCmd.Flags().StringVar(&opts.DomainName, "domainname", "", "Container NIS domain name")
@@ -68,8 +68,7 @@ func runUp(ctx context.Context, opts composeOptions) error {
 		if err != nil {
 			return "", err
 		}
-
-		return "", c.ComposeService().Up(ctx, project)
+		return "", c.ComposeService().Up(ctx, project, opts.Detach)
 	})
 	return err
 }

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -40,7 +40,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project) error {
+func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project, detach bool) error {
 	cmd := exec.Command("docker-compose", "version", "--short")
 	b := bytes.Buffer{}
 	b.WriteString("v")

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -26,7 +26,7 @@ import (
 	"github.com/compose-spec/compose-go/types"
 )
 
-func (b *ecsAPIService) Up(ctx context.Context, project *types.Project) error {
+func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, detach bool) error {
 	err := b.SDK.CheckRequirements(ctx, b.Region)
 	if err != nil {
 		return err
@@ -58,7 +58,9 @@ func (b *ecsAPIService) Up(ctx context.Context, project *types.Project) error {
 			return err
 		}
 	}
-
+	if detach {
+		return nil
+	}
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {

--- a/example/backend.go
+++ b/example/backend.go
@@ -131,7 +131,7 @@ func (cs *containerService) Delete(ctx context.Context, id string, request conta
 
 type composeService struct{}
 
-func (cs *composeService) Up(ctx context.Context, project *types.Project) error {
+func (cs *composeService) Up(ctx context.Context, project *types.Project, detach bool) error {
 	fmt.Printf("Up command on project %q", project.Name)
 	return nil
 }


### PR DESCRIPTION
Added a `detach` flag to the up api method that returns after stack creation if flag is set.

```
$ docker compose up -d
$ docker compose ls
NAME                STATUS
hello               Starting

$ docker compose ls
NAME                STATUS
hello               Running
```

/test-ecs

Closes https://github.com/docker/compose-cli/issues/666