### PR TITLE
restore status in addition to reason as progress message

### DIFF
--- a/ecs/wait.go
+++ b/ecs/wait.go
@@ -104,7 +104,7 @@ func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, op
 			w.Event(progress.Event{
 				ID:         resource,
 				Status:     progressStatus,
-				StatusText: reason,
+				StatusText: fmt.Sprintf("%s %s", status, reason),
 			})
 		}
 		if operation != stackCreate || stackErr != nil {


### PR DESCRIPTION
**What I did**
Prior to #706 progress message included `DELETE_COMPLETE` and e2e test is based on this string found on output.

**Related issue**
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
