### PR TITLE
Add version to UserAgent on  ACI

### DIFF
--- a/aci/login/client.go
+++ b/aci/login/client.go
@@ -27,9 +27,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/docker/compose-cli/errdefs"
+	"github.com/docker/compose-cli/internal"
 )
-
-const userAgent = "docker-cli"
 
 // NewContainerGroupsClient get client toi manipulate containerGrouos
 func NewContainerGroupsClient(subscriptionID string) (containerinstance.ContainerGroupsClient, error) {
@@ -45,7 +44,7 @@ func NewContainerGroupsClient(subscriptionID string) (containerinstance.Containe
 }
 
 func setupClient(aciClient *autorest.Client) error {
-	aciClient.UserAgent = userAgent
+	aciClient.UserAgent = internal.UserAgentName + "/" + internal.Version
 	auth, err := NewAuthorizerFromLogin()
 	if err != nil {
 		return err

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -15,6 +15,8 @@
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)
 
+PKG_NAME := github.com/docker/compose-cli
+
 PROTOS=$(shell find protos -name \*.proto)
 
 EXTENSION:=
@@ -26,7 +28,7 @@ STATIC_FLAGS=CGO_ENABLED=0
 
 GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
 
-LDFLAGS="-s -w -X main.version=${GIT_TAG}"
+LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG}"
 GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 
 BINARY?=bin/docker

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -26,18 +26,19 @@ import (
 	"github.com/docker/compose-cli/cli/cmd/mobyflags"
 	"github.com/docker/compose-cli/cli/mobycli"
 	"github.com/docker/compose-cli/formatter"
+	"github.com/docker/compose-cli/internal"
 )
 
 const formatOpt = "format"
 
 // VersionCommand command to display version
-func VersionCommand(version string) *cobra.Command {
+func VersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the Docker version information",
 		Args:  cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
-			runVersion(cmd, version)
+			runVersion(cmd)
 		},
 	}
 	// define flags for backward compatibility with com.docker.cli
@@ -49,15 +50,15 @@ func VersionCommand(version string) *cobra.Command {
 	return cmd
 }
 
-func runVersion(cmd *cobra.Command, version string) {
+func runVersion(cmd *cobra.Command) {
 	var versionString string
 	format := strings.ToLower(strings.ReplaceAll(cmd.Flag(formatOpt).Value.String(), " ", ""))
-	displayedVersion := strings.TrimPrefix(version, "v")
+	displayedVersion := strings.TrimPrefix(internal.Version, "v")
 	// Replace is preferred in this case to keep the order.
 	switch format {
 	case formatter.PRETTY, "":
 		versionString = strings.Replace(getOutFromMoby(cmd, fixedPrettyArgs(os.Args[1:])...),
-			"\n Version:", "\n Cloud integration:  "+displayedVersion+"\n Version:", 1)
+			"\n Version:", "\n Cloud integration: "+displayedVersion+"\n Version:", 1)
 	case formatter.JSON, formatter.TemplateJSON: // Try to catch full JSON formats
 		versionString = strings.Replace(getOutFromMoby(cmd, fixedJSONArgs(os.Args[1:])...),
 			`"Version":`, fmt.Sprintf(`"CloudIntegration":%q,"Version":`, displayedVersion), 1)

--- a/cli/main.go
+++ b/cli/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/docker/compose-cli/cli/cmd/login"
 	"github.com/docker/compose-cli/cli/cmd/logout"
 	"github.com/docker/compose-cli/cli/cmd/run"
-	volume "github.com/docker/compose-cli/cli/cmd/volume"
+	"github.com/docker/compose-cli/cli/cmd/volume"
 	"github.com/docker/compose-cli/cli/mobycli"
 	cliopts "github.com/docker/compose-cli/cli/options"
 	"github.com/docker/compose-cli/config"
@@ -52,10 +52,6 @@ import (
 	_ "github.com/docker/compose-cli/ecs/local"
 	_ "github.com/docker/compose-cli/example"
 	_ "github.com/docker/compose-cli/local"
-)
-
-var (
-	version = "dev"
 )
 
 var (
@@ -122,7 +118,7 @@ func main() {
 		cmd.InspectCommand(),
 		login.Command(),
 		logout.Command(),
-		cmd.VersionCommand(version),
+		cmd.VersionCommand(),
 		cmd.StopCommand(),
 		cmd.KillCommand(),
 		cmd.SecretCommand(),

--- a/ecs/sdk.go
+++ b/ecs/sdk.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/secrets"
+	"github.com/docker/compose-cli/internal"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -69,7 +70,7 @@ type sdk struct {
 
 func newSDK(sess *session.Session) sdk {
 	sess.Handlers.Build.PushBack(func(r *request.Request) {
-		request.AddToUserAgent(r, "Docker CLI")
+		request.AddToUserAgent(r, internal.ECSUserAgentName+"/"+internal.Version)
 	})
 	return sdk{
 		ECS: ecs.New(sess),

--- a/internal/variables.go
+++ b/internal/variables.go
@@ -1,0 +1,29 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+const (
+	// UserAgentName is the default user agent used by the cli
+	UserAgentName = "docker-cli"
+	// ECSUserAgentName is the ECS specific user agent used by the cli
+	ECSUserAgentName = "Docker CLI"
+)
+
+var (
+	// Version is the version of the CLI injected in compilation time
+	Version = "dev"
+)


### PR DESCRIPTION
**What I did**
Add version to UserAgent on  ACI
This also refactors the Version insertion to make it global

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/619

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![version](https://user-images.githubusercontent.com/373485/95339144-0838ae80-08b4-11eb-93a2-7aa2f3f37ce5.jpg)
