### PR TITLE
Fix e2e-aci tests on comparing with empty string

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -384,7 +384,7 @@ func TestContainerRunAttached(t *testing.T) {
 
 		checkRunning := func(t poll.LogT) poll.Result {
 			res := c.RunDockerOrExitError("inspect", container)
-			if res.ExitCode == 0 && strings.Contains(res.Stdout(), `"Status": "Running"`) {
+			if res.ExitCode == 0 && strings.Contains(res.Stdout(), `"Status": "Running"`) && !strings.Contains(res.Stdout(), `"HostIP": ""`) {
 				return poll.Success()
 			}
 			return poll.Continue("waiting for container to be running, current inspect result: \n%s", res.Combined())
@@ -404,7 +404,7 @@ func TestContainerRunAttached(t *testing.T) {
 
 		assert.Assert(t, is.Len(containerInspect.Ports, 1))
 		port := containerInspect.Ports[0]
-		assert.Assert(t, port.HostIP != "")
+		assert.Assert(t, port.HostIP != "", "empty hostIP, inspect: \n"+inspectRes.Stdout())
 		assert.Equal(t, port.ContainerPort, uint32(80))
 		assert.Equal(t, port.HostPort, uint32(80))
 		assert.Equal(t, containerInspect.Config.FQDN, fqdn)

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -404,7 +404,7 @@ func TestContainerRunAttached(t *testing.T) {
 
 		assert.Assert(t, is.Len(containerInspect.Ports, 1))
 		port := containerInspect.Ports[0]
-		assert.Assert(t, len(port.HostIP) > 0)
+		assert.Assert(t, port.HostIP != "")
 		assert.Equal(t, port.ContainerPort, uint32(80))
 		assert.Equal(t, port.HostPort, uint32(80))
 		assert.Equal(t, containerInspect.Config.FQDN, fqdn)

--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -207,7 +207,7 @@ func ParseContainerInspect(stdout string) (*containers.Container, error) {
 	return &res, nil
 }
 
-// HTTPGetWithRetry performs an HTTP GET on an `endpoint`.
+// HTTPGetWithRetry performs an HTTP GET on an `endpoint`, using retryDelay also as a request timeout.
 // In the case of an error or the response status is not the expeted one, it retries the same request,
 // returning the response body as a string (empty if we could not reach it)
 func HTTPGetWithRetry(t *testing.T, endpoint string, expectedStatus int, retryDelay time.Duration, timeout time.Duration) string {
@@ -215,8 +215,11 @@ func HTTPGetWithRetry(t *testing.T, endpoint string, expectedStatus int, retryDe
 		r   *http.Response
 		err error
 	)
+	client := &http.Client{
+		Timeout: retryDelay * time.Second,
+	}
 	checkUp := func(t poll.LogT) poll.Result {
-		r, err = http.Get(endpoint)
+		r, err = client.Get(endpoint)
 		if err != nil {
 			return poll.Continue("reaching %q: Error %s", endpoint, err.Error())
 		}


### PR DESCRIPTION
**What I did**
Fix `e2e-aci` tests on comparing with empty string.
It's not that the old code is not "correct", but the comparison wasn't getting to the right assertion. When printing the value just before or comparing the empty string, that went back to work.

I'm not sure what happened here, maybe that's a GO specifics that I ignore. Anyways, IMHO comparing with empty string even looks more readable.

**Tests**
/test-aci
