### PR TITLE
Add --quiet for some commands

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -114,6 +114,8 @@ func (a *aciAPIService) ComposeService() compose.Service {
 }
 
 func (a *aciAPIService) SecretsService() secrets.Service {
+	// Not implemented on ACI
+	// Secrets are created and mounted in the container at it's creation and not stored on ACI
 	return nil
 }
 

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/compose-spec/compose-go/cli"
+	"github.com/spf13/pflag"
 
 	"github.com/spf13/cobra"
 
@@ -35,6 +36,13 @@ type composeOptions struct {
 	Environment []string
 	Format      string
 	Detach      bool
+	Quiet       bool
+}
+
+func addComposeCommonFlags(f *pflag.FlagSet, opts *composeOptions) {
+	f.StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	f.StringVar(&opts.Format, "format", "", "Format the output. Values: [pretty | json]. (Default: pretty)")
+	f.BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs")
 }
 
 func (o *composeOptions) toProjectName() (string, error) {

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
@@ -43,11 +42,6 @@ func listCommand() *cobra.Command {
 	return lsCmd
 }
 
-func addComposeCommonFlags(f *pflag.FlagSet, opts *composeOptions) {
-	f.StringVarP(&opts.Name, "project-name", "p", "", "Project name")
-	f.StringVar(&opts.Format, "format", "", "Format the output. Values: [pretty | json]. (Default: pretty)")
-}
-
 func runList(ctx context.Context, opts composeOptions) error {
 	c, err := client.New(ctx)
 	if err != nil {
@@ -57,7 +51,12 @@ func runList(ctx context.Context, opts composeOptions) error {
 	if err != nil {
 		return err
 	}
-
+	if opts.Quiet {
+		for _, s := range stackList {
+			fmt.Println(s.Name)
+		}
+		return nil
+	}
 	view := viewFromStackList(stackList)
 	return formatter.Print(view, opts.Format, os.Stdout, func(w io.Writer) {
 		for _, stack := range view {

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -58,7 +58,12 @@ func runPs(ctx context.Context, opts composeOptions) error {
 	if err != nil {
 		return err
 	}
-
+	if opts.Quiet {
+		for _, s := range serviceList {
+			fmt.Println(s.ID)
+		}
+		return nil
+	}
 	view := viewFromServiceStatusList(serviceList)
 	return formatter.Print(view, opts.Format, os.Stdout,
 		func(w io.Writer) {

--- a/cli/cmd/secrets.go
+++ b/cli/cmd/secrets.go
@@ -106,6 +106,7 @@ func inspectSecret() *cobra.Command {
 
 type listSecretsOpts struct {
 	format string
+	quiet  bool
 }
 
 func listSecrets() *cobra.Command {
@@ -123,6 +124,12 @@ func listSecrets() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if opts.quiet {
+				for _, s := range secretsList {
+					fmt.Println(s.ID)
+				}
+				return nil
+			}
 			view := viewFromSecretList(secretsList)
 			return formatter.Print(view, opts.format, os.Stdout, func(w io.Writer) {
 				for _, secret := range view {
@@ -132,6 +139,7 @@ func listSecrets() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.format, "format", "", "Format the output. Values: [pretty | json]. (Default: pretty)")
+	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Only display IDs")
 	return cmd
 }
 

--- a/cli/cmd/volume/list.go
+++ b/cli/cmd/volume/list.go
@@ -30,6 +30,7 @@ import (
 
 type listVolumeOpts struct {
 	format string
+	quiet  bool
 }
 
 func listVolume() *cobra.Command {
@@ -47,6 +48,12 @@ func listVolume() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if opts.quiet {
+				for _, v := range vols {
+					fmt.Println(v.ID)
+				}
+				return nil
+			}
 			view := viewFromVolumeList(vols)
 			return formatter.Print(view, opts.format, os.Stdout, func(w io.Writer) {
 				for _, vol := range view {
@@ -56,6 +63,7 @@ func listVolume() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.format, "format", formatter.PRETTY, "Format the output. Values: [pretty | json]. (Default: pretty)")
+	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Only display IDs")
 	return cmd
 }
 

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -209,13 +209,19 @@ func TestRunVolume(t *testing.T) {
 	volumeID2 := accountName + "/dockertestshare2"
 
 	t.Run("list volumes", func(t *testing.T) {
-		res := c.RunDockerCmd("volume", "ls")
-		lines := lines(res.Stdout())
-		assert.Equal(t, len(lines), 3)
-		firstAccount := lines[1]
+		res := c.RunDockerCmd("volume", "ls", "--quiet")
+		l := lines(res.Stdout())
+		assert.Equal(t, len(l), 2)
+		assert.Equal(t, l[0], volumeID)
+		assert.Equal(t, l[1], volumeID2)
+
+		res = c.RunDockerCmd("volume", "ls")
+		l = lines(res.Stdout())
+		assert.Equal(t, len(l), 3)
+		firstAccount := l[1]
 		fields := strings.Fields(firstAccount)
 		assert.Equal(t, fields[0], volumeID)
-		secondAccount := lines[2]
+		secondAccount := l[2]
 		fields = strings.Fields(secondAccount)
 		assert.Equal(t, fields[0], volumeID2)
 	})
@@ -611,11 +617,15 @@ func TestUpUpdate(t *testing.T) {
 	})
 
 	t.Run("compose ps", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ps", "--project-name", composeProjectName)
-		lines := lines(res.Stdout())
-		assert.Assert(t, is.Len(lines, 4))
+		res := c.RunDockerCmd("compose", "ps", "--project-name", composeProjectName, "--quiet")
+		l := lines(res.Stdout())
+		assert.Assert(t, is.Len(l, 3))
+
+		res = c.RunDockerCmd("compose", "ps", "--project-name", composeProjectName)
+		l = lines(res.Stdout())
+		assert.Assert(t, is.Len(l, 4))
 		var wordsDisplayed, webDisplayed, dbDisplayed bool
-		for _, line := range lines {
+		for _, line := range l {
 			fields := strings.Fields(line)
 			containerID := fields[0]
 			switch containerID {
@@ -635,11 +645,14 @@ func TestUpUpdate(t *testing.T) {
 	})
 
 	t.Run("compose ls", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ls")
-		lines := lines(res.Stdout())
+		res := c.RunDockerCmd("compose", "ls", "--quiet")
+		l := lines(res.Stdout())
+		assert.Assert(t, is.Len(l, 1))
+		res = c.RunDockerCmd("compose", "ls")
+		l = lines(res.Stdout())
 
-		assert.Equal(t, 2, len(lines))
-		fields := strings.Fields(lines[1])
+		assert.Equal(t, 2, len(l))
+		fields := strings.Fields(l[1])
 		assert.Equal(t, 2, len(fields))
 		assert.Equal(t, fields[0], composeProjectName)
 		assert.Equal(t, "Running", fields[1])


### PR DESCRIPTION
**What I did**

Add `--quiet` for some commands
- compose ls
- compose ps
- secret ls
- volume ls

**Tests**
/test-aci

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/745

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
