### PR TITLE
Trim line returns for windows tests

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -796,7 +796,7 @@ func TestRunEnvVars(t *testing.T) {
 			}
 			return poll.Continue("waiting for DB container to be up")
 		}
-		poll.WaitOn(t, check, poll.WithDelay(5*time.Second), poll.WithTimeout(60*time.Second))
+		poll.WaitOn(t, check, poll.WithDelay(5*time.Second), poll.WithTimeout(90*time.Second))
 	})
 }
 

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -563,9 +563,12 @@ func TestUpSecrets(t *testing.T) {
 		endpoint := fmt.Sprintf("http://%s:%d", containerInspect.Ports[0].HostIP, containerInspect.Ports[0].HostPort)
 
 		output := HTTPGetWithRetry(t, endpoint+"/"+secret1Name, http.StatusOK, 2*time.Second, 20*time.Second)
+		// replace windows carriage return
+		output = strings.ReplaceAll(output, "\r", "")
 		assert.Equal(t, output, secret1Value)
 
 		output = HTTPGetWithRetry(t, endpoint+"/"+secret2Name, http.StatusOK, 2*time.Second, 20*time.Second)
+		output = strings.ReplaceAll(output, "\r", "")
 		assert.Equal(t, output, secret2Value)
 
 		t.Cleanup(func() {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Trim line return to fix tests on windows

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
https://github.com/docker/compose-cli/runs/1242211704

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/5d/74/4d/5d744dd5ae5d272b52c2e55999b633c3.jpg)