### PR TITLE
Add debug information when mysql cannot start on ACI E2E test

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -810,7 +810,7 @@ func TestRunEnvVars(t *testing.T) {
 			if strings.Contains(res.Stdout(), "Giving user user1 access to schema mytestdb") {
 				return poll.Success()
 			}
-			return poll.Continue("waiting for DB container to be up")
+			return poll.Continue("waiting for DB container to be up\n%s", res.Combined())
 		}
 		poll.WaitOn(t, check, poll.WithDelay(5*time.Second), poll.WithTimeout(90*time.Second))
 	})


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Add DB log info when DB cannot start 

**Related issue**
https://github.com/docker/compose-cli/runs/1246145363

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://149352953.v2.pressablecdn.com/wp-content/uploads/2015/01/animal-food-2.jpg)