### PR TITLE
Disabling mysql ACI test again, see https://github.com/docker/compose-cli/runs/1246970427

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -770,6 +770,7 @@ func TestUpUpdate(t *testing.T) {
 	})
 }
 
+/*
 func TestRunEnvVars(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 	_, _, _ = setupTestResourceGroup(t, c)
@@ -815,6 +816,7 @@ func TestRunEnvVars(t *testing.T) {
 		poll.WaitOn(t, check, poll.WithDelay(5*time.Second), poll.WithTimeout(90*time.Second))
 	})
 }
+*/
 
 func setupTestResourceGroup(t *testing.T, c *E2eCLI) (string, string, string) {
 	startTime := strconv.Itoa(int(time.Now().Unix()))


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
This deployment is too flaky, still associated with new logs from the Atlas platform

**Related issue**
https://github.com/docker/compose-cli/runs/1246970427

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
