### PR TITLE
Fix panic when invoking inspect with empty container id 

### DIFF
--- a/aci/containers.go
+++ b/aci/containers.go
@@ -235,12 +235,15 @@ func (cs *aciContainerService) Delete(ctx context.Context, containerID string, r
 
 func (cs *aciContainerService) Inspect(ctx context.Context, containerID string) (containers.Container, error) {
 	groupName, containerName := getGroupAndContainerName(containerID)
+	if containerID == "" {
+		return containers.Container{}, errors.New("cannot inspect empty container ID")
+	}
 
 	cg, err := getACIContainerGroup(ctx, cs.ctx, groupName)
 	if err != nil {
 		return containers.Container{}, err
 	}
-	if cg.StatusCode == http.StatusNoContent {
+	if cg.IsHTTPStatus(http.StatusNoContent) || cg.ContainerGroupProperties == nil || cg.ContainerGroupProperties.Containers == nil {
 		return containers.Container{}, errdefs.ErrNotFound
 	}
 


### PR DESCRIPTION
ACI SDK returns status 200 but nil container group properties

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Check for empty container ID, and never dereference nil pointer

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
/test-aci