### PR TITLE
Extract ACI_DNS_SIDECAR_IMAGE

### DIFF
--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
 	"github.com/docker/compose-cli/context/store"
+	"github.com/docker/compose-cli/internal"
 	"github.com/docker/compose-cli/utils/formatter"
 )
 
@@ -44,7 +45,6 @@ const (
 	// ComposeDNSSidecarName name of the dns sidecar container
 	ComposeDNSSidecarName = "aci--dns--sidecar"
 
-	dnsSidecarImage                = "busybox:1.31.1"
 	azureFileDriverName            = "azure_file"
 	volumeDriveroptsShareNameKey   = "share_name"
 	volumeDriveroptsAccountNameKey = "storage_account_name"
@@ -173,7 +173,7 @@ func getDNSSidecar(containers []containerinstance.Container) containerinstance.C
 	dnsSideCar := containerinstance.Container{
 		Name: to.StringPtr(ComposeDNSSidecarName),
 		ContainerProperties: &containerinstance.ContainerProperties{
-			Image:   to.StringPtr(dnsSidecarImage),
+			Image:   to.StringPtr(internal.ACIDNSSidecarImage),
 			Command: &alpineCmd,
 			Resources: &containerinstance.ResourceRequirements{
 				Requests: &containerinstance.ResourceRequests{

--- a/aci/convert/convert_test.go
+++ b/aci/convert/convert_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
 	"github.com/docker/compose-cli/context/store"
+	"github.com/docker/compose-cli/internal"
 )
 
 var (
@@ -185,7 +186,7 @@ func TestComposeContainerGroupToContainerWithDnsSideCarSide(t *testing.T) {
 
 	assert.Equal(t, *(*group.Containers)[0].Image, "image1")
 	assert.Equal(t, *(*group.Containers)[1].Image, "image2")
-	assert.Equal(t, *(*group.Containers)[2].Image, dnsSidecarImage)
+	assert.Equal(t, *(*group.Containers)[2].Image, internal.ACIDNSSidecarImage)
 }
 
 func TestComposeSingleContainerGroupToContainerNoDnsSideCarSide(t *testing.T) {

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -12,6 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+include vars.mk
+
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)
 
@@ -28,7 +30,10 @@ STATIC_FLAGS=CGO_ENABLED=0
 
 GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
 
-LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG}"
+INJECTED_VARS:=${INJECTED_VARS} -X $(PKG_NAME)/internal.Version=${GIT_TAG}
+INJECTED_VARS:=${INJECTED_VARS} -X $(PKG_NAME)/internal.ACIDNSSidecarImage=${ACI_DNS_SIDECAR_IMAGE}
+
+LDFLAGS="-s -w $(INJECTED_VARS)"
 GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 
 BINARY?=bin/docker

--- a/internal/variables.go
+++ b/internal/variables.go
@@ -16,6 +16,9 @@
 
 package internal
 
+// UNDEFINED is the placeholder to variables that have to be specified at build time
+const UNDEFINED = `Undefined! To be injected in the build. Please check "vars.mk" and "builder.Makefile"`
+
 const (
 	// UserAgentName is the default user agent used by the cli
 	UserAgentName = "docker-cli"
@@ -23,7 +26,10 @@ const (
 	ECSUserAgentName = "Docker CLI"
 )
 
+// The variables below are injected on build time
 var (
 	// Version is the version of the CLI injected in compilation time
 	Version = "dev"
+	// ACIDNSSidecarImage is the image used by the side car container in ACI
+	ACIDNSSidecarImage = UNDEFINED
 )

--- a/vars.mk
+++ b/vars.mk
@@ -1,0 +1,1 @@
+ACI_DNS_SIDECAR_IMAGE=busybox:1.32.0


### PR DESCRIPTION
**What I did**
Propose the extraction of the ACI sidecar image specification to a "config" file then injected during the build. 
This would make it easier to bump versions afterwards.

**Tests**
/test-aci