### PR TITLE
Trying to Re-re enable ACI mysql E2E test, showing logs in case of error waiting for DB

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -770,7 +770,6 @@ func TestUpUpdate(t *testing.T) {
 	})
 }
 
-/*
 func TestRunEnvVars(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 	_, _, _ = setupTestResourceGroup(t, c)
@@ -816,7 +815,6 @@ func TestRunEnvVars(t *testing.T) {
 		poll.WaitOn(t, check, poll.WithDelay(5*time.Second), poll.WithTimeout(90*time.Second))
 	})
 }
-*/
 
 func setupTestResourceGroup(t *testing.T, c *E2eCLI) (string, string, string) {
 	startTime := strconv.Itoa(int(time.Now().Unix()))


### PR DESCRIPTION

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Uncommented test

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRfG1CQKYVo8NeH9kSykYnv8lpgn6AkJc_rLg&usqp=CAU)