### PR TITLE
add support for ulimits.nofile

### DIFF
--- a/ecs/compatibility.go
+++ b/ecs/compatibility.go
@@ -135,3 +135,12 @@ func (c *fargateCompatibilityChecker) CheckLoggingDriver(config *types.LoggingCo
 		c.Unsupported("services.logging.driver %s is not supported", config.Driver)
 	}
 }
+
+func (c *fargateCompatibilityChecker) CheckUlimits(service *types.ServiceConfig) {
+	for k := range service.Ulimits {
+		if k != "nofile" {
+			c.Unsupported("services.ulimits.%s is not supported by Fargate", k)
+			delete(service.Ulimits, k)
+		}
+	}
+}

--- a/ecs/down.go
+++ b/ecs/down.go
@@ -28,12 +28,12 @@ func (b *ecsAPIService) Down(ctx context.Context, project string) error {
 		return err
 	}
 
-	err = resources.apply(awsTypeCapacityProvider, delete(ctx, b.aws.DeleteCapacityProvider))
+	err = resources.apply(awsTypeCapacityProvider, doDelete(ctx, b.aws.DeleteCapacityProvider))
 	if err != nil {
 		return err
 	}
 
-	err = resources.apply(awsTypeAutoscalingGroup, delete(ctx, b.aws.DeleteAutoscalingGroup))
+	err = resources.apply(awsTypeAutoscalingGroup, doDelete(ctx, b.aws.DeleteAutoscalingGroup))
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (b *ecsAPIService) previousStackEvents(ctx context.Context, project string)
 	return previousEvents, nil
 }
 
-func delete(ctx context.Context, delete func(ctx context.Context, arn string) error) func(r stackResource) error {
+func doDelete(ctx context.Context, delete func(ctx context.Context, arn string) error) func(r stackResource) error {
 	return func(r stackResource) error {
 		w := progress.ContextWriter(ctx)
 		w.Event(progress.Event{


### PR DESCRIPTION
**What I did**
Claim support for `services.ulimits` - conversion was actually already implemented
According to ECS docs, fargate only allows use of `nofile` ulimit, so the custom CompatibilityChecker

**Related issue**
fix https://github.com/docker/compose-cli/issues/664

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/95953526-35c4b100-0dfa-11eb-8258-2d3c9c32663c.png)

