### PR TITLE
Document cross build step reason & timing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
           path: ~/go/pkg/mod
           key: go-${{ hashFiles('**/go.sum') }}
 
+      # Ensure we don't discover cross platform build issues at release time.
+      # Time used to build linux here is gained back in the build for local E2E step
       - name: Build packages
         run: make -f builder.Makefile cross
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Check CI exec timing and decided to keep full cross compile, rather than specifically compile for  darwin, since the  overall exec time will not be that different
* document why we have this step in CI

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://marenahhs.weebly.com/uploads/9/8/9/7/9897312/8252870_orig.jpg)