### PR TITLE
Let user pass EFS create option by driver_opts

### DIFF
--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -58,7 +58,10 @@ func (b *ecsAPIService) convert(ctx context.Context, project *types.Project) (*c
 	}
 
 	template := cloudformation.NewTemplate()
-	b.ensureResources(&resources, project, template)
+	err = b.ensureResources(&resources, project, template)
+	if err != nil {
+		return nil, err
+	}
 
 	for name, secret := range project.Secrets {
 		err := b.createSecret(project, name, secret, template)
@@ -439,6 +442,10 @@ func networkResourceName(network string) string {
 
 func serviceResourceName(service string) string {
 	return fmt.Sprintf("%sService", normalizeResourceName(service))
+}
+
+func volumeResourceName(service string) string {
+	return fmt.Sprintf("%sFilesystem", normalizeResourceName(service))
 }
 
 func normalizeResourceName(s string) string {

--- a/ecs/compatibility.go
+++ b/ecs/compatibility.go
@@ -98,6 +98,7 @@ var compatibleComposeAttributes = []string{
 	"volumes",
 	"volumes.external",
 	"volumes.name",
+	"volumes.driver_opts",
 	"networks.external",
 	"networks.name",
 }


### PR DESCRIPTION
**What I did**

Allow user to pass EFS volume options by `driver_opts` in volume configuration

Move volume creation into cloudformation template with `Retain` policy so it survives `down`, reports on console as `DELETE_SKIPPED`


**Related issue**
fixes #781

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/95969322-d91fc100-0e0e-11eb-90b9-752462bcb373.png)
