### PR TITLE
ACI docker prune

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -97,6 +97,9 @@ func getAciAPIService(aciCtx store.AciContext) *aciAPIService {
 		aciVolumeService: &aciVolumeService{
 			aciContext: aciCtx,
 		},
+		aciResourceService: &aciResourceService{
+			aciContext: aciCtx,
+		},
 	}
 }
 

--- a/aci/backend.go
+++ b/aci/backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/compose-cli/aci/login"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/backend"
@@ -103,6 +104,7 @@ type aciAPIService struct {
 	*aciContainerService
 	*aciComposeService
 	*aciVolumeService
+	*aciResourceService
 }
 
 func (a *aciAPIService) ContainerService() containers.Service {
@@ -121,6 +123,10 @@ func (a *aciAPIService) SecretsService() secrets.Service {
 
 func (a *aciAPIService) VolumeService() volumes.Service {
 	return a.aciVolumeService
+}
+
+func (a *aciAPIService) ResourceService() resources.Service {
+	return a.aciResourceService
 }
 
 func getContainerID(group containerinstance.ContainerGroup, container containerinstance.Container) string {

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -542,12 +542,17 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 
 // GetStatus returns status for the specified container
 func GetStatus(container containerinstance.Container, group containerinstance.ContainerGroup) string {
-	status := compose.UNKNOWN
-	if group.InstanceView != nil && group.InstanceView.State != nil {
-		status = "Node " + *group.InstanceView.State
-	}
+	status := GetGroupStatus(group)
 	if container.InstanceView != nil && container.InstanceView.CurrentState != nil {
 		status = *container.InstanceView.CurrentState.State
 	}
 	return status
+}
+
+// GetGroupStatus returns status for the container group
+func GetGroupStatus(group containerinstance.ContainerGroup) string {
+	if group.InstanceView != nil && group.InstanceView.State != nil {
+		return "Node " + *group.InstanceView.State
+	}
+	return compose.UNKNOWN
 }

--- a/aci/resources.go
+++ b/aci/resources.go
@@ -1,0 +1,34 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package aci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/compose-cli/api/resources"
+	"github.com/docker/compose-cli/context/store"
+)
+
+type aciResourceService struct {
+	aciContext store.AciContext
+}
+
+func (cs *aciResourceService) Prune(ctx context.Context, request resources.PruneRequest) ([]string, error) {
+	fmt.Println("PRUNE " + cs.aciContext.ResourceGroup)
+	return nil, nil
+}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/backend"
@@ -106,4 +107,13 @@ func (c *Client) VolumeService() volumes.Service {
 	}
 
 	return &volumeService{}
+}
+
+// ResourceService returns the backend service for the current context
+func (c *Client) ResourceService() resources.Service {
+	if vs := c.bs.ResourceService(); vs != nil {
+		return vs
+	}
+
+	return &resourceService{}
 }

--- a/api/client/resources.go
+++ b/api/client/resources.go
@@ -14,20 +14,19 @@
    limitations under the License.
 */
 
-package resources
+package client
 
 import (
 	"context"
+
+	"github.com/docker/compose-cli/api/resources"
+	"github.com/docker/compose-cli/errdefs"
 )
 
-// PruneRequest options on what to prune
-type PruneRequest struct {
-	Force  bool
-	DryRun bool
+type resourceService struct {
 }
 
-// Service interacts with the underlying container backend
-type Service interface {
-	// Prune prune resources
-	Prune(ctx context.Context, request PruneRequest) ([]string, error)
+// Prune prune resources
+func (c *resourceService) Prune(ctx context.Context, request resources.PruneRequest) ([]string, error) {
+	return nil, errdefs.ErrNotImplemented
 }

--- a/api/resources/api.go
+++ b/api/resources/api.go
@@ -1,0 +1,32 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+)
+
+// PruneRequest options on what to prune
+type PruneRequest struct {
+	Force bool
+}
+
+// Service interacts with the underlying container backend
+type Service interface {
+	// Prune prune resources
+	Prune(ctx context.Context, request PruneRequest) ([]string, error)
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/context/cloud"
@@ -55,6 +56,7 @@ var backends = struct {
 type Service interface {
 	ContainerService() containers.Service
 	ComposeService() compose.Service
+	ResourceService() resources.Service
 	SecretsService() secrets.Service
 	VolumeService() volumes.Service
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -1,0 +1,69 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/resources"
+)
+
+type pruneOpts struct {
+	force  bool
+	dryRun bool
+}
+
+// PruneCommand deletes backend resources
+func PruneCommand() *cobra.Command {
+	var opts pruneOpts
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "prune existing resources in current context",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPrune(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.force, "force", false, "Also prune running containers and Compose applications")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "List resources to be deleted, but do not delete them")
+
+	return cmd
+}
+
+func runPrune(ctx context.Context, opts pruneOpts) error {
+	c, err := client.New(ctx)
+	if err != nil {
+		return errors.Wrap(err, "cannot connect to backend")
+	}
+
+	ids, err := c.ResourceService().Prune(ctx, resources.PruneRequest{Force: opts.force, DryRun: opts.dryRun})
+	if opts.dryRun {
+		fmt.Println("resources that would be deleted:")
+	} else {
+		fmt.Println("deleted resources:")
+	}
+	for _, id := range ids {
+		fmt.Println(id)
+	}
+	return err
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -122,6 +122,7 @@ func main() {
 		cmd.StopCommand(),
 		cmd.KillCommand(),
 		cmd.SecretCommand(),
+		cmd.PruneCommand(),
 
 		// Place holders
 		cmd.EcsCommand(),

--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/backend"
@@ -100,6 +101,10 @@ func (a *ecsAPIService) SecretsService() secrets.Service {
 }
 
 func (a *ecsAPIService) VolumeService() volumes.Service {
+	return nil
+}
+
+func (a *ecsAPIService) ResourceService() resources.Service {
 	return nil
 }
 

--- a/ecs/local/backend.go
+++ b/ecs/local/backend.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/backend"
@@ -69,4 +70,8 @@ func (e ecsLocalSimulation) SecretsService() secrets.Service {
 
 func (e ecsLocalSimulation) ComposeService() compose.Service {
 	return e
+}
+
+func (e ecsLocalSimulation) ResourceService() resources.Service {
+	return nil
 }

--- a/example/backend.go
+++ b/example/backend.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/backend"
@@ -56,6 +57,10 @@ func (a *apiService) VolumeService() volumes.Service {
 	return nil
 }
 
+func (a *apiService) ResourceService() resources.Service {
+	return nil
+}
+
 func init() {
 	backend.Register("example", "example", service, cloud.NotImplementedCloudService)
 }
@@ -68,9 +73,9 @@ type containerService struct{}
 
 func (cs *containerService) Inspect(ctx context.Context, id string) (containers.Container, error) {
 	return containers.Container{
-		ID:                     "id",
-		Image:                  "nginx",
-		Platform:               "Linux",
+		ID:       "id",
+		Image:    "nginx",
+		Platform: "Linux",
 		HostConfig: &containers.HostConfig{
 			RestartPolicy: "none",
 		},

--- a/local/backend.go
+++ b/local/backend.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	"github.com/docker/compose-cli/backend"
@@ -77,6 +78,10 @@ func (ms *local) SecretsService() secrets.Service {
 }
 
 func (ms *local) VolumeService() volumes.Service {
+	return nil
+}
+
+func (ms *local) ResourceService() resources.Service {
 	return nil
 }
 

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/compose-cli/api/resources"
+
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -116,6 +118,7 @@ func (noopService) ContainerService() containers.Service { return nil }
 func (noopService) ComposeService() compose.Service      { return nil }
 func (noopService) SecretsService() secrets.Service      { return nil }
 func (noopService) VolumeService() volumes.Service       { return nil }
+func (noopService) ResourceService() resources.Service   { return nil }
 
 type mockMetricsClient struct {
 	mock.Mock


### PR DESCRIPTION
**What I did**
* Add ResourceService() interface next to ContainerService, ComposeService, to hold Prune() that is not specific to any kind of resource
* Add a cli `prune` command, with `--dry-run` and `--force`flags
* Add an ACI implementation, deleting containers and compose apps, Running ones only if `--force`

Many things still subject to discussion/improvement: 
* exact ouput needs to be refined (probably remove `deleted resources:` before IDs ; I'm more and more thinking output should be driven by the backend, to possibly provide custom info like amount of CPU saved, maybe money saved, etc.)
* we could display a summary or freed resources : nb CPU, memory 
* there is no gRPC API yet
* ECS implementation should be easy to add

**Related issue**
https://github.com/docker/compose-cli/issues/744

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://www.thesun.co.uk/wp-content/uploads/2020/02/NINTCHDBPICT000563674645.jpg)