### PR TITLE
Display summary of reclaimed ACI resources (CPU/mem) in `docker prune`

### DIFF
--- a/api/client/resources.go
+++ b/api/client/resources.go
@@ -27,6 +27,6 @@ type resourceService struct {
 }
 
 // Prune prune resources
-func (c *resourceService) Prune(ctx context.Context, request resources.PruneRequest) ([]string, error) {
-	return nil, errdefs.ErrNotImplemented
+func (c *resourceService) Prune(ctx context.Context, request resources.PruneRequest) (resources.PruneResult, error) {
+	return resources.PruneResult{}, errdefs.ErrNotImplemented
 }

--- a/api/resources/api.go
+++ b/api/resources/api.go
@@ -26,8 +26,14 @@ type PruneRequest struct {
 	DryRun bool
 }
 
+// PruneResult info on what has been pruned
+type PruneResult struct {
+	DeletedIDs []string
+	Summary    string
+}
+
 // Service interacts with the underlying container backend
 type Service interface {
 	// Prune prune resources
-	Prune(ctx context.Context, request PruneRequest) ([]string, error)
+	Prune(ctx context.Context, request PruneRequest) (PruneResult, error)
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -56,14 +56,17 @@ func runPrune(ctx context.Context, opts pruneOpts) error {
 		return errors.Wrap(err, "cannot connect to backend")
 	}
 
-	ids, err := c.ResourceService().Prune(ctx, resources.PruneRequest{Force: opts.force, DryRun: opts.dryRun})
+	result, err := c.ResourceService().Prune(ctx, resources.PruneRequest{Force: opts.force, DryRun: opts.dryRun})
 	if opts.dryRun {
-		fmt.Println("resources that would be deleted:")
+		fmt.Println("Resources that would be deleted:")
 	} else {
-		fmt.Println("deleted resources:")
+		fmt.Println("Deleted resources:")
 	}
-	for _, id := range ids {
+	for _, id := range result.DeletedIDs {
 		fmt.Println(id)
+	}
+	if result.Summary != "" {
+		fmt.Println(result.Summary)
 	}
 	return err
 }

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -490,21 +490,20 @@ func TestContainerRunAttached(t *testing.T) {
 
 	t.Run("prune dry run", func(t *testing.T) {
 		res := c.RunDockerCmd("prune", "--dry-run")
-		fmt.Println("prune output:")
-		assert.Equal(t, "resources that would be deleted:\n", res.Stdout())
+		assert.Equal(t, "Resources that would be deleted:\nTotal CPUs reclaimed: 0.00, total memory reclaimed: 0.00 GB\n", res.Stdout())
 		res = c.RunDockerCmd("prune", "--dry-run", "--force")
-		assert.Equal(t, "resources that would be deleted:\n"+container+"\n", res.Stdout())
+		assert.Equal(t, "Resources that would be deleted:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n", res.Stdout())
 	})
 
 	t.Run("prune", func(t *testing.T) {
 		res := c.RunDockerCmd("prune")
-		assert.Equal(t, "deleted resources:\n", res.Stdout())
+		assert.Equal(t, "Deleted resources:\nTotal CPUs reclaimed: 0.00, total memory reclaimed: 0.00 GB\n", res.Stdout())
 		res = c.RunDockerCmd("ps")
 		l := lines(res.Stdout())
 		assert.Equal(t, 2, len(l))
 
 		res = c.RunDockerCmd("prune", "--force")
-		assert.Equal(t, "deleted resources:\n"+container+"\n", res.Stdout())
+		assert.Equal(t, "Deleted resources:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n", res.Stdout())
 
 		res = c.RunDockerCmd("ps", "--all")
 		l = lines(res.Stdout())


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Add summary after list of deleted resources: 
```
 $ ./bin/docker --context acicontext prune --dry-run --force
Resources that would be deleted:
test-prune1
test-prune2
Total CPUs reclaimed: 5.02, total memory reclaimed: 5.40 GB
```

**Related issue**
https://github.com/docker/compose-cli/issues/744

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://static.boredpanda.com/blog/wp-content/uploads/2015/11/animal-hybrids-182.jpg)