### PR TITLE
Store external cluster as metadata

### DIFF
--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -64,10 +64,10 @@ func (r *awsResources) allSecurityGroups() []string {
 }
 
 // parse look into compose project for configured resource to use, and check they are valid
-func (b *ecsAPIService) parse(ctx context.Context, project *types.Project) (awsResources, error) {
+func (b *ecsAPIService) parse(ctx context.Context, project *types.Project, template *cloudformation.Template) (awsResources, error) {
 	r := awsResources{}
 	var err error
-	r.cluster, err = b.parseClusterExtension(ctx, project)
+	r.cluster, err = b.parseClusterExtension(ctx, project, template)
 	if err != nil {
 		return r, err
 	}
@@ -90,7 +90,7 @@ func (b *ecsAPIService) parse(ctx context.Context, project *types.Project) (awsR
 	return r, nil
 }
 
-func (b *ecsAPIService) parseClusterExtension(ctx context.Context, project *types.Project) (string, error) {
+func (b *ecsAPIService) parseClusterExtension(ctx context.Context, project *types.Project, template *cloudformation.Template) (string, error) {
 	if x, ok := project.Extensions[extensionCluster]; ok {
 		cluster := x.(string)
 		ok, err := b.aws.ClusterExists(ctx, cluster)
@@ -100,6 +100,8 @@ func (b *ecsAPIService) parseClusterExtension(ctx context.Context, project *type
 		if !ok {
 			return "", errors.Wrapf(errdefs.ErrNotFound, "cluster %q does not exist", cluster)
 		}
+
+		template.Metadata["Cluster"] = cluster
 		return cluster, nil
 	}
 	return "", nil

--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -52,12 +52,12 @@ func (b *ecsAPIService) convert(ctx context.Context, project *types.Project) (*c
 		return nil, err
 	}
 
-	resources, err := b.parse(ctx, project)
+	template := cloudformation.NewTemplate()
+	resources, err := b.parse(ctx, project, template)
 	if err != nil {
 		return nil, err
 	}
 
-	template := cloudformation.NewTemplate()
 	err = b.ensureResources(&resources, project, template)
 	if err != nil {
 		return nil, err

--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -492,6 +492,18 @@ services:
 	}
 }
 
+func TestTemplateMetadata(t *testing.T) {
+	template := convertYaml(t, `
+x-aws-cluster: "arn:aws:ecs:region:account:cluster/name"
+services:
+  test:
+    image: nginx
+`, useDefaultVPC, func(m *MockAPIMockRecorder) {
+		m.ClusterExists(gomock.Any(), "arn:aws:ecs:region:account:cluster/name").Return(true, nil)
+	})
+	assert.Equal(t, template.Metadata["Cluster"], "arn:aws:ecs:region:account:cluster/name")
+}
+
 func convertYaml(t *testing.T, yaml string, fn ...func(m *MockAPIMockRecorder)) *cloudformation.Template {
 	project := loadConfig(t, yaml)
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
**What I did**
1. add a sanity check to sdk.DescribeService
2. store external cluster as template metadata so we can get this information back

DescribeService API, even we pass a service ARN, require cluster ID (?)
If cluster was set by user as `x-aws-cluster`, we can't get this ID from CloudFormation stack resources
Proposed change uses CloudFormation template Metadata to track the user-provided cluster so we can easily get this ID back on `compose ps`

**Related issue**
https://github.com/docker/compose-cli/issues/790

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/96238237-8d9c1d00-0f9e-11eb-8317-a52977e71881.png)


