### PR TITLE
Fix Makefile command to cleanup ACI E2E resource groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ validate: validate-go-mod validate-headers ## Validate sources
 pre-commit: cli test e2e-local lint validate
 
 clean-aci-e2e: ## Make sure no ACI tests are currently runnnig in the CI when invoking this. Delete ACI E2E tests resources that might have leaked when ctrl-C E2E tests.
-	 az group list | jq '.[].name' | grep E2E-Test | xargs -n1 az-cmd group delete -y --no-wait -g
+	 az group list | jq '.[].name' | grep E2E-Test | xargs -n1 az group delete -y --no-wait -g
 
 help: ## Show help
 	@echo Please specify a build target. The choices are:


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* remove typo

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://secure.i.telegraph.co.uk/multimedia/archive/02152/panda-upside-down_2152868i.jpg)