### PR TITLE
fix "autoscaling" typo

### DIFF
--- a/ecs/architecture.md
+++ b/ecs/architecture.md
@@ -22,7 +22,7 @@ This diagram shows compose model and on same line AWS components that get create
   |       |  +---------+
   |       +--+ Deploy  |
   |       |  +---------+                    +-------------------+
-  |       |  x-aws-autoscale  . . . . . .   | ScalableTarget    |
+  |       |  x-aws-autoscaling  . . . . . . | ScalableTarget    |
   |       |                                 +-------------------+---+
   |       |                                     | ScalingPolicy     |
   |       |                                     +-------------------+-+


### PR DESCRIPTION
Fixing x-aws-autoscaling typo in architecture document