### PR TITLE
Introduce use of EFS Access Point to mount filesystems as volumes

### DIFF
--- a/ecs/autoscaling.go
+++ b/ecs/autoscaling.go
@@ -62,7 +62,7 @@ func (b *ecsAPIService) createAutoscalingPolicy(project *types.Project, resource
 	}
 
 	// Why isn't this just the service ARN ?????
-	resourceID := cloudformation.Join("/", []string{"service", resources.cluster, cloudformation.GetAtt(serviceResourceName(service.Name), "Name")})
+	resourceID := cloudformation.Join("/", []string{"service", resources.cluster.ID(), cloudformation.GetAtt(serviceResourceName(service.Name), "Name")})
 
 	target := fmt.Sprintf("%sScalableTarget", normalizeResourceName(service.Name))
 	template.Resources[target] = &applicationautoscaling.ScalableTarget{

--- a/ecs/aws.go
+++ b/ecs/aws.go
@@ -35,11 +35,11 @@ const (
 // API hides aws-go-sdk into a simpler, focussed API subset
 type API interface {
 	CheckRequirements(ctx context.Context, region string) error
-	ClusterExists(ctx context.Context, name string) (bool, error)
+	ResolveCluster(ctx context.Context, nameOrArn string) (awsResource, error)
 	CreateCluster(ctx context.Context, name string) (string, error)
 	CheckVPC(ctx context.Context, vpcID string) error
 	GetDefaultVPC(ctx context.Context) (string, error)
-	GetSubNets(ctx context.Context, vpcID string) ([]string, error)
+	GetSubNets(ctx context.Context, vpcID string) ([]awsResource, error)
 	GetRoleArn(ctx context.Context, name string) (string, error)
 	StackExists(ctx context.Context, name string) (bool, error)
 	CreateStack(ctx context.Context, name string, template []byte) error
@@ -66,14 +66,14 @@ type API interface {
 	getURLWithPortMapping(ctx context.Context, targetGroupArns []string) ([]compose.PortPublisher, error)
 	ListTasks(ctx context.Context, cluster string, family string) ([]string, error)
 	GetPublicIPs(ctx context.Context, interfaces ...string) (map[string]string, error)
-	LoadBalancerType(ctx context.Context, arn string) (string, error)
+	ResolveLoadBalancer(ctx context.Context, nameOrArn string) (awsResource, string, error)
 	GetLoadBalancerURL(ctx context.Context, arn string) (string, error)
 	GetParameter(ctx context.Context, name string) (string, error)
 	SecurityGroupExists(ctx context.Context, sg string) (bool, error)
 	DeleteCapacityProvider(ctx context.Context, arn string) error
 	DeleteAutoscalingGroup(ctx context.Context, arn string) error
-	FileSystemExists(ctx context.Context, id string) (bool, error)
-	FindFileSystem(ctx context.Context, tags map[string]string) (string, error)
+	ResolveFileSystem(ctx context.Context, id string) (awsResource, error)
+	FindFileSystem(ctx context.Context, tags map[string]string) (awsResource, error)
 	CreateFileSystem(ctx context.Context, tags map[string]string) (string, error)
 	DeleteFileSystem(ctx context.Context, id string) error
 }

--- a/ecs/aws_mock.go
+++ b/ecs/aws_mock.go
@@ -6,12 +6,13 @@ package ecs
 
 import (
 	context "context"
+	reflect "reflect"
+
 	cloudformation "github.com/aws/aws-sdk-go/service/cloudformation"
 	ecs "github.com/aws/aws-sdk-go/service/ecs"
 	compose "github.com/docker/compose-cli/api/compose"
 	secrets "github.com/docker/compose-cli/api/secrets"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface
@@ -63,21 +64,6 @@ func (m *MockAPI) CheckVPC(arg0 context.Context, arg1 string) error {
 func (mr *MockAPIMockRecorder) CheckVPC(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckVPC", reflect.TypeOf((*MockAPI)(nil).CheckVPC), arg0, arg1)
-}
-
-// ClusterExists mocks base method
-func (m *MockAPI) ClusterExists(arg0 context.Context, arg1 string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClusterExists", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ClusterExists indicates an expected call of ClusterExists
-func (mr *MockAPIMockRecorder) ClusterExists(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterExists", reflect.TypeOf((*MockAPI)(nil).ClusterExists), arg0, arg1)
 }
 
 // CreateChangeSet mocks base method
@@ -254,26 +240,11 @@ func (mr *MockAPIMockRecorder) DescribeStackEvents(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEvents", reflect.TypeOf((*MockAPI)(nil).DescribeStackEvents), arg0, arg1)
 }
 
-// FileSystemExists mocks base method
-func (m *MockAPI) FileSystemExists(arg0 context.Context, arg1 string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FileSystemExists", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FileSystemExists indicates an expected call of FileSystemExists
-func (mr *MockAPIMockRecorder) FileSystemExists(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileSystemExists", reflect.TypeOf((*MockAPI)(nil).FileSystemExists), arg0, arg1)
-}
-
 // FindFileSystem mocks base method
-func (m *MockAPI) FindFileSystem(arg0 context.Context, arg1 map[string]string) (string, error) {
+func (m *MockAPI) FindFileSystem(arg0 context.Context, arg1 map[string]string) (awsResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindFileSystem", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(awsResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -439,10 +410,10 @@ func (mr *MockAPIMockRecorder) GetStackID(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetSubNets mocks base method
-func (m *MockAPI) GetSubNets(arg0 context.Context, arg1 string) ([]string, error) {
+func (m *MockAPI) GetSubNets(arg0 context.Context, arg1 string) ([]awsResource, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubNets", arg0, arg1)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]awsResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -573,19 +544,50 @@ func (mr *MockAPIMockRecorder) ListTasks(arg0, arg1, arg2 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*MockAPI)(nil).ListTasks), arg0, arg1, arg2)
 }
 
-// LoadBalancerType mocks base method
-func (m *MockAPI) LoadBalancerType(arg0 context.Context, arg1 string) (string, error) {
+// ResolveCluster mocks base method
+func (m *MockAPI) ResolveCluster(arg0 context.Context, arg1 string) (awsResource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadBalancerType", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "ResolveCluster", arg0, arg1)
+	ret0, _ := ret[0].(awsResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadBalancerType indicates an expected call of LoadBalancerType
-func (mr *MockAPIMockRecorder) LoadBalancerType(arg0, arg1 interface{}) *gomock.Call {
+// ResolveCluster indicates an expected call of ResolveCluster
+func (mr *MockAPIMockRecorder) ResolveCluster(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerType", reflect.TypeOf((*MockAPI)(nil).LoadBalancerType), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveCluster", reflect.TypeOf((*MockAPI)(nil).ResolveCluster), arg0, arg1)
+}
+
+// ResolveFileSystem mocks base method
+func (m *MockAPI) ResolveFileSystem(arg0 context.Context, arg1 string) (awsResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveFileSystem", arg0, arg1)
+	ret0, _ := ret[0].(awsResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveFileSystem indicates an expected call of ResolveFileSystem
+func (mr *MockAPIMockRecorder) ResolveFileSystem(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveFileSystem", reflect.TypeOf((*MockAPI)(nil).ResolveFileSystem), arg0, arg1)
+}
+
+// ResolveLoadBalancer mocks base method
+func (m *MockAPI) ResolveLoadBalancer(arg0 context.Context, arg1 string) (awsResource, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveLoadBalancer", arg0, arg1)
+	ret0, _ := ret[0].(awsResource)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ResolveLoadBalancer indicates an expected call of ResolveLoadBalancer
+func (mr *MockAPIMockRecorder) ResolveLoadBalancer(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveLoadBalancer", reflect.TypeOf((*MockAPI)(nil).ResolveLoadBalancer), arg0, arg1)
 }
 
 // SecurityGroupExists mocks base method

--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -19,9 +19,6 @@ package ecs
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
 	"github.com/docker/compose-cli/api/resources"
@@ -32,6 +29,9 @@ import (
 	"github.com/docker/compose-cli/context/cloud"
 	"github.com/docker/compose-cli/context/store"
 	"github.com/docker/compose-cli/errdefs"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 const backendType = store.EcsContextType

--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -367,7 +367,7 @@ volumes:
     external: true
     name: fs-123abc
 `, useDefaultVPC, func(m *MockAPIMockRecorder) {
-		m.FileSystemExists(gomock.Any(), "fs-123abc").Return(true, nil)
+		m.ResolveFileSystem(gomock.Any(), "fs-123abc").Return(existingAWSResource{id: "fs-123abc"}, nil)
 	})
 	s := template.Resources["DbdataNFSMountTargetOnSubnet1"].(*efs.MountTarget)
 	assert.Check(t, s != nil)
@@ -395,7 +395,7 @@ volumes:
 		m.FindFileSystem(gomock.Any(), map[string]string{
 			compose.ProjectTag: t.Name(),
 			compose.VolumeTag:  "db-data",
-		}).Return("", nil)
+		}).Return(nil, nil)
 	})
 	n := volumeResourceName("db-data")
 	f := template.Resources[n].(*efs.FileSystem)
@@ -411,6 +411,25 @@ volumes:
 	assert.Equal(t, s.FileSystemId, cloudformation.Ref(n)) //nolint:staticcheck
 }
 
+func TestCreateAccessPoint(t *testing.T) {
+	template := convertYaml(t, `
+services:
+  test:
+    image: nginx
+volumes:
+  db-data:
+    driver_opts:
+      uid: 1002
+      gid: 1002
+`, useDefaultVPC, func(m *MockAPIMockRecorder) {
+		m.FindFileSystem(gomock.Any(), gomock.Any()).Return(nil, nil)
+	})
+	a := template.Resources["DbdataAccessPoint"].(*efs.AccessPoint)
+	assert.Check(t, a != nil)
+	assert.Equal(t, a.PosixUser.Uid, "1002") //nolint:staticcheck
+	assert.Equal(t, a.PosixUser.Gid, "1002") //nolint:staticcheck
+}
+
 func TestReusePreviousVolume(t *testing.T) {
 	template := convertYaml(t, `
 services:
@@ -422,7 +441,7 @@ volumes:
 		m.FindFileSystem(gomock.Any(), map[string]string{
 			compose.ProjectTag: t.Name(),
 			compose.VolumeTag:  "db-data",
-		}).Return("fs-123abc", nil)
+		}).Return(existingAWSResource{id: "fs-123abc"}, nil)
 	})
 	s := template.Resources["DbdataNFSMountTargetOnSubnet1"].(*efs.MountTarget)
 	assert.Check(t, s != nil)
@@ -499,7 +518,10 @@ services:
   test:
     image: nginx
 `, useDefaultVPC, func(m *MockAPIMockRecorder) {
-		m.ClusterExists(gomock.Any(), "arn:aws:ecs:region:account:cluster/name").Return(true, nil)
+		m.ResolveCluster(gomock.Any(), "arn:aws:ecs:region:account:cluster/name").Return(existingAWSResource{
+			arn: "arn:aws:ecs:region:account:cluster/name",
+			id:  "name",
+		}, nil)
 	})
 	assert.Equal(t, template.Metadata["Cluster"], "arn:aws:ecs:region:account:cluster/name")
 }
@@ -548,7 +570,10 @@ func getMainContainer(def *ecs.TaskDefinition, t *testing.T) ecs.TaskDefinition_
 
 func useDefaultVPC(m *MockAPIMockRecorder) {
 	m.GetDefaultVPC(gomock.Any()).Return("vpc-123", nil)
-	m.GetSubNets(gomock.Any(), "vpc-123").Return([]string{"subnet1", "subnet2"}, nil)
+	m.GetSubNets(gomock.Any(), "vpc-123").Return([]awsResource{
+		existingAWSResource{id: "subnet1"},
+		existingAWSResource{id: "subnet2"},
+	}, nil)
 }
 
 func useGPU(m *MockAPIMockRecorder) {

--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -81,11 +81,15 @@ func (b *ecsAPIService) createTaskDefinition(project *types.Project, service typ
 	}
 
 	for _, v := range service.Volumes {
-		volume := project.Volumes[v.Source]
+		n := fmt.Sprintf("%sAccessPoint", normalizeResourceName(v.Source))
 		volumes = append(volumes, ecs.TaskDefinition_Volume{
 			EFSVolumeConfiguration: &ecs.TaskDefinition_EFSVolumeConfiguration{
-				FilesystemId:  resources.filesystems[v.Source],
-				RootDirectory: volume.DriverOpts["root_directory"],
+				AuthorizationConfig: &ecs.TaskDefinition_AuthorizationConfig{
+					AccessPointId: cloudformation.Ref(n),
+					IAM:           "ENABLED",
+				},
+				FilesystemId:      resources.filesystems[v.Source].ID(),
+				TransitEncryption: "ENABLED",
 			},
 			Name: v.Source,
 		})

--- a/ecs/ec2.go
+++ b/ecs/ec2.go
@@ -65,7 +65,7 @@ func (b *ecsAPIService) createCapacityProvider(ctx context.Context, project *typ
 		LaunchConfigurationName: cloudformation.Ref("LaunchConfiguration"),
 		MaxSize:                 "10", //TODO
 		MinSize:                 "1",
-		VPCZoneIdentifier:       resources.subnets,
+		VPCZoneIdentifier:       resources.subnetsIDs(),
 	}
 
 	userData := base64.StdEncoding.EncodeToString([]byte(

--- a/ecs/sdk.go
+++ b/ecs/sdk.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/compose-cli/internal"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -107,15 +108,22 @@ func (s sdk) CheckRequirements(ctx context.Context, region string) error {
 	return nil
 }
 
-func (s sdk) ClusterExists(ctx context.Context, name string) (bool, error) {
-	logrus.Debug("CheckRequirements if cluster was already created: ", name)
+func (s sdk) ResolveCluster(ctx context.Context, nameOrArn string) (awsResource, error) {
+	logrus.Debug("CheckRequirements if cluster was already created: ", nameOrArn)
 	clusters, err := s.ECS.DescribeClustersWithContext(ctx, &ecs.DescribeClustersInput{
-		Clusters: []*string{aws.String(name)},
+		Clusters: []*string{aws.String(nameOrArn)},
 	})
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return len(clusters.Clusters) > 0, nil
+	if len(clusters.Clusters) == 0 {
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "cluster %q does not exist", nameOrArn)
+	}
+	it := clusters.Clusters[0]
+	return existingAWSResource{
+		arn: aws.StringValue(it.ClusterArn),
+		id:  aws.StringValue(it.ClusterName),
+	}, nil
 }
 
 func (s sdk) CreateCluster(ctx context.Context, name string) (string, error) {
@@ -139,7 +147,7 @@ func (s sdk) CheckVPC(ctx context.Context, vpcID string) error {
 	if !*output.EnableDnsSupport.Value {
 		return fmt.Errorf("VPC %q doesn't have DNS resolution enabled", vpcID)
 	}
-	return err
+	return nil
 }
 
 func (s sdk) GetDefaultVPC(ctx context.Context) (string, error) {
@@ -161,7 +169,7 @@ func (s sdk) GetDefaultVPC(ctx context.Context) (string, error) {
 	return *vpcs.Vpcs[0].VpcId, nil
 }
 
-func (s sdk) GetSubNets(ctx context.Context, vpcID string) ([]string, error) {
+func (s sdk) GetSubNets(ctx context.Context, vpcID string) ([]awsResource, error) {
 	logrus.Debug("Retrieve SubNets")
 	subnets, err := s.EC2.DescribeSubnetsWithContext(ctx, &ec2.DescribeSubnetsInput{
 		DryRun: nil,
@@ -176,9 +184,12 @@ func (s sdk) GetSubNets(ctx context.Context, vpcID string) ([]string, error) {
 		return nil, err
 	}
 
-	ids := []string{}
+	ids := []awsResource{}
 	for _, subnet := range subnets.Subnets {
-		ids = append(ids, *subnet.SubnetId)
+		ids = append(ids, existingAWSResource{
+			arn: aws.StringValue(subnet.SubnetArn),
+			id:  aws.StringValue(subnet.SubnetId),
+		})
 	}
 	return ids, nil
 }
@@ -785,18 +796,31 @@ func (s sdk) GetPublicIPs(ctx context.Context, interfaces ...string) (map[string
 	return publicIPs, nil
 }
 
-func (s sdk) LoadBalancerType(ctx context.Context, arn string) (string, error) {
-	logrus.Debug("Check if LoadBalancer exists: ", arn)
+func (s sdk) ResolveLoadBalancer(ctx context.Context, nameOrarn string) (awsResource, string, error) {
+	logrus.Debug("Check if LoadBalancer exists: ", nameOrarn)
+	var arns []*string
+	var names []*string
+	if arn.IsARN(nameOrarn) {
+		arns = append(arns, aws.String(nameOrarn))
+	} else {
+		names = append(names, aws.String(nameOrarn))
+	}
+
 	lbs, err := s.ELB.DescribeLoadBalancersWithContext(ctx, &elbv2.DescribeLoadBalancersInput{
-		LoadBalancerArns: []*string{aws.String(arn)},
+		LoadBalancerArns: arns,
+		Names:            names,
 	})
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	if len(lbs.LoadBalancers) == 0 {
-		return "", fmt.Errorf("load balancer does not exist: %s", arn)
+		return nil, "", errors.Wrapf(errdefs.ErrNotFound, "load balancer %q does not exist", nameOrarn)
 	}
-	return aws.StringValue(lbs.LoadBalancers[0].Type), nil
+	it := lbs.LoadBalancers[0]
+	return existingAWSResource{
+		arn: aws.StringValue(it.LoadBalancerArn),
+		id:  aws.StringValue(it.LoadBalancerName),
+	}, aws.StringValue(it.Type), nil
 }
 
 func (s sdk) GetLoadBalancerURL(ctx context.Context, arn string) (string, error) {
@@ -864,32 +888,42 @@ func (s sdk) DeleteAutoscalingGroup(ctx context.Context, arn string) error {
 	return err
 }
 
-func (s sdk) FileSystemExists(ctx context.Context, id string) (bool, error) {
+func (s sdk) ResolveFileSystem(ctx context.Context, id string) (awsResource, error) {
 	desc, err := s.EFS.DescribeFileSystemsWithContext(ctx, &efs.DescribeFileSystemsInput{
 		FileSystemId: aws.String(id),
 	})
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return len(desc.FileSystems) > 0, nil
+	if len(desc.FileSystems) == 0 {
+		return nil, errors.Wrapf(errdefs.ErrNotFound, "EFS file system %q doesn't exist", id)
+	}
+	it := desc.FileSystems[0]
+	return existingAWSResource{
+		arn: aws.StringValue(it.FileSystemArn),
+		id:  aws.StringValue(it.FileSystemId),
+	}, nil
 }
 
-func (s sdk) FindFileSystem(ctx context.Context, tags map[string]string) (string, error) {
+func (s sdk) FindFileSystem(ctx context.Context, tags map[string]string) (awsResource, error) {
 	var token *string
 	for {
 		desc, err := s.EFS.DescribeFileSystemsWithContext(ctx, &efs.DescribeFileSystemsInput{
 			Marker: token,
 		})
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		for _, filesystem := range desc.FileSystems {
 			if containsAll(filesystem.Tags, tags) {
-				return aws.StringValue(filesystem.FileSystemId), nil
+				return existingAWSResource{
+					arn: aws.StringValue(filesystem.FileSystemArn),
+					id:  aws.StringValue(filesystem.FileSystemId),
+				}, nil
 			}
 		}
 		if desc.NextMarker == token {
-			return "", nil
+			return nil, nil
 		}
 		token = desc.NextMarker
 	}

--- a/ecs/testdata/simple/simple-cloudformation-conversion.golden
+++ b/ecs/testdata/simple/simple-cloudformation-conversion.golden
@@ -98,7 +98,10 @@
       ],
       "Properties": {
         "Cluster": {
-          "Ref": "Cluster"
+          "Fn::GetAtt": [
+            "Cluster",
+            "Arn"
+          ]
         },
         "DeploymentConfiguration": {
           "MaximumPercent": 200,
@@ -299,6 +302,7 @@
               "Action": [
                 "sts:AssumeRole"
               ],
+              "Condition": {},
               "Effect": "Allow",
               "Principal": {
                 "Service": "ecs-tasks.amazonaws.com"


### PR DESCRIPTION
**What I did**
Generate an [AccessPoint](https://aws.amazon.com/fr/s3/features/access-points/) for compose file's volumes so that binding can be customized:
- add support for `uid`,`gid` to let container access a volume without entering the file permission hell
- add support for `root_directory` so volume can actually point to a sub-path within the filesystem
- add support for creating such a sub-path for uid,gid + permissions

How to test:

Create a compose file to create filesystem as root: 
```yaml
services:
  server:
    image: jenkins/jenkins:lts
    user: root
    volumes:
      - config:/var/jenkins_home
volumes:
  config: {}
```

Then update compose file to remove the root user and double check filesystem still can be mounted read/writen by container without posix permission issues

```yaml
services:
  server:
    image: jenkins/jenkins:lts
    volumes:
      - config:/var/jenkins_home
volumes:
  config: 
    driver_opts:
      uid: 0
      gid: 0
```

This PR also introduce `awsResource` interface as an attempt to abstract references to AWS resources by ID or ARN, which depend on the resource type and API in use:
- some only use IDs (vpc)
- some can use both (load balancers)
- some require ARN (iam)
Also handle the heterogeneous behaviour CloudFormation resources regarding `!Ref`, which for some returns `ARN`, otherwise `ID` ¯\_(ツ)_/¯

**Related issue**
https://github.com/docker/compose-cli/issues/739

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/96440997-0bfbf780-1209-11eb-88a8-6a5626ce92d1.png)
