### PR TITLE
Remove status truncate on wait

### DIFF
--- a/ecs/wait.go
+++ b/ecs/wait.go
@@ -74,8 +74,7 @@ func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, op
 			knownEvents[*event.EventId] = struct{}{}
 
 			resource := aws.StringValue(event.LogicalResourceId)
-			reason := shortenMessage(
-				aws.StringValue(event.ResourceStatusReason))
+			reason := aws.StringValue(event.ResourceStatusReason)
 			status := aws.StringValue(event.ResourceStatus)
 			progressStatus := progress.Working
 
@@ -116,21 +115,13 @@ func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, op
 			}
 			stackErr = err
 			operation = stackDelete
-			reason := shortenMessage(err.Error())
 			w.Event(progress.Event{
 				ID:         name,
 				Status:     progress.Error,
-				StatusText: reason,
+				StatusText: err.Error(),
 			})
 		}
 	}
 
 	return stackErr
-}
-
-func shortenMessage(message string) string {
-	if len(message) < 30 {
-		return message
-	}
-	return message[:30] + "..."
 }

--- a/progress/tty.go
+++ b/progress/tty.go
@@ -146,12 +146,19 @@ func lineText(event Event, terminalWidth, statusPadding int, color bool) string 
 	if padding < 0 {
 		padding = 0
 	}
+	// calculate the max length for the status text, on errors it
+	// is 2-3 lines long and breaks the line formating
+	maxStatusLen := terminalWidth - textLen - statusPadding - 15
+	status := event.StatusText
+	if len(status) > maxStatusLen {
+		status = status[:maxStatusLen] + "..."
+	}
 	text := fmt.Sprintf(" %s %s %s%s %s",
 		event.spinner.String(),
 		event.ID,
 		event.Text,
 		strings.Repeat(" ", padding),
-		event.StatusText,
+		status,
 	)
 	timer := fmt.Sprintf("%.1fs\n", elapsed)
 	o := align(text, timer, terminalWidth)


### PR DESCRIPTION
On errors, the event status text exceeds one line length and this breaks the progress writer output. 
We now removed the status truncation from wait and calculate the max length for the status text based on the terminal width in the progress writer.
At the end, we return the full error text.

```
$ docker compose up
[+] Running 10/10
 ⠿ hello                       DELETE_COMPLETE                                                                                          192.0s
 ⠿ Cluster                     DELETE_COMPLETE                                                                                          142.0s
 ⠿ DefaultNetwork              DELETE_COMPLETE                                                                                          142.0s
 ⠿ CloudMap                    DELETE_COMPLETE                                                                                          188.0s
 ⠿ LogGroup                    DELETE_COMPLETE                                                                                          144.0s
 ⠿ HelloTaskExecutionRole      DELETE_COMPLETE                                                                                          145.1s
 ⠿ DefaultNetworkIngress       DELETE_COMPLETE                                                                                           80.0s
 ⠿ HelloTaskDefinition         DELETE_COMPLETE                                                                                          124.0s
 ⠿ HelloServiceDiscoveryEntry  DELETE_COMPLETE                                                                                           94.0s
 ⠿ HelloService                DELETE_COMPLETE                                                                                           89.0s
HelloService TaskFailedToStart: CannotPullContainerError: failed to resolve ref "docker.io/ancaiordache/hello:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed

```
\test-ecs