### PR TITLE
Enable cross zone load balancing

### DIFF
--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -400,12 +400,24 @@ func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Proje
 		// Network Load Balancers do not have associated security groups
 		securityGroups = r.getLoadBalancerSecurityGroups(project)
 	}
+
+	var loadBalancerAttributes []elasticloadbalancingv2.LoadBalancer_LoadBalancerAttribute
+	if balancerType == elbv2.LoadBalancerTypeEnumNetwork {
+		loadBalancerAttributes = append(
+			loadBalancerAttributes,
+			elasticloadbalancingv2.LoadBalancer_LoadBalancerAttribute{
+				Key:   "load_balancing.cross_zone.enabled",
+				Value: "true",
+			})
+	}
+
 	template.Resources["LoadBalancer"] = &elasticloadbalancingv2.LoadBalancer{
-		Scheme:         elbv2.LoadBalancerSchemeEnumInternetFacing,
-		SecurityGroups: securityGroups,
-		Subnets:        r.subnetsIDs(),
-		Tags:           projectTags(project),
-		Type:           balancerType,
+		Scheme:                 elbv2.LoadBalancerSchemeEnumInternetFacing,
+		SecurityGroups:         securityGroups,
+		Subnets:                r.subnetsIDs(),
+		Tags:                   projectTags(project),
+		Type:                   balancerType,
+		LoadBalancerAttributes: loadBalancerAttributes,
 	}
 	r.loadBalancer = cloudformationARNResource{
 		logicalName:  "LoadBalancer",


### PR DESCRIPTION
Cross zone load balancing is enabled by default for NLB.

```
version: "3.8"
services:
  hello:
    image: ancaiordache/hello
    ports:
      - 8080:8080
```
```
docker compose up
[+] Running 14/14
 ⠿ hello                       CREATE_COMPLETE                                                                                          217.0s
 ⠿ LogGroup                    CREATE_COMPLETE                                                                                            2.0s
 ⠿ Cluster                     CREATE_COMPLETE                                                                                            5.0s
 ⠿ DefaultNetwork              CREATE_COMPLETE                                                                                            5.0s
 ⠿ HelloTCP8080TargetGroup     CREATE_COMPLETE                                                                                            1.0s
 ⠿ CloudMap                    CREATE_COMPLETE                                                                                           47.0s
 ⠿ LoadBalancer                CREATE_COMPLETE                                                                                          152.0s
 ⠿ HelloTaskExecutionRole      CREATE_COMPLETE                                                                                           19.0s
 ⠿ Default8080Ingress          CREATE_COMPLETE                                                                                            0.0s
 ⠿ DefaultNetworkIngress       CREATE_COMPLETE                                                                                            0.0s
 ⠿ HelloTaskDefinition         CREATE_COMPLETE                                                                                            2.0s
 ⠿ HelloServiceDiscoveryEntry  CREATE_COMPLETE                                                                                            2.0s
 ⠿ HelloTCP8080Listener        CREATE_COMPLETE                                                                                            1.0s
 ⠿ HelloService                CREATE_COMPLETE   
```
Checked LB attributes in the AWS Web console
```
Attributes
Deletion protection                Disabled
Cross-Zone Load Balancing          Enabled
Access logs                        Disabled
```

\test-ecs