### PR TITLE
Return json array for  `ps/ls --format json` commands

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -35,15 +35,11 @@ func Print(toJSON interface{}, format string, outWriter io.Writer, writerFn func
 	case JSON:
 		switch reflect.TypeOf(toJSON).Kind() {
 		case reflect.Slice:
-			s := reflect.ValueOf(toJSON)
-			for i := 0; i < s.Len(); i++ {
-				obj := s.Index(i).Interface()
-				jsonLine, err := ToJSON(obj, "", "")
-				if err != nil {
-					return err
-				}
-				_, _ = fmt.Fprint(outWriter, jsonLine)
+			outJSON, err := ToJSON(toJSON, "", "")
+			if err != nil {
+				return err
 			}
+			_, _ = fmt.Fprint(outWriter, outJSON)
 		default:
 			outJSON, err := ToStandardJSON(toJSON)
 			if err != nil {

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -57,7 +57,6 @@ func TestPrint(t *testing.T) {
 			_, _ = fmt.Fprintf(w, "%s\t%s\n", t.Name, t.Status)
 		}
 	}, "NAME", "STATUS"))
-	assert.Equal(t, b.String(), `{"Name":"myName1","Status":"myStatus1"}
-{"Name":"myName2","Status":"myStatus2"}
+	assert.Equal(t, b.String(), `[{"Name":"myName1","Status":"myStatus1"},{"Name":"myName2","Status":"myStatus2"}]
 `)
 }

--- a/tests/e2e/testdata/ls-out-json-windows.golden
+++ b/tests/e2e/testdata/ls-out-json-windows.golden
@@ -1,1 +1,1 @@
-{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}
+[{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}]

--- a/tests/e2e/testdata/ls-out-json.golden
+++ b/tests/e2e/testdata/ls-out-json.golden
@@ -1,1 +1,1 @@
-{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}
+[{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}]

--- a/tests/e2e/testdata/ps-out-example-json.golden
+++ b/tests/e2e/testdata/ps-out-example-json.golden
@@ -1,2 +1,1 @@
-{"ID":"id","Image":"nginx","Status":"","Command":"","Ports":[]}
-{"ID":"1234","Image":"alpine","Status":"","Command":"","Ports":[]}
+[{"ID":"id","Image":"nginx","Status":"","Command":"","Ports":[]},{"ID":"1234","Image":"alpine","Status":"","Command":"","Ports":[]}]


### PR DESCRIPTION
Print json arrays for 'ps' or 'ls' commands.
```
$ docker ps --format json
[{"ID":"nginx_app","Image":"nginx","Status":"Running","Command":"","Ports":["52.157.252.16:80->80/tcp"]}]

$ docker volume ls --format json
[]

docker compose ls --format json
[{"Name":"e2eTestCompose1602770221964365386","Status":"Running"},{"Name":"e2eTestCompose1601985767794954638","Status":"Running"},{"Name":"e2eTestCompose1601985581055863340","Status":"Running"}]
```

/test-aci
/test-ecs