### PR TITLE
Fix typo in comments against Event struct definition inside writer.go

### DIFF
--- a/progress/writer.go
+++ b/progress/writer.go
@@ -39,7 +39,7 @@ const (
 	Error
 )
 
-// Event reprensents a progress event
+// Event represents a progress event.
 type Event struct {
 	ID         string
 	Text       string


### PR DESCRIPTION
**What I did**
Fixed a typo in comments against Event struct definition inside writer.go
