### PR TITLE
Small fixes in secrets docs

### DIFF
--- a/docs/aci-compose-features.md
+++ b/docs/aci-compose-features.md
@@ -177,9 +177,9 @@ In this example the `nginx` service will have its secret mounted in `/run/secret
 Both of them with be mounted in the same folder (`/mnt/dbmount/`).
 
 
-**Note that absolute file paths are not allowed in the target**
+**Note:** Relative file paths are not allowed in the target
 
-**The target folder will be empty when mounting inside**
+**Note:** Secret files cannot be mounted in a folder next to other existing files
 
 ## Container Resources
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Fix: *relative* paths are not supported in secret targets

**Related issue**
#807 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/736x/b6/62/36/b6623618b519bbd2638249073665c7f0.jpg)