### PR TITLE
Fix Dockerfile syntax in ecs sidecars 

### DIFF
--- a/ecs/resolv/Dockerfile
+++ b/ecs/resolv/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM FROM golang:1.15 AS builder
+FROM golang:1.15 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/resolv
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/resolv main/main.go

--- a/ecs/secrets/Dockerfile
+++ b/ecs/secrets/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM FROM golang:1.15 AS builder
+FROM golang:1.15 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/secrets
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/secrets main/main.go


### PR DESCRIPTION
introduced by https://github.com/docker/compose-cli/pull/799

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**

**Related issue**
https://hub.docker.com/repository/registry-1.docker.io/docker/ecs-searchdomain-sidecar/builds/4c35d039-2c00-485f-a24a-b5e02a99e39f

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
