### PR TITLE
Fix typo in comments against Password method attached to User struct

### DIFF
--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -64,7 +64,7 @@ func (u User) Confirm(message string, defaultValue bool) (bool, error) {
 	return b, err
 }
 
-// Password  implemetns a text input with masked characters
+// Password implements a text input with masked characters.
 func (u User) Password(message string) (string, error) {
 	qs := &survey.Password{
 		Message: message,


### PR DESCRIPTION
Signed-off-by: Sarath Kumar Sivan <sarathkumarsivan@gmail.com>

**What I did**
Fix typo in comments against Password method attached to User struct defined inside prompt.go