### PR TITLE
Fix e2e GET timeout, was *1000 twice

### DIFF
--- a/tests/framework/e2e.go
+++ b/tests/framework/e2e.go
@@ -216,8 +216,9 @@ func HTTPGetWithRetry(t *testing.T, endpoint string, expectedStatus int, retryDe
 		err error
 	)
 	client := &http.Client{
-		Timeout: retryDelay * time.Second,
+		Timeout: retryDelay,
 	}
+	fmt.Printf("	[%s] GET %s\n", t.Name(), endpoint)
 	checkUp := func(t poll.LogT) poll.Result {
 		r, err = client.Get(endpoint)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* 🤦 
* Do not multiply timeout by `time.seconds` twice
* add a log when we try GET to make things easier to follow in e2e tests

**Related issue**
We were still experiencing e2e not doing retry because the first attempt did not timeout: https://github.com/docker/compose-cli/runs/1313631290

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://dcassetcdn.com/w1k/submissions/579000/579489_eef4.jpg)