### PR TITLE
Pin version of ACI sidecar image, so that we don’t affect prod users when re-publishing :latest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,12 @@ validate: validate-go-mod validate-headers ## Validate sources
 
 pre-commit: cli test e2e-local lint validate
 
+build-aci-sidecar:  ## build aci sidecar image locally and tag it with make build-aci-sidecar tag=0.1
+	docker build -t docker/aci-hostnames-sidecar:$(tag) aci/etchosts
+
+publish-aci-sidecar: build-aci-sidecar ## build & publish aci sidecar image with make publish-aci-sidecar tag=0.1
+	docker pull docker/aci-hostnames-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/aci-hostnames-sidecar:$(tag)
+
 clean-aci-e2e: ## Make sure no ACI tests are currently runnnig in the CI when invoking this. Delete ACI E2E tests resources that might have leaked when ctrl-C E2E tests.
 	 az group list | jq '.[].name' | grep E2E-Test | xargs -n1 az group delete -y --no-wait -g
 

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -42,7 +42,7 @@ const (
 	// ComposeDNSSidecarName name of the dns sidecar container
 	ComposeDNSSidecarName = "aci--dns--sidecar"
 
-	dnsSidecarImage = "docker/aci-hostnames-sidecar"
+	dnsSidecarImage = "docker/aci-hostnames-sidecar:1.0"
 )
 
 // ToContainerGroup converts a compose project into a ACI container group


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* pined ACI sidecar image
* updated Makefile: new target to publish new versions, ensuring we don’t override an existing image tag

**Related issue**
Will need something similar fo ECS sidecars ; I'd like to add more E2E tests on ECS to be sure not to break anything, will do in a separate PR

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/83/66/5d/83665de904400db11fb5ca171a34c4fb.jpg)