### PR TITLE
cloudformation: fix typo in generated ingress description

### DIFF
--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -210,7 +210,7 @@ func (b *ecsAPIService) createIngress(service types.ServiceConfig, net string, p
 	ingress := fmt.Sprintf("%s%dIngress", normalizeResourceName(net), port.Target)
 	template.Resources[ingress] = &ec2.SecurityGroupIngress{
 		CidrIp:      "0.0.0.0/0",
-		Description: fmt.Sprintf("%s:%d/%s on %s nextwork", service.Name, port.Target, port.Protocol, net),
+		Description: fmt.Sprintf("%s:%d/%s on %s network", service.Name, port.Target, port.Protocol, net),
 		GroupId:     resources.securityGroups[net],
 		FromPort:    int(port.Target),
 		IpProtocol:  protocol,

--- a/ecs/testdata/simple/simple-cloudformation-conversion.golden
+++ b/ecs/testdata/simple/simple-cloudformation-conversion.golden
@@ -24,7 +24,7 @@
     "Default80Ingress": {
       "Properties": {
         "CidrIp": "0.0.0.0/0",
-        "Description": "simple:80/tcp on default nextwork",
+        "Description": "simple:80/tcp on default network",
         "FromPort": 80,
         "GroupId": {
           "Ref": "DefaultNetwork"


### PR DESCRIPTION
**What I did**

Updated the generated ingress description and the related test case

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![platypus](https://user-images.githubusercontent.com/38863/97504937-df19b400-196f-11eb-9df3-fe3a087f581e.jpeg)
A platy**o**s.