### PR TITLE
Fix path appending

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -73,7 +73,7 @@ func init() {
 	if err != nil {
 		fatal(errors.Wrap(err, "unable to get absolute bin path"))
 	}
-	if err := os.Setenv("PATH", fmt.Sprintf("%s:%s", os.Getenv("PATH"), path)); err != nil {
+	if err := os.Setenv("PATH", fmt.Sprintf("%s%s%s", os.Getenv("PATH"), os.PathListSeparator, path)); err != nil {
 		panic(err)
 	}
 	// Seed random

--- a/cli/main.go
+++ b/cli/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"syscall"
 	"time"
 
@@ -73,11 +74,19 @@ func init() {
 	if err != nil {
 		fatal(errors.Wrap(err, "unable to get absolute bin path"))
 	}
-	if err := os.Setenv("PATH", fmt.Sprintf("%s%s%s", os.Getenv("PATH"), os.PathListSeparator, path)); err != nil {
+
+	if err := os.Setenv("PATH", appendPaths(os.Getenv("PATH"), path)); err != nil {
 		panic(err)
 	}
 	// Seed random
 	rand.Seed(time.Now().UnixNano())
+}
+
+func appendPaths(envPath string, path string) string {
+	if envPath == "" {
+		return path
+	}
+	return strings.Join([]string{envPath, path}, string(os.PathListSeparator))
 }
 
 func isContextAgnosticCommand(cmd *cobra.Command) bool {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -69,3 +69,8 @@ func TestCheckOwnCommand(t *testing.T) {
 	assert.Assert(t, !isContextAgnosticCommand(cmd.LogsCommand()))
 	assert.Assert(t, !isContextAgnosticCommand(cmd.PsCommand()))
 }
+
+func TestAppendPaths(t *testing.T) {
+	assert.Equal(t, appendPaths("", "/bin/path"), "/bin/path")
+	assert.Equal(t, appendPaths("path1", "binaryPath"), "path1"+string(os.PathListSeparator)+"binaryPath")
+}

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -434,14 +434,7 @@ func TestContainerRunAttached(t *testing.T) {
 		endpoint = fmt.Sprintf("http://%s:%d", fqdn, port.HostPort)
 
 		assert.Assert(t, !strings.Contains(followLogsProcess.Stdout(), "/test"))
-		checkRequest := func(t poll.LogT) poll.Result {
-			r, _ := http.Get(endpoint + "/test")
-			if r != nil && r.StatusCode == http.StatusNotFound {
-				return poll.Success()
-			}
-			return poll.Continue("waiting for container to serve request")
-		}
-		poll.WaitOn(t, checkRequest, poll.WithDelay(1*time.Second), poll.WithTimeout(60*time.Second))
+		HTTPGetWithRetry(t, endpoint+"/test", http.StatusNotFound, 2*time.Second, 60*time.Second)
 
 		checkLog := func(t poll.LogT) poll.Result {
 			if strings.Contains(followLogsProcess.Stdout(), "/test") {


### PR DESCRIPTION
**What I did**
* windows PATH should use windows separator (;)
* do not add separator if initial PATH is empty (was creating PATH=:/path)

**Related issue**
Maybe fixing https://github.com/docker/compose-cli/issues/754, but not fixing the Konvoy scenario

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdn.pocket-lint.com/r/s/320x/assets/images/145762-apps-feature-bonkers-new-animals-imagined-with-the-power-of-photoshop-image1-hfkkzbibre-jpg.webp?v1)