### PR TITLE
Revert breaking change on `docker context ls —format “{{ json . }}` 

### DIFF
--- a/cli/cmd/context/ls.go
+++ b/cli/cmd/context/ls.go
@@ -70,7 +70,7 @@ func runList(cmd *cobra.Command, opts lsOpts) error {
 		return err
 	}
 	format := strings.ToLower(strings.ReplaceAll(opts.format, " ", ""))
-	if format != "" && format != formatter.JSON && format != formatter.PRETTY && format != formatter.TemplateJSON {
+	if format != "" && format != formatter.JSON && format != formatter.PRETTY && format != formatter.TemplateLegacyJSON {
 		mobycli.Exec(cmd.Root())
 		return nil
 	}
@@ -94,8 +94,11 @@ func runList(cmd *cobra.Command, opts lsOpts) error {
 		return nil
 	}
 
-	if opts.json || format == formatter.JSON || format == formatter.TemplateJSON {
+	if opts.json || format == formatter.JSON {
 		opts.format = formatter.JSON
+	}
+	if format == formatter.TemplateLegacyJSON {
+		opts.format = formatter.TemplateLegacyJSON
 	}
 
 	view := viewFromContextList(contexts, currentContext)

--- a/cli/cmd/context/ls.go
+++ b/cli/cmd/context/ls.go
@@ -111,7 +111,7 @@ func runList(cmd *cobra.Command, opts lsOpts) error {
 				}
 				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 					contextName,
-					c.Type,
+					c.ContextType,
 					c.Description,
 					c.DockerEndpoint,
 					c.KubernetesEndpoint,
@@ -144,7 +144,7 @@ type contextView struct {
 	Description        string
 	DockerEndpoint     string
 	KubernetesEndpoint string
-	Type               string
+	ContextType        string
 	Name               string
 	StackOrchestrator  string
 }
@@ -158,7 +158,7 @@ func viewFromContextList(contextList []*store.DockerContext, currentContext stri
 			DockerEndpoint:     getEndpoint("docker", c.Endpoints),
 			KubernetesEndpoint: getEndpoint("kubernetes", c.Endpoints),
 			Name:               c.Name,
-			Type:               c.Type(),
+			ContextType:        c.Type(),
 			StackOrchestrator:  c.Metadata.StackOrchestrator,
 		}
 	}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -59,7 +59,7 @@ func runVersion(cmd *cobra.Command) {
 	case formatter.PRETTY, "":
 		versionString = strings.Replace(getOutFromMoby(cmd, fixedPrettyArgs(os.Args[1:])...),
 			"\n Version:", "\n Cloud integration: "+displayedVersion+"\n Version:", 1)
-	case formatter.JSON, formatter.TemplateJSON: // Try to catch full JSON formats
+	case formatter.JSON, formatter.TemplateLegacyJSON: // Try to catch full JSON formats
 		versionString = strings.Replace(getOutFromMoby(cmd, fixedJSONArgs(os.Args[1:])...),
 			`"Version":`, fmt.Sprintf(`"CloudIntegration":%q,"Version":`, displayedVersion), 1)
 	default:

--- a/formatter/consts.go
+++ b/formatter/consts.go
@@ -19,8 +19,8 @@ package formatter
 const (
 	// JSON is the constant for Json formats on list commands
 	JSON = "json"
-	// TemplateJSON the legacy json formatting value using go template
-	TemplateJSON = "{{json.}}"
+	// TemplateLegacyJSON the legacy json formatting value using go template
+	TemplateLegacyJSON = "{{json.}}"
 	// PRETTY is the constant for default formats on list commands
 	PRETTY = "pretty"
 )

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -32,6 +32,25 @@ func Print(toJSON interface{}, format string, outWriter io.Writer, writerFn func
 	switch strings.ToLower(format) {
 	case PRETTY, "":
 		return PrintPrettySection(outWriter, writerFn, headers...)
+	case TemplateLegacyJSON:
+		switch reflect.TypeOf(toJSON).Kind() {
+		case reflect.Slice:
+			s := reflect.ValueOf(toJSON)
+			for i := 0; i < s.Len(); i++ {
+				obj := s.Index(i).Interface()
+				outJSON, err := ToJSON(obj, "", "")
+				if err != nil {
+					return err
+				}
+				_, _ = fmt.Fprint(outWriter, outJSON)
+			}
+		default:
+			outJSON, err := ToStandardJSON(toJSON)
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(outWriter, outJSON)
+		}
 	case JSON:
 		switch reflect.TypeOf(toJSON).Kind() {
 		case reflect.Slice:

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -59,4 +59,15 @@ func TestPrint(t *testing.T) {
 	}, "NAME", "STATUS"))
 	assert.Equal(t, b.String(), `[{"Name":"myName1","Status":"myStatus1"},{"Name":"myName2","Status":"myStatus2"}]
 `)
+
+	b.Reset()
+	assert.NilError(t, Print(testList, TemplateLegacyJSON, b, func(w io.Writer) {
+		for _, t := range testList {
+			_, _ = fmt.Fprintf(w, "%s\t%s\n", t.Name, t.Status)
+		}
+	}, "NAME", "STATUS"))
+	json := b.String()
+	assert.Equal(t, json, `{"Name":"myName1","Status":"myStatus1"}
+{"Name":"myName2","Status":"myStatus2"}
+`)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -86,7 +86,7 @@ func TestContextDefault(t *testing.T) {
 		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
 
 		res = c.RunDockerCmd("context", "ls", "--format", "{{ json . }}")
-		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
+		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-legacy-json"))
 	})
 
 	t.Run("inspect", func(t *testing.T) {

--- a/tests/e2e/testdata/ls-out-json-windows.golden
+++ b/tests/e2e/testdata/ls-out-json-windows.golden
@@ -1,1 +1,1 @@
-[{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}]
+[{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","ContextType":"moby","Name":"default","StackOrchestrator":"swarm"}]

--- a/tests/e2e/testdata/ls-out-json.golden
+++ b/tests/e2e/testdata/ls-out-json.golden
@@ -1,1 +1,1 @@
-[{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}]
+[{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","ContextType":"moby","Name":"default","StackOrchestrator":"swarm"}]

--- a/tests/e2e/testdata/ls-out-legacy-json-windows.golden
+++ b/tests/e2e/testdata/ls-out-legacy-json-windows.golden
@@ -1,1 +1,1 @@
-{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}
+{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","ContextType":"moby","Name":"default","StackOrchestrator":"swarm"}

--- a/tests/e2e/testdata/ls-out-legacy-json-windows.golden
+++ b/tests/e2e/testdata/ls-out-legacy-json-windows.golden
@@ -1,0 +1,1 @@
+{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"npipe:////./pipe/docker_engine","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}

--- a/tests/e2e/testdata/ls-out-legacy-json.golden
+++ b/tests/e2e/testdata/ls-out-legacy-json.golden
@@ -1,0 +1,1 @@
+{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}

--- a/tests/e2e/testdata/ls-out-legacy-json.golden
+++ b/tests/e2e/testdata/ls-out-legacy-json.golden
@@ -1,1 +1,1 @@
-{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","Type":"moby","Name":"default","StackOrchestrator":"swarm"}
+{"Current":true,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","KubernetesEndpoint":"","ContextType":"moby","Name":"default","StackOrchestrator":"swarm"}


### PR DESCRIPTION
this is used by VSCode Docker extension
VSCode should move to using `docker context ls --format json` and parse a regular json array. But for existing deployment, and not introduce breaking changes, `docker context ls —format "{{ json . }}"` will return json lines as before

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Support old format with a specific case, returning json lines and not a full json array; only in the case of the legacy `docker context ls —format "{{ json . }}"` (space variations allowed in the format value)

**Related issue**
https://github.com/microsoft/vscode-docker/issues/2452

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/d8/42/74/d84274705ba9ddaaeb2ba4e3273ab886.jpg)