### PR TITLE
Pinned and publish docker/ecs-searchdomain-sidecar:1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,12 @@ build-aci-sidecar:  ## build aci sidecar image locally and tag it with make buil
 publish-aci-sidecar: build-aci-sidecar ## build & publish aci sidecar image with make publish-aci-sidecar tag=0.1
 	docker pull docker/aci-hostnames-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/aci-hostnames-sidecar:$(tag)
 
+build-ecs-search-sidecar:  ## build ecs search sidecar image locally and tag it with make build-ecs-search-sidecar tag=0.1
+	docker build -t docker/ecs-searchdomain-sidecar:$(tag) ecs/resolv
+
+publish-ecs-search-sidecar: build-ecs-search-sidecar ## build & publish ecs search sidecar image with make publish-ecs-search-sidecar tag=0.1
+	docker pull docker/ecs-searchdomain-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/ecs-searchdomain-sidecar:$(tag)
+
 clean-aci-e2e: ## Make sure no ACI tests are currently runnnig in the CI when invoking this. Delete ACI E2E tests resources that might have leaked when ctrl-C E2E tests.
 	 az group list | jq '.[].name' | grep E2E-Test | xargs -n1 az group delete -y --no-wait -g
 

--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -37,7 +37,7 @@ import (
 )
 
 const secretsInitContainerImage = "docker/ecs-secrets-sidecar"
-const searchDomainInitContainerImage = "docker/ecs-searchdomain-sidecar"
+const searchDomainInitContainerImage = "docker/ecs-searchdomain-sidecar:1.0"
 
 func (b *ecsAPIService) createTaskDefinition(project *types.Project, service types.ServiceConfig, resources awsResources) (*ecs.TaskDefinition, error) {
 	cpu, mem, err := toLimits(service)

--- a/ecs/testdata/simple/simple-cloudformation-conversion.golden
+++ b/ecs/testdata/simple/simple-cloudformation-conversion.golden
@@ -234,7 +234,7 @@
               "TestSimpleConvert.local"
             ],
             "Essential": "false",
-            "Image": "docker/ecs-searchdomain-sidecar",
+            "Image": "docker/ecs-searchdomain-sidecar:1.0",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* pin  docker/ecs-searchdomain-sidecar:1.0
* Add targets to makefile for publishing new tags
* pushed  docker/ecs-searchdomain-sidecar:1.0

**Related issue**
ECS E2E tests not validate cross container communication with https://github.com/docker/compose-cli/pull/849

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.redd.it/393zq2ks2up11.jpg)