### PR TITLE
Sorting env pair array to avoid creating different CloudFormation templates between calls

### DIFF
--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -288,6 +288,13 @@ func createEnvironment(project *types.Project, service types.ServiceConfig) ([]e
 			Value: value,
 		})
 	}
+
+	//order env keys for idempotence between calls
+	//to avoid unnecessary resource recreations on CloudFormation
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].Name < pairs[j].Name
+	})
+
 	return pairs, nil
 }
 


### PR DESCRIPTION
Sorting env pair array to avoid creating different CloudFormation templates between calls

**What I did**
Sorted ENV key value array before marshal so that two consecutive "convert" with the same input docker-compose.yml contents generates the same template contents.

A random ordering was taking place before because ENV is read from a map, which doesn't guarantee key ordering.

This was tested against ECS and it was verified that TaskDefinitions/Task recreations only occur when ENVs are really changed. See below:

Before changing one ENV

![image](https://user-images.githubusercontent.com/7790172/97788435-ad833180-1b97-11eb-8feb-eb2a4c0f9aa1.png)

After changing one ENV from service "admin-backend"

![image](https://user-images.githubusercontent.com/7790172/97788474-005ce900-1b98-11eb-820a-4079ccbf2518.png)

Verify that version increment occured only to "admin-backend". Before this all services were updated.

**Related issue**
#858

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/7790172/97788207-0baf1500-1b96-11eb-99c0-8d56c956d64c.png)
:)