### PR TITLE
Nicer cleanup make target for ACI resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,9 @@ publish-aci-sidecar: build-aci-sidecar ## build & publish aci sidecar image with
 	docker pull docker/aci-hostnames-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/aci-hostnames-sidecar:$(tag)
 
 clean-aci-e2e: ## Make sure no ACI tests are currently runnnig in the CI when invoking this. Delete ACI E2E tests resources that might have leaked when ctrl-C E2E tests.
-	 az group list | jq '.[].name' | grep E2E-Test | xargs -n1 az group delete -y --no-wait -g
+	@ echo "Will delete resource groups: "
+	@ az group list | jq '.[].name' | grep -i E2E-Test
+	az group list | jq '.[].name' | grep -i E2E-Test | xargs -n1 az group delete -y --no-wait -g
 
 help: ## Show help
 	@echo Please specify a build target. The choices are:


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Display resource groups that are going to be cleaned up
* grep ignore case, sometimes we have case difference in test resource group names

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/98/0f/45/980f451b0f2528f6867a8d422678714e.jpg)