### PR TITLE
Update main readme mission statement to mention Compose applications & remove beta warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Continuous%20integration/badge.svg)](https://github.com/docker/compose-cli/actions)
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Cloud%20integration%20tests/badge.svg)](https://github.com/docker/compose-cli/actions)
 
-This CLI tool makes it easy to run containers in the cloud using either Amazon
+This CLI tool makes it easy to run Docker containers and Docker Compose applications in the cloud using either Amazon
 Elastic Container Service
 ([ECS](https://aws.amazon.com/ecs))
 or Microsoft Azure Container Instances
@@ -20,13 +20,13 @@ To get started, all you need is:
 * Linux:
   [Install script](INSTALL.md)
 
-:warning: *This CLI is currently in beta please create*
-*[issues](https://github.com/docker/compose-cli/issues) to leave feedback*
+Please create [issues](https://github.com/docker/compose-cli/issues) to leave feedback.
 
 ## Examples
 
 * ECS: [Deploying Wordpress to the cloud](https://www.docker.com/blog/deploying-wordpress-to-the-cloud/)
 * ACI: [Deploying a Minecraft server to the cloud](https://www.docker.com/blog/deploying-a-minecraft-docker-server-to-the-cloud/)
+* ACI: [Setting Up Cloud Deployments Using Docker, Azure and Github Actions](https://www.docker.com/blog/setting-up-cloud-deployments-using-docker-azure-and-github-actions/)
 
 ## Development
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Update main readme mission statement to mention Compose applications
* remove Beta warning
* add ACI example on CI deployments

**Related issue**
https://github.com/docker/compose-cli/issues/809

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://twistedsifter.files.wordpress.com/2015/11/photoshopped-animal-hybrids-9.jpg?w=800&h=684)