### PR TITLE
Display ecs status in CamelCase in order to have homogeneous output between backends.

### DIFF
--- a/ecs/down.go
+++ b/ecs/down.go
@@ -68,7 +68,7 @@ func doDelete(ctx context.Context, delete func(ctx context.Context, arn string) 
 		w.Event(progress.Event{
 			ID:         r.LogicalID,
 			Status:     progress.Working,
-			StatusText: "DELETE_IN_PROGRESS",
+			StatusText: "DeleteInProgress",
 		})
 		return delete(ctx, r.ARN)
 	}

--- a/ecs/wait.go
+++ b/ecs/wait.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/compose-cli/progress"
-
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/iancoleman/strcase"
+
+	"github.com/docker/compose-cli/progress"
 )
 
 func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, operation int, ignored ...string) error { //nolint:gocyclo
@@ -103,7 +104,7 @@ func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, op
 			w.Event(progress.Event{
 				ID:         resource,
 				Status:     progressStatus,
-				StatusText: fmt.Sprintf("%s %s", status, reason),
+				StatusText: fmt.Sprintf("%s %s", toCamelCase(status), reason),
 			})
 		}
 		if operation != stackCreate || stackErr != nil {
@@ -124,4 +125,8 @@ func (b *ecsAPIService) WaitStackCompletion(ctx context.Context, name string, op
 	}
 
 	return stackErr
+}
+
+func toCamelCase(status string) string {
+	return strcase.ToCamel(strings.ToLower(status))
 }

--- a/ecs/wait_test.go
+++ b/ecs/wait_test.go
@@ -1,0 +1,27 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ecs
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestStatusCamelCase(t *testing.T) {
+	assert.Equal(t, toCamelCase("CREATE_IN_PROGRESS"), "CreateInProgress")
+}

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/iancoleman/strcase v0.1.2
 	github.com/joho/godotenv v1.3.0
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -313,6 +313,8 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDG
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.1.2 h1:gnomlvw9tnV3ITTAxzKSgTF+8kFWcU/f+TgttpXGz1U=
+github.com/iancoleman/strcase v0.1.2/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -148,7 +148,7 @@ func TestCompose(t *testing.T) {
 
 		checkUp := func(t poll.LogT) poll.Result {
 			out := res.Stdout()
-			if !strings.Contains(out, "DELETE_COMPLETE") {
+			if !strings.Contains(out, "DeleteComplete") {
 				return poll.Continue("current status \n%s\n", out)
 			}
 			return poll.Success()


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* toCamelCase(ecsStatus). 
* did not change global status display in progress because we are displaying status and reason from ECS. 

display examples: 
```
[+] Running 8/14
 ⠹ demo-multi-port          CreateInProgress User Initiated                           16.3s
 ⠹ CloudMap                 CreateInProgress Resource creation Initiated         12.2s
 ⠿ Cluster                  CreateComplete                                                             5.0s


[+] Running 3/7
 ⠇ demo-multi-port        DeleteInProgress User Initiated                    15.9s
 ⠇ DbService              DeleteInProgress                                                14.9s
 ⠿ DefaultNetworkIngress  DeleteComplete                                         1.0s
 ⠇ WebService             DeleteInProgress                                               14.9s
 ⠿ Default80Ingress       DeleteComplete                                              1.0s
```

**Related issue**
https://github.com/docker/compose-cli/issues/856

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://gd120jmaiorano.weebly.com/uploads/1/3/7/5/13751403/4621217.jpg?316)