### PR TITLE
Pin ECS secrets sidecar image & add makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,12 @@ build-ecs-search-sidecar:  ## build ecs search sidecar image locally and tag it 
 publish-ecs-search-sidecar: build-ecs-search-sidecar ## build & publish ecs search sidecar image with make publish-ecs-search-sidecar tag=0.1
 	docker pull docker/ecs-searchdomain-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/ecs-searchdomain-sidecar:$(tag)
 
+build-ecs-secrets-sidecar:  ## build ecs secrets sidecar image locally and tag it with make build-ecs-secrets-sidecar tag=0.1
+	docker build -t docker/ecs-secrets-sidecar:$(tag) ecs/secrets
+
+publish-ecs-secrets-sidecar: build-ecs-secrets-sidecar ## build & publish ecs secrets sidecar image with make publish-ecs-secrets-sidecar tag=0.1
+	docker pull docker/ecs-secrets-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/ecs-secrets-sidecar:$(tag)
+
 clean-aci-e2e: ## Make sure no ACI tests are currently runnnig in the CI when invoking this. Delete ACI E2E tests resources that might have leaked when ctrl-C E2E tests.
 	@ echo "Will delete resource groups: "
 	@ az group list | jq '.[].name' | grep -i E2E-Test

--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -36,7 +36,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-const secretsInitContainerImage = "docker/ecs-secrets-sidecar"
+const secretsInitContainerImage = "docker/ecs-secrets-sidecar:1.0"
 const searchDomainInitContainerImage = "docker/ecs-searchdomain-sidecar:1.0"
 
 func (b *ecsAPIService) createTaskDefinition(project *types.Project, service types.ServiceConfig, resources awsResources) (*ecs.TaskDefinition, error) {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* pin docker/ecs-secrets-sidecar:1.0 in ecs/convert.go
* check ECS E2E test fail, image not found
* add target to ublish image in makefile, and publish tag 1.0

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://static.boredpanda.com/blog/wp-content/uploads/2017/09/The-Internet-has-transformed-felines-and-birds-into-hybrid-animals-59b9d57eef555__700.jpg)