### PR TITLE
Remove obsolete flag `docker context ls --json` (that was marked hidden)

### DIFF
--- a/cli/cmd/context/ls.go
+++ b/cli/cmd/context/ls.go
@@ -57,9 +57,7 @@ func listCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Only show context names")
-	cmd.Flags().BoolVar(&opts.json, "json", false, "Format output as JSON")
 	cmd.Flags().StringVar(&opts.format, "format", "", "Format the output. Values: [pretty | json]. (Default: pretty)")
-	_ = cmd.Flags().MarkHidden("json")
 
 	return cmd
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -82,9 +82,6 @@ func TestContextDefault(t *testing.T) {
 		res = c.RunDockerCmd("context", "ls", "--format", "json")
 		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
 
-		res = c.RunDockerCmd("context", "ls", "--json")
-		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-json"))
-
 		res = c.RunDockerCmd("context", "ls", "--format", "{{ json . }}")
 		golden.Assert(t, res.Stdout(), GoldenFile("ls-out-legacy-json"))
 	})


### PR DESCRIPTION
This had been kept for VSCode extension but is not used, `docker context ls --format “{{ json . }}”` is used in the extension.

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* remove hiddent obsolete flag
* double check in VSCode extension nothing is broken

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://external-preview.redd.it/m641Qd31OebKT8Q2DHEvjtHttLQkhX6W4Nxp41RJN3A.jpg?auto=webp&s=3e330d8324ea632235292a7d1f8d9d3f7fb075fd)