### PR TITLE
Flag to import access key & secret from file

### DIFF
--- a/cli/cmd/context/create_ecs.go
+++ b/cli/cmd/context/create_ecs.go
@@ -17,16 +17,18 @@
 package context
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"os"
+	"strings"
 
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/context/store"
 	"github.com/docker/compose-cli/ecs"
 	"github.com/docker/compose-cli/errdefs"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -41,14 +43,28 @@ $ docker context create ecs CONTEXT [flags]
 func createEcsCommand() *cobra.Command {
 	var localSimulation bool
 	var opts ecs.ContextParams
+	var accessKeysFile string
 	cmd := &cobra.Command{
 		Use:   "ecs CONTEXT [flags]",
 		Short: "Create a context for Amazon ECS",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Name = args[0]
+			if accessKeysFile != "" {
+				err := parseAccessKeysFile(accessKeysFile, &opts)
+				if err != nil {
+					return err
+				}
+			}
+
 			if opts.CredsFromEnv && opts.Profile != "" {
 				return fmt.Errorf("--profile and --from-env flags cannot be set at the same time")
+			}
+			if accessKeysFile != "" && opts.Profile != "" {
+				return fmt.Errorf("--profile and --access-keys flags cannot be set at the same time")
+			}
+			if opts.CredsFromEnv && accessKeysFile != "" {
+				return fmt.Errorf("--access-keys and --from-env flags cannot be set at the same time")
 			}
 			if localSimulation {
 				return runCreateLocalSimulation(cmd.Context(), args[0], opts)
@@ -60,8 +76,35 @@ func createEcsCommand() *cobra.Command {
 	addDescriptionFlag(cmd, &opts.Description)
 	cmd.Flags().BoolVar(&localSimulation, "local-simulation", false, "Create context for ECS local simulation endpoints")
 	cmd.Flags().StringVar(&opts.Profile, "profile", "", "Use an existing AWS profile")
+	cmd.Flags().StringVar(&accessKeysFile, "access-keys", "", "Use AWS access keys from file")
 	cmd.Flags().BoolVar(&opts.CredsFromEnv, "from-env", false, "Use AWS environment variables for profile, or credentials and region")
 	return cmd
+}
+
+func parseAccessKeysFile(file string, opts *ecs.ContextParams) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close() // nolint:errcheck
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+	values := map[string]string{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, "=", 2)
+		values[parts[0]] = parts[1]
+	}
+	var ok bool
+	opts.AccessKey, ok = values["AWSAccessKeyId"]
+	if !ok {
+		return fmt.Errorf("%s is missing AWSAccessKeyId", file)
+	}
+	opts.SecretKey, ok = values["AWSSecretKey"]
+	if !ok {
+		return fmt.Errorf("%s is missing AWSSecretKey", file)
+	}
+	return nil
 }
 
 func runCreateLocalSimulation(ctx context.Context, contextName string, opts ecs.ContextParams) error {


### PR DESCRIPTION
**What I did**
Introduce `--access-keys` flag on `context create ecs` command to import an AWS access key CSV file (which isn't actually CSV but key=value pairs file ¯\\_(ツ)_/¯


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
