### PR TITLE
Remap restart policies for command run

### DIFF
--- a/api/containers/api.go
+++ b/api/containers/api.go
@@ -24,16 +24,21 @@ import (
 )
 
 const (
-	// RestartPolicyAny Always restarts
-	RestartPolicyAny = "any"
 	// RestartPolicyNone Never restarts
 	RestartPolicyNone = "none"
+	// RestartPolicyAny Always restarts
+	RestartPolicyAny = "any"
 	// RestartPolicyOnFailure Restarts only on failure
 	RestartPolicyOnFailure = "on-failure"
+
+	// RestartPolicyRunNo Always restarts
+	RestartPolicyRunNo = "no"
+	// RestartPolicyRunAlways Always restarts
+	RestartPolicyRunAlways = "always"
 )
 
 // RestartPolicyList all available restart policy values
-var RestartPolicyList = []string{RestartPolicyNone, RestartPolicyAny, RestartPolicyOnFailure}
+var RestartPolicyList = []string{RestartPolicyRunNo, RestartPolicyRunAlways, RestartPolicyOnFailure}
 
 // Container represents a created container
 type Container struct {

--- a/cli/cmd/run/run.go
+++ b/cli/cmd/run/run.go
@@ -57,7 +57,7 @@ func Command(contextType string) *cobra.Command {
 	cmd.Flags().VarP(&opts.Memory, "memory", "m", "Memory limit")
 	cmd.Flags().StringArrayVarP(&opts.Environment, "env", "e", []string{}, "Set environment variables")
 	cmd.Flags().StringArrayVar(&opts.EnvironmentFiles, "env-file", []string{}, "Path to environment files to be translated as environment variables")
-	cmd.Flags().StringVarP(&opts.RestartPolicyCondition, "restart", "", containers.RestartPolicyNone, "Restart policy to apply when a container exits")
+	cmd.Flags().StringVarP(&opts.RestartPolicyCondition, "restart", "", containers.RestartPolicyRunNo, "Restart policy to apply when a container exits (no|always|on-failure)")
 	cmd.Flags().BoolVar(&opts.Rm, "rm", false, "Automatically remove the container when it exits")
 
 	if contextType == store.AciContextType {

--- a/cli/cmd/run/testdata/run-help.golden
+++ b/cli/cmd/run/testdata/run-help.golden
@@ -13,5 +13,5 @@ Flags:
   -m, --memory bytes           Memory limit
       --name string            Assign a name to the container
   -p, --publish stringArray    Publish a container's port(s). [HOST_PORT:]CONTAINER_PORT
-      --restart string         Restart policy to apply when a container exits (default "none")
+      --restart string         Restart policy to apply when a container exits (no|always|on-failure) (default "no")
   -v, --volume stringArray     Volume. Ex: storageaccount/my_share[:/absolute/path/to/target][:ro]

--- a/cli/options/run/opts.go
+++ b/cli/options/run/opts.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/docker/compose-cli/api/containers"
 	"github.com/docker/compose-cli/formatter"
-	"github.com/docker/compose-cli/utils"
 )
 
 // Opts contain run command options
@@ -93,15 +92,22 @@ func (r *Opts) ToContainerConfig(image string) (containers.ContainerConfig, erro
 	}, nil
 }
 
-func toRestartPolicy(value string) (string, error) {
-	if value == "" {
-		return containers.RestartPolicyNone, nil
-	}
-	if utils.StringContains(containers.RestartPolicyList, value) {
-		return value, nil
-	}
+var restartPolicyMap = map[string]string{
+	"":                                containers.RestartPolicyNone,
+	containers.RestartPolicyNone:      containers.RestartPolicyNone,
+	containers.RestartPolicyAny:       containers.RestartPolicyAny,
+	containers.RestartPolicyOnFailure: containers.RestartPolicyOnFailure,
 
-	return "", fmt.Errorf("invalid restart value, must be one of %s", strings.Join(containers.RestartPolicyList, ", "))
+	containers.RestartPolicyRunNo:     containers.RestartPolicyNone,
+	containers.RestartPolicyRunAlways: containers.RestartPolicyAny,
+}
+
+func toRestartPolicy(value string) (string, error) {
+	value, ok := restartPolicyMap[value]
+	if !ok {
+		return "", fmt.Errorf("invalid restart value, must be one of %s", strings.Join(containers.RestartPolicyList, ", "))
+	}
+	return value, nil
 }
 
 func (r *Opts) toPorts() ([]containers.Port, error) {

--- a/cli/options/run/opts_test.go
+++ b/cli/options/run/opts_test.go
@@ -201,9 +201,20 @@ func TestValidateRestartPolicy(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			in:            "no",
+			expected:      "none",
+			expectedError: nil,
+		},
+		{
+			in:            "always",
+			expected:      "any",
+			expectedError: nil,
+		},
+
+		{
 			in:            "toto",
 			expected:      "",
-			expectedError: errors.New("invalid restart value, must be one of none, any, on-failure"),
+			expectedError: errors.New("invalid restart value, must be one of no, always, on-failure"),
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
**What I did**
Remap restart policies for command run
This adds 'no' and 'always' as options.

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/877

**Tests**
/test-aci
