### PR TITLE
ECS E2E timeout update due to flakiness in CI

### DIFF
--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -134,7 +134,7 @@ func TestCompose(t *testing.T) {
 	})
 
 	t.Run("Words GET validating cross service connection", func(t *testing.T) {
-		out := HTTPGetWithRetry(t, wordsURL, http.StatusOK, 5*time.Second, 180*time.Second)
+		out := HTTPGetWithRetry(t, wordsURL, http.StatusOK, 5*time.Second, 240*time.Second)
 		assert.Assert(t, strings.Contains(out, `"word":`))
 	})
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
E2E timeout 3 mins => 4mins , waiting for name resolution between containers

**Related issue**
https://github.com/docker/compose-cli/runs/1363717278

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
