### PR TITLE
Minor refactoring: Move list of run specific flags where it’s used

### DIFF
--- a/api/containers/api.go
+++ b/api/containers/api.go
@@ -39,9 +39,6 @@ const (
 	RestartPolicyRunAlways = "always"
 )
 
-// RestartPolicyList all available restart policy values
-var RestartPolicyList = []string{RestartPolicyRunNo, RestartPolicyRunAlways, RestartPolicyOnFailure}
-
 // Container represents a created container
 type Container struct {
 	ID          string

--- a/cli/options/run/opts.go
+++ b/cli/options/run/opts.go
@@ -53,6 +53,9 @@ type Opts struct {
 	HealthTimeout          time.Duration
 }
 
+// RestartPolicyList all available restart policy values
+var RestartPolicyList = []string{containers.RestartPolicyRunNo, containers.RestartPolicyRunAlways, containers.RestartPolicyOnFailure}
+
 // ToContainerConfig convert run options to a container configuration
 func (r *Opts) ToContainerConfig(image string) (containers.ContainerConfig, error) {
 	if r.Name == "" {
@@ -124,7 +127,7 @@ var restartPolicyMap = map[string]string{
 func toRestartPolicy(value string) (string, error) {
 	value, ok := restartPolicyMap[value]
 	if !ok {
-		return "", fmt.Errorf("invalid restart value, must be one of %s", strings.Join(containers.RestartPolicyList, ", "))
+		return "", fmt.Errorf("invalid restart value, must be one of %s", strings.Join(RestartPolicyList, ", "))
 	}
 	return value, nil
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Move const specific to run command where it's used

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://albertmoyerjr.files.wordpress.com/2013/10/funny-bizarre-animal-blends-photo-manipulation-monkey-bird-7.jpg)