### PR TITLE
Avoid nil pointer when reading logs of a just terminated container.

### DIFF
--- a/aci/aci.go
+++ b/aci/aci.go
@@ -282,6 +282,9 @@ func getACIContainerLogs(ctx context.Context, aciContext store.AciContext, conta
 	if err != nil {
 		return "", fmt.Errorf("cannot get container logs: %v", err)
 	}
+	if logs.Content == nil {
+		return "", nil
+	}
 	return *logs.Content, err
 }
 


### PR DESCRIPTION
Hit this when following logs of a container restarted with a health check: 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x168771e]

goroutine 1 [running]:
github.com/docker/compose-cli/aci.getACIContainerLogs(0x2d85260, 0xc000526c60, 0xc0001465a0, 0x24, 0xc0004f4da0, 0xa, 0xc0004f4db0, 0x7, 0x7ffeefbffab2, 0xb, ...)
	github.com/docker/compose-cli/aci/aci.go:285 +0x1fe
github.com/docker/compose-cli/aci.streamLogs(0x2d85260, 0xc000526c60, 0xc0001465a0, 0x24, 0xc0004f4da0, 0xa, 0xc0004f4db0, 0x7, 0x7ffeefbffab2, 0xb, ...)
	github.com/docker/compose-cli/aci/aci.go:297 +0x2e5
```

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
