### PR TITLE
Deploy e2e compose stack with health check and validate it restarts failed container

### DIFF
--- a/tests/composefiles/aci_secrets_resources/compose.yml
+++ b/tests/composefiles/aci_secrets_resources/compose.yml
@@ -9,6 +9,8 @@ services:
         target: mytarget1
       - mysecret2
     deploy:
+      restart_policy:
+        condition: on-failure
       resources:
         limits:
           cpus: '0.7'
@@ -16,6 +18,9 @@ services:
         reservations:
           cpus: '0.5'
           memory: 0.5G
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/healthz"]
+      interval: 5s
 
   web2:
     build: ./web
@@ -25,6 +30,8 @@ services:
     environment:
       - PORT=8080
     deploy:
+      restart_policy:
+        condition: on-failure
       resources:
         reservations:
           cpus: '0.5'

--- a/tests/composefiles/aci_secrets_resources/web/Dockerfile
+++ b/tests/composefiles/aci_secrets_resources/web/Dockerfile
@@ -21,5 +21,6 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o server main.go
 
 FROM alpine
+RUN apk --no-cache add curl
 COPY --from=build /go/server /
 CMD /server "${PORT:-80}" "${DIR:-/run/secrets}"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Add e2e test validating AcI healthchecks

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTe4MjGaK-nnhnqyAHZKo3y3R1ig-tkD-8xHQ&usqp=CAU)