### PR TITLE
Specific error message when specifying path as a volume source

### DIFF
--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -50,7 +50,7 @@ const (
 func ToContainerGroup(ctx context.Context, aciContext store.AciContext, p types.Project, storageHelper login.StorageLogin) (containerinstance.ContainerGroup, error) {
 	project := projectAciHelper(p)
 	containerGroupName := strings.ToLower(project.Name)
-	volumesCache, volumesSlice, err := project.getAciFileVolumes(ctx, storageHelper)
+	volumesSlice, err := project.getAciFileVolumes(ctx, storageHelper)
 	if err != nil {
 		return containerinstance.ContainerGroup{}, err
 	}
@@ -90,7 +90,7 @@ func ToContainerGroup(ctx context.Context, aciContext store.AciContext, p types.
 	var dnsLabelName *string
 	for _, s := range project.Services {
 		service := serviceConfigAciHelper(s)
-		containerDefinition, err := service.getAciContainer(volumesCache)
+		containerDefinition, err := service.getAciContainer()
 		if err != nil {
 			return containerinstance.ContainerGroup{}, err
 		}
@@ -162,8 +162,8 @@ type projectAciHelper types.Project
 
 type serviceConfigAciHelper types.ServiceConfig
 
-func (s serviceConfigAciHelper) getAciContainer(volumesCache map[string]bool) (containerinstance.Container, error) {
-	aciServiceVolumes, err := s.getAciFileVolumeMounts(volumesCache)
+func (s serviceConfigAciHelper) getAciContainer() (containerinstance.Container, error) {
+	aciServiceVolumes, err := s.getAciFileVolumeMounts()
 	if err != nil {
 		return containerinstance.Container{}, err
 	}

--- a/aci/convert/volume_test.go
+++ b/aci/convert/volume_test.go
@@ -119,6 +119,30 @@ func TestComposeVolumes(t *testing.T) {
 	assert.DeepEqual(t, (*group.Volumes)[0], expectedGroupVolume)
 }
 
+func TestPathVolumeErrorMessage(t *testing.T) {
+	ctx := context.TODO()
+	accountName := "myAccount"
+	mockStorageHelper.On("GetAzureStorageAccountKey", ctx, accountName).Return("123456", nil)
+	project := types.Project{
+		Services: []types.ServiceConfig{
+			{
+				Name:  "service1",
+				Image: "image1",
+				Volumes: []types.ServiceVolumeConfig{
+					{
+						Source: "/path",
+						Target: "/target",
+						Type:   string(types.VolumeTypeBind),
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ToContainerGroup(ctx, convertCtx, project, mockStorageHelper)
+	assert.ErrorContains(t, err, `host path ("/path") not allowed as volume source, you need to reference an Azure File Share defined in the 'volumes' section`)
+}
+
 func TestComposeVolumesRO(t *testing.T) {
 	ctx := context.TODO()
 	accountName := "myAccount"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
add specific error message when user tries to specify a host path in compose file

**Related issue**
https://github.com/docker/compose-cli/issues/865

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://miro.medium.com/max/600/0*_u8R30i-MKMXGkuW)