### PR TITLE
Use ACI .IsHttpStatus() rather than accessing .StatusCode directly

### DIFF
--- a/aci/aci.go
+++ b/aci/aci.go
@@ -173,7 +173,7 @@ func stopACIContainerGroup(ctx context.Context, aciContext store.AciContext, con
 	}
 
 	result, err := containerGroupsClient.Stop(ctx, aciContext.ResourceGroup, containerGroupName)
-	if result.StatusCode == http.StatusNotFound {
+	if result.IsHTTPStatus(http.StatusNotFound) {
 		return errdefs.ErrNotFound
 	}
 	return err

--- a/aci/compose.go
+++ b/aci/compose.go
@@ -62,7 +62,7 @@ func (cs *aciComposeService) Down(ctx context.Context, project string) error {
 	if err != nil {
 		return err
 	}
-	if cg.StatusCode == http.StatusNoContent {
+	if cg.IsHTTPStatus(http.StatusNoContent) {
 		return errdefs.ErrNotFound
 	}
 

--- a/aci/containers.go
+++ b/aci/containers.go
@@ -223,7 +223,7 @@ func (cs *aciContainerService) Delete(ctx context.Context, containerID string, r
 
 	cg, err := deleteACIContainerGroup(ctx, cs.ctx, groupName)
 	// Delete returns `StatusNoContent` if the group is not found
-	if cg.StatusCode == http.StatusNoContent {
+	if cg.IsHTTPStatus(http.StatusNoContent) {
 		return errdefs.ErrNotFound
 	}
 	if err != nil {

--- a/aci/volumes.go
+++ b/aci/volumes.go
@@ -223,7 +223,7 @@ func (cs *aciVolumeService) Delete(ctx context.Context, id string, options inter
 		if err == nil {
 			if _, ok := account.Tags[dockerVolumeTag]; ok {
 				result, err := storageAccountsClient.Delete(ctx, cs.aciContext.ResourceGroup, storageAccount)
-				if result.StatusCode == http.StatusNoContent {
+				if result.IsHTTPStatus(http.StatusNoContent) {
 					return errors.Wrapf(errdefs.ErrNotFound, "storage account %s does not exist", storageAccount)
 				}
 				return err


### PR DESCRIPTION
that might lead to nil pointer panic

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
is in the title

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://zenitube.com/img/posts/2016/0003animal-photoshop/14-geckobat.jpg)