### PR TITLE
Collect metrics --help flag

### DIFF
--- a/metrics/commands.go
+++ b/metrics/commands.go
@@ -18,7 +18,7 @@ package metrics
 
 var commandFlags = []string{
 	//added to catch scan details
-	"--version", "--login", "--help",
+	"--version", "--login",
 }
 
 // Generated with generatecommands/main.go

--- a/metrics/commands.go
+++ b/metrics/commands.go
@@ -23,6 +23,7 @@ var commandFlags = []string{
 
 // Generated with generatecommands/main.go
 var managementCommands = []string{
+	"help",
 	"ecs",
 	"scan",
 	"app",

--- a/metrics/commands.go
+++ b/metrics/commands.go
@@ -18,7 +18,7 @@ package metrics
 
 var commandFlags = []string{
 	//added to catch scan details
-	"--version", "--login",
+	"--version", "--login", "--help",
 }
 
 // Generated with generatecommands/main.go

--- a/metrics/generatecommands/main.go
+++ b/metrics/generatecommands/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	fmt.Printf(`
 var managementCommands = []string{
+	"help",
 	"%s",
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -17,6 +17,8 @@
 package metrics
 
 import (
+	"strings"
+
 	"github.com/docker/compose-cli/utils"
 )
 
@@ -51,15 +53,15 @@ func GetCommand(args []string) string {
 	result := ""
 	onlyFlags := false
 	for _, arg := range args {
+		if arg == "--help" {
+			result = strings.TrimSpace(arg + " " + result)
+			continue
+		}
 		if arg == "--" {
 			break
 		}
 		if isCommandFlag(arg) || (!onlyFlags && isCommand(arg)) {
-			if result == "" {
-				result = arg
-			} else {
-				result = result + " " + arg
-			}
+			result = strings.TrimSpace(result + " " + arg)
 			if isCommand(arg) && !isManagementCommand(arg) {
 				onlyFlags = true
 			}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -51,9 +51,6 @@ func GetCommand(args []string) string {
 	result := ""
 	onlyFlags := false
 	for _, arg := range args {
-		if arg == "--help" {
-			return ""
-		}
 		if arg == "--" {
 			break
 		}
@@ -63,7 +60,7 @@ func GetCommand(args []string) string {
 			} else {
 				result = result + " " + arg
 			}
-			if !isManagementCommand(arg) {
+			if isCommand(arg) && !isManagementCommand(arg) {
 				onlyFlags = true
 			}
 		}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -174,6 +174,11 @@ func TestKeepHelpCommands(t *testing.T) {
 			args:     []string{"--help"},
 			expected: "--help",
 		},
+		{
+			name:     "help commands",
+			args:     []string{"help", "run"},
+			expected: "help run",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -162,12 +162,12 @@ func TestKeepHelpCommands(t *testing.T) {
 		{
 			name:     "run with help flag",
 			args:     []string{"run", "--help"},
-			expected: "run --help",
+			expected: "--help run",
 		},
 		{
 			name:     "with help flag before-after commands",
 			args:     []string{"compose", "--help", "up"},
-			expected: "compose --help up",
+			expected: "--help compose up",
 		},
 		{
 			name:     "help flag",

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -153,26 +153,26 @@ func TestGetCommand(t *testing.T) {
 	}
 }
 
-func TestIgnoreHelpCommands(t *testing.T) {
+func TestKeepHelpCommands(t *testing.T) {
 	testCases := []struct {
 		name     string
 		args     []string
 		expected string
 	}{
 		{
-			name:     "help",
-			args:     []string{"--help"},
-			expected: "",
-		},
-		{
-			name:     "help on run",
+			name:     "run with help flag",
 			args:     []string{"run", "--help"},
-			expected: "",
+			expected: "run --help",
 		},
 		{
-			name:     "help on compose up",
-			args:     []string{"compose", "up", "--help"},
-			expected: "",
+			name:     "with help flag before-after commands",
+			args:     []string{"compose", "--help", "up"},
+			expected: "compose --help up",
+		},
+		{
+			name:     "help flag",
+			args:     []string{"--help"},
+			expected: "--help",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Add --help in specific flags we catch in metrics

**Related issue**
https://docker.slack.com/archives/C0111G2RCE4/p1605266835109100

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://www.psd-dude.com/tutorials/resources-images/animal-morph-photoshop-tutorials/morphing-photoshop-tutorial.jpg)