### PR TITLE
Add support for gpu devices reservation

### DIFF
--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -319,6 +319,21 @@ services:
 	def = template.Resources["TestTaskDefinition"].(*ecs.TaskDefinition)
 	assert.Equal(t, def.Cpu, "")
 	assert.Equal(t, def.Memory, "")
+
+	template = convertYaml(t, `
+services:
+  test:
+    image: nginx
+    deploy:
+      resources:
+        reservations:
+          devices: 
+            - capabilities: [gpu]
+              count: 2
+`, useDefaultVPC, useGPU)
+	def = template.Resources["TestTaskDefinition"].(*ecs.TaskDefinition)
+	assert.Equal(t, def.Cpu, "")
+	assert.Equal(t, def.Memory, "")
 }
 
 func TestLoadBalancerTypeNetwork(t *testing.T) {

--- a/ecs/compatibility.go
+++ b/ecs/compatibility.go
@@ -65,6 +65,8 @@ var compatibleComposeAttributes = []string{
 	"services.deploy.resources.reservations",
 	"services.deploy.resources.reservations.cpus",
 	"services.deploy.resources.reservations.memory",
+	"services.deploy.resources.reservations.devices",
+	"services.deploy.resources.reservations.devices.count",
 	"services.deploy.resources.reservations.generic_resources",
 	"services.deploy.resources.reservations.generic_resources.discrete_resource_spec",
 	"services.deploy.update_config",
@@ -154,6 +156,14 @@ func (c *fargateCompatibilityChecker) CheckUlimits(service *types.ServiceConfig)
 		if k != "nofile" {
 			c.Unsupported("services.ulimits.%s is not supported by Fargate", k)
 			delete(service.Ulimits, k)
+		}
+	}
+}
+
+func (c *fargateCompatibilityChecker) CheckDeployResourcesDevicesCapabilities(s string, r types.DeviceRequest) {
+	for _, cap := range r.Capabilities {
+		if cap != "gpu" {
+			c.Unsupported("services.deploy.resources.%s.devices.capabilities = %s", s, cap)
 		}
 	}
 }

--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -562,6 +562,11 @@ func gpuRequirements(s types.ServiceConfig) int64 {
 					return resource.DiscreteResourceSpec.Value
 				}
 			}
+			for _, device := range reservations.Devices {
+				if len(device.Capabilities) == 1 && device.Capabilities[0] == "gpu" {
+					return int64(device.Count)
+				}
+			}
 		}
 	}
 	return 0

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go v1.35.15
 	github.com/awslabs/goformation/v4 v4.15.3
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
-	github.com/compose-spec/compose-go v0.0.0-20201104130931-5afecaa4cb35
+	github.com/compose-spec/compose-go v0.0.0-20201116112017-777513ca88e2
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.3.5 // indirect
 	github.com/docker/cli v0.0.0-20200528204125-dd360c7c0de8
@@ -36,7 +36,7 @@ require (
 	github.com/gobwas/ws v1.0.4
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.3
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/hashicorp/go-multierror v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/compose-spec/compose-go v0.0.0-20201104130931-5afecaa4cb35 h1:HLxSiPmzCkBi3mGgxHQGBi3vxUuzT72Q9xjG49hkvSA=
-github.com/compose-spec/compose-go v0.0.0-20201104130931-5afecaa4cb35/go.mod h1:cBdHyUvAothdUpqXANCfTHU7cEqsXRvSiLxjhOTuwvc=
+github.com/compose-spec/compose-go v0.0.0-20201116112017-777513ca88e2 h1:m6m0rnxmq3mPapGNAWqO6FLYg6GST7tJAAZqJ0pjadk=
+github.com/compose-spec/compose-go v0.0.0-20201116112017-777513ca88e2/go.mod h1:cZJ8y+zQzrYfN5XnEu/kMeDEP0V2D9ojF7Rb4nrneUc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -256,8 +256,8 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
-github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.3 h1:x95R7cp+rSeeqAMI2knLtQ0DKlaBhv2NrtrOvafPHRo=
+github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=


### PR DESCRIPTION
**What I did**
In addition to swarm-style for generic_resources, support devices reservation as defined by Adopt https://github.com/compose-spec/compose-spec/pull/100

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
