### PR TITLE
Don't mess with exiting .aws/credentials

### DIFF
--- a/ecs/context.go
+++ b/ecs/context.go
@@ -199,8 +199,15 @@ func (h contextCreateAWSHelper) saveCredentials(profile string, accessKeyID stri
 		return err
 	}
 
-	credIni := ini.Empty()
-	section, err := credIni.NewSection(profile)
+	credentials, err := ini.Load(file)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		credentials = ini.Empty()
+	}
+
+	section, err := credentials.NewSection(profile)
 	if err != nil {
 		return err
 	}
@@ -212,7 +219,7 @@ func (h contextCreateAWSHelper) saveCredentials(profile string, accessKeyID stri
 	if err != nil {
 		return err
 	}
-	return credIni.SaveTo(file)
+	return credentials.SaveTo(file)
 }
 
 func (h contextCreateAWSHelper) saveRegion(profile, region string) error {


### PR DESCRIPTION
**What I did**
Fix ECS context creation by secret+token to override existing .aws/credentials file

**Related issue**
https://github.com/docker/compose-cli/issues/910

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
