### PR TITLE
Use json to marshall ecs-local enhanced docker-compose config

### DIFF
--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -57,7 +58,7 @@ func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project, deta
 		return fmt.Errorf("ECS simulation mode require Docker-compose 1.27, found %s", version)
 	}
 
-	converted, err := e.Convert(ctx, project, "yaml")
+	converted, err := e.Convert(ctx, project, "json")
 	if err != nil {
 		return err
 	}
@@ -137,7 +138,15 @@ func (e ecsLocalSimulation) Convert(ctx context.Context, project *types.Project,
 		"secrets":  project.Secrets,
 		"configs":  project.Configs,
 	}
-	return yaml.Marshal(config)
+	switch format {
+	case "json":
+		return json.MarshalIndent(config, "", "  ")
+	case "yaml":
+		return yaml.Marshal(config)
+	default:
+		return nil, fmt.Errorf("unsupported format %q", format)
+	}
+
 }
 
 func (e ecsLocalSimulation) Down(ctx context.Context, projectName string) error {


### PR DESCRIPTION
**What I did**
marshall compose enhanced model to docker-compose in json to workaround format mismatch with un-quoted strings.

**Related issue**
close https://github.com/docker/compose-cli/issues/914


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/99376227-f4299900-28c4-11eb-9ede-49175acf0988.png)
