### PR TITLE
Run convergence in service dependency order

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -79,8 +79,8 @@ func (s *local) Up(ctx context.Context, project *types.Project, detach bool) err
 		}
 	}
 
-	err := inDependencyOrder(ctx, project, func(service types.ServiceConfig) error {
-		return s.ensureService(ctx, project, service)
+	err := inDependencyOrder(ctx, project, func(c context.Context, service types.ServiceConfig) error {
+		return s.ensureService(c, project, service)
 	})
 	return err
 }

--- a/local/compose.go
+++ b/local/compose.go
@@ -389,10 +389,10 @@ func getContainerCreateOptions(p *types.Project, s types.ServiceConfig, number i
 		MacAddress:      s.MacAddress,
 		Labels:          labels,
 		StopSignal:      s.StopSignal,
-		//		Env:             s.Environment, FIXME conversion
-		//		Healthcheck:     s.HealthCheck, FIXME conversion
+		Env:             toMobyEnv(s.Environment),
+		Healthcheck:     toMobyHealthCheck(s.HealthCheck),
 		// Volumes:         // FIXME unclear to me the overlap with HostConfig.Mounts
-		// StopTimeout: 	 s.StopGracePeriod FIXME conversion
+		StopTimeout: toSeconds(s.StopGracePeriod),
 	}
 
 	mountOptions := buildContainerMountOptions(p, s, inherit)

--- a/local/convergence.go
+++ b/local/convergence.go
@@ -223,6 +223,9 @@ func (s *local) recreateContainer(ctx context.Context, project *types.Project, s
 func setDependentLifecycle(project *types.Project, service string, strategy string) {
 	for i, s := range project.Services {
 		if contains(s.GetDependencies(), service) {
+			if s.Extensions == nil {
+				s.Extensions = map[string]interface{}{}
+			}
 			s.Extensions[extLifecycle] = strategy
 			project.Services[i] = s
 		}

--- a/local/convert.go
+++ b/local/convert.go
@@ -23,7 +23,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	compose "github.com/compose-spec/compose-go/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
@@ -91,6 +93,57 @@ func toPorts(ports []types.Port) []containers.Port {
 	}
 
 	return result
+}
+
+func toMobyEnv(environment compose.MappingWithEquals) []string {
+	var env []string
+	for k, v := range environment {
+		if v == nil {
+			env = append(env, k)
+		} else {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+	return env
+}
+
+func toMobyHealthCheck(check *compose.HealthCheckConfig) *container.HealthConfig {
+	if check == nil {
+		return nil
+	}
+	var (
+		interval time.Duration
+		timeout  time.Duration
+		period   time.Duration
+		retries  int
+	)
+	if check.Interval != nil {
+		interval = time.Duration(*check.Interval)
+	}
+	if check.Timeout != nil {
+		timeout = time.Duration(*check.Timeout)
+	}
+	if check.StartPeriod != nil {
+		period = time.Duration(*check.StartPeriod)
+	}
+	if check.Retries != nil {
+		retries = int(*check.Retries)
+	}
+	return &container.HealthConfig{
+		Test:        check.Test,
+		Interval:    interval,
+		Timeout:     timeout,
+		StartPeriod: period,
+		Retries:     retries,
+	}
+}
+
+func toSeconds(d *compose.Duration) *int {
+	if d == nil {
+		return nil
+	}
+	s := int(time.Duration(*d).Seconds())
+	return &s
 }
 
 func fromPorts(ports []containers.Port) (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {

--- a/local/convert.go
+++ b/local/convert.go
@@ -101,7 +101,7 @@ func toMobyEnv(environment compose.MappingWithEquals) []string {
 		if v == nil {
 			env = append(env, k)
 		} else {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
+			env = append(env, fmt.Sprintf("%s=%s", k, *v))
 		}
 	}
 	return env

--- a/local/dependencies.go
+++ b/local/dependencies.go
@@ -62,9 +62,9 @@ type node struct {
 	dependent    []string
 }
 
-func (d dependencyGraph) independents() []node {
+func (graph dependencyGraph) independents() []node {
 	var nodes []node
-	for _, node := range d {
+	for _, node := range graph {
 		if len(node.dependencies) == 0 {
 			nodes = append(nodes, node)
 		}

--- a/local/dependencies_test.go
+++ b/local/dependencies_test.go
@@ -49,7 +49,7 @@ func TestInDependencyOrder(t *testing.T) {
 		},
 	}
 	//nolint:errcheck, unparam
-	go inDependencyOrder(context.TODO(), &project, func(config types.ServiceConfig) error {
+	go inDependencyOrder(context.TODO(), &project, func(ctx context.Context, config types.ServiceConfig) error {
 		order <- config.Name
 		return nil
 	})

--- a/local/util.go
+++ b/local/util.go
@@ -40,12 +40,3 @@ func contains(slice []string, item string) bool {
 	}
 	return false
 }
-
-func containsAll(slice []string, items []string) bool {
-	for _, i := range items {
-		if !contains(slice, i) {
-			return false
-		}
-	}
-	return true
-}


### PR DESCRIPTION
**What I did**
sort services in respect to dependency order so as we recreate one we can flag it's dependent services as `force_recreate` before convergence is applied on those.

Also fix a panic with attempt to write to `results` channel while already closed. Replaced by a dedicated errors channel. 

Bonus: implement `service_healthy` depends_on condition for parity with docker-compose

can be tested using:
```yaml
services:
  jenkins:
    image: jenkins/jenkins:lts
    healthcheck: 
      test: "curl http://localhost:8080/login"
  redis:
    image: redis
    depends_on:
      jenkins:
        condition: service_healthy
```

`compose up` will demonstrate jenkins service being created, and redis one only created after a delay (healthy state)
then change jenkins service configuration, `compose up` will recreate jenkins service _then_ recreate redis one.


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
