### PR TITLE
Local compose ls implementation

### DIFF
--- a/local/compose_test.go
+++ b/local/compose_test.go
@@ -1,0 +1,68 @@
+// +build local
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose-cli/api/compose"
+)
+
+func TestContainersToStacks(t *testing.T) {
+	containers := []types.Container{
+		{
+			ID:     "service1",
+			State:  "running",
+			Labels: map[string]string{projectLabel: "project1"},
+		},
+		{
+			ID:     "service2",
+			State:  "running",
+			Labels: map[string]string{projectLabel: "project1"},
+		},
+		{
+			ID:     "service3",
+			State:  "running",
+			Labels: map[string]string{projectLabel: "project2"},
+		},
+	}
+	stacks, err := containersToStacks(containers)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, stacks, []compose.Stack{
+		{
+			ID:     "project1",
+			Name:   "project1",
+			Status: "running(2)",
+		},
+		{
+			ID:     "project2",
+			Name:   "project2",
+			Status: "running(1)",
+		},
+	})
+}
+
+func TestStacksMixedStatus(t *testing.T) {
+	assert.Equal(t, combinedStatus([]string{"running"}), "running(1)")
+	assert.Equal(t, combinedStatus([]string{"running", "running", "running"}), "running(3)")
+	assert.Equal(t, combinedStatus([]string{"running", "exited", "running"}), "exited(1), running(2)")
+}

--- a/local/convergence.go
+++ b/local/convergence.go
@@ -24,12 +24,13 @@ import (
 	"strconv"
 
 	"github.com/compose-spec/compose-go/types"
-	"github.com/docker/compose-cli/api/containers"
-	"github.com/docker/compose-cli/progress"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose-cli/api/containers"
+	"github.com/docker/compose-cli/progress"
 )
 
 func (s *local) ensureService(ctx context.Context, project *types.Project, service types.ServiceConfig) error {

--- a/local/labels.go
+++ b/local/labels.go
@@ -34,3 +34,7 @@ const (
 func projectFilter(projectName string) filters.KeyValuePair {
 	return filters.Arg("label", fmt.Sprintf("%s=%s", projectLabel, projectName))
 }
+
+func hasProjectLabelFilter() filters.KeyValuePair {
+	return filters.Arg("label", projectLabel)
+}


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
Add implementation for compose ls

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/8d/66/a3/8d66a32aeaaeec04cec25986f62eee86.jpg)