### PR TITLE
compose ps implementation

### DIFF
--- a/local/compose_test.go
+++ b/local/compose_test.go
@@ -61,6 +61,47 @@ func TestContainersToStacks(t *testing.T) {
 	})
 }
 
+func TestContainersToServiceStatus(t *testing.T) {
+	containers := []types.Container{
+		{
+			ID:     "c1",
+			State:  "running",
+			Labels: map[string]string{serviceLabel: "service1"},
+		},
+		{
+			ID:     "c2",
+			State:  "exited",
+			Labels: map[string]string{serviceLabel: "service1"},
+		},
+		{
+			ID:     "c3",
+			State:  "running",
+			Labels: map[string]string{serviceLabel: "service1"},
+		},
+		{
+			ID:     "c4",
+			State:  "running",
+			Labels: map[string]string{serviceLabel: "service2"},
+		},
+	}
+	services, err := containersToServiceStatus(containers)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, services, []compose.ServiceStatus{
+		{
+			ID:       "service1",
+			Name:     "service1",
+			Replicas: 2,
+			Desired:  3,
+		},
+		{
+			ID:       "service2",
+			Name:     "service2",
+			Replicas: 1,
+			Desired:  1,
+		},
+	})
+}
+
 func TestStacksMixedStatus(t *testing.T) {
 	assert.Equal(t, combinedStatus([]string{"running"}), "running(1)")
 	assert.Equal(t, combinedStatus([]string{"running", "running", "running"}), "running(3)")


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* swear about manipulating collections in go
* transform a collection of containers to a collection of service status with many for loops
* unit test

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://dcassetcdn.com/w1k/submissions/9093500/9093760_585d.jpg)