### PR TITLE
Define graph.walk to run into dependencies in dependency order

### DIFF
--- a/local/util.go
+++ b/local/util.go
@@ -40,3 +40,12 @@ func contains(slice []string, item string) bool {
 	}
 	return false
 }
+
+func containsAll(slice []string, items []string) bool {
+	for _, i := range items {
+		if !contains(slice, i) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
**What I did**
Implement "process services in dependency order" by introducing `graph.walk` and a _producer_ goroutine to schedule service processing as their dependencies have been managed

also introduce a `direction` so we can run the same in reverse order for `down` 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
