### PR TITLE
X certificate

### DIFF
--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -451,6 +451,10 @@ func portIsHTTP(it types.ServicePortConfig) bool {
 		protocol := v.(string)
 		return protocol == "http" || protocol == "https"
 	}
+	if _, ok := it.Extensions[extensionCertificate]; ok {
+		// setting certificate implies protocol = https
+		return true
+	}
 	return it.Target == 80 || it.Target == 443
 }
 

--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -128,9 +128,14 @@ func (b *ecsAPIService) createService(project *types.Project, service types.Serv
 		}
 
 		protocol := strings.ToUpper(port.Protocol)
+		if p, ok := port.Extensions[extensionProtocol]; ok {
+			protocol = strings.ToUpper(p.(string))
+		}
 		if resources.loadBalancerType == elbv2.LoadBalancerTypeEnumApplication {
-			// we don't set Https as a certificate must be specified for HTTPS listeners
 			protocol = elbv2.ProtocolEnumHttp
+			if _, ok := port.Extensions[extensionCertificate]; ok {
+				protocol = elbv2.ProtocolEnumHttps
+			}
 		}
 		targetGroupName := b.createTargetGroup(project, service, port, template, protocol, resources.vpc)
 		listenerName := b.createListener(project, service, port, template, targetGroupName, resources.loadBalancer, protocol)

--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -351,6 +351,26 @@ services:
 	assert.Check(t, loadBalancer.Type == elbv2.LoadBalancerTypeEnumNetwork)
 }
 
+func TestServiceCertificate(t *testing.T) {
+	template := convertYaml(t, `
+services:
+  test:
+    image: nginx
+    ports:
+      - target: 443
+        x-aws-certificate: certificate 
+secrets:
+  certificate:
+    external: true
+    name: "arn:123:abc"
+`, useDefaultVPC)
+	l := template.Resources["Test443Listener"]
+	assert.Check(t, l != nil)
+	listener := *l.(*elasticloadbalancingv2.Listener)
+	assert.Equal(t, len(listener.Certificates), 1)
+	assert.Equal(t, listener.Certificates[0].CertificateArn, "arn:123:abc")
+}
+
 func TestUseExternalNetwork(t *testing.T) {
 	template := convertYaml(t, `
 services:

--- a/ecs/x.go
+++ b/ecs/x.go
@@ -30,4 +30,5 @@ const (
 	extensionRole            = "x-aws-role"
 	extensionManagedPolicies = "x-aws-policies"
 	extensionAutoScaling     = "x-aws-autoscaling"
+	extensionCertificate     = "x-aws-certificate"
 )


### PR DESCRIPTION
**What I did**
Added support to configure SSL termination by LoadBalancer

**how to test**

1. Create a (self-signed) certificate or use AWS Certificate Manager to get one for your domain.
I'm using `aws.loof.fr` here

```console
openssl genrsa -out aws.loof.fr.key 2048
echo "
[req]
distinguished_name=req
[SAN]
subjectAltName=DNS:aws.loof.fr " > aws.loof.fr.conf
openssl req -new -x509 -key aws.loof.fr.key -out aws.loof.fr.cert -days 3650 -subj /CN=aws.loof.fr -extensions SAN -config 'aws.loof.fr.conf'
```

2. Import this certificate into AWS Certificate Manager

3. Configure compose app with an external secret for certificate ARN, and service to refer to it by `x-aws-certificate`:

```yaml
services:
  web:
    image: nginx
    ports:
      - target: 80
        x-aws-certificate: certificate

secrets:
  certificate:
    external: true
    name: "arn:aws:acm:us-east-1:123abc:certificate/123-abc-456-def"
```


**Related issue**
https://github.com/docker/compose-cli/issues/775

4. run `docker compose up`

5. configure DNS CNAME for your domain to point to application LoadBalancer

6. access your domain

```console
~ curl  --insecure https://aws.loof.fr:80
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
...
```

**TODO**
- manage secret as a file within the compose project (not as an `external`)
- define inner loop experience with certificates

I wonder this would be better addressed as a `route`, as certificate will only apply to external service connectivity, not service-2-service (until we introduce AppMesh support here?) 
see discussion on https://github.com/compose-spec/compose-spec/issues/111

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

