### PR TITLE
Change resource reservation in e2e tests, fighting ACI flakyness

### DIFF
--- a/aci/aci.go
+++ b/aci/aci.go
@@ -18,9 +18,11 @@ package aci
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -41,6 +43,7 @@ import (
 	"github.com/docker/compose-cli/context/store"
 	"github.com/docker/compose-cli/errdefs"
 	"github.com/docker/compose-cli/progress"
+	"github.com/docker/compose-cli/utils"
 )
 
 func createACIContainers(ctx context.Context, aciContext store.AciContext, groupDefinition containerinstance.ContainerGroup) error {
@@ -100,6 +103,11 @@ func autocreateFileshares(ctx context.Context, project *types.Project) error {
 }
 
 func createOrUpdateACIContainers(ctx context.Context, aciContext store.AciContext, groupDefinition containerinstance.ContainerGroup) error {
+	if utils.StringContains(os.Args, "-D") {
+		bytes, _ := json.MarshalIndent(groupDefinition, "", " ")
+		fmt.Println(string(bytes))
+		return nil
+	}
 	w := progress.ContextWriter(ctx)
 	containerGroupsClient, err := login.NewContainerGroupsClient(aciContext.SubscriptionID)
 	if err != nil {

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -262,12 +262,9 @@ func TestRunVolume(t *testing.T) {
 
 	t.Run("run", func(t *testing.T) {
 		mountTarget := "/usr/share/nginx/html"
-		res := c.RunDockerCmd(
-			"run", "-d",
-			"-v", fmt.Sprintf("%s:%s", volumeID, mountTarget),
-			"-p", "80:80",
-			"nginx",
-		)
+		res := c.RunDockerCmd("-D", "run", "-d", "-v", fmt.Sprintf("%s:%s", volumeID, mountTarget), "-p", "80:80", "nginx")
+		fmt.Println(res.Stdout())
+		res = c.RunDockerCmd("run", "-d", "-v", fmt.Sprintf("%s:%s", volumeID, mountTarget), "-p", "80:80", "nginx")
 		container = getContainerName(res.Stdout())
 	})
 
@@ -537,8 +534,10 @@ func TestUpSecretsResources(t *testing.T) {
 	_, _, _ = setupTestResourceGroup(t, c)
 
 	t.Run("compose up", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "up", "-D", "-f", composefilePath, "--project-name", composeProjectName)
+		fmt.Println(res.Stdout())
 		c.RunDockerCmd("compose", "up", "-f", composefilePath, "--project-name", composeProjectName)
-		res := c.RunDockerCmd("ps")
+		res = c.RunDockerCmd("ps")
 		out := lines(res.Stdout())
 		// Check 2 containers running
 		assert.Assert(t, is.Len(out, 3))

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -584,14 +584,14 @@ func TestUpSecretsResources(t *testing.T) {
 	})
 
 	t.Run("check resource limits", func(t *testing.T) {
-		assert.Equal(t, web1Inspect.HostConfig.CPULimit, 0.7)
+		assert.Equal(t, web1Inspect.HostConfig.CPULimit, 1.7)
 		assert.Equal(t, web1Inspect.HostConfig.MemoryLimit, uint64(1073741824))
-		assert.Equal(t, web1Inspect.HostConfig.CPUReservation, 0.5)
+		assert.Equal(t, web1Inspect.HostConfig.CPUReservation, 1.5)
 		assert.Equal(t, web1Inspect.HostConfig.MemoryReservation, uint64(536870912))
 
-		assert.Equal(t, web2Inspect.HostConfig.CPULimit, 0.5)
+		assert.Equal(t, web2Inspect.HostConfig.CPULimit, 1.5)
 		assert.Equal(t, web2Inspect.HostConfig.MemoryLimit, uint64(751619276))
-		assert.Equal(t, web2Inspect.HostConfig.CPUReservation, 0.5)
+		assert.Equal(t, web2Inspect.HostConfig.CPUReservation, 1.5)
 		assert.Equal(t, web2Inspect.HostConfig.MemoryReservation, uint64(751619276))
 	})
 

--- a/tests/composefiles/aci_secrets_resources/compose.yml
+++ b/tests/composefiles/aci_secrets_resources/compose.yml
@@ -13,10 +13,10 @@ services:
         condition: on-failure
       resources:
         limits:
-          cpus: '0.7'
+          cpus: '1.7'
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: '1.5'
           memory: 0.5G
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/healthz"]
@@ -34,7 +34,7 @@ services:
         condition: on-failure
       resources:
         reservations:
-          cpus: '0.5'
+          cpus: '1.5'
           memory: 0.7G
     secrets:
       - mysecret2


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
change resource reservation in compose resource limit ACI e2e test

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
