### PR TITLE
On GH Actions windows nodes, ensure there is no automatic docker login before running ACI E2E tests

### DIFF
--- a/.github/workflows/optional-ci.yml
+++ b/.github/workflows/optional-ci.yml
@@ -141,4 +141,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-        run: make e2e-aci
+        # need to docker logout on windows nodes, it seems GHActions does a `docker login --user githubactions` specifically on windows nodes
+        run: |
+          docker logout
+          make e2e-aci


### PR DESCRIPTION
ACI currently has some flaky issue where deploying a payload containing docker credentials just freezes forever without error message

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* in windows GHActions workflow, `docker logout` before running ACI E2E tests

**Related issue**
https://github.com/docker/compose-cli/pull/952/checks?check_run_id=1442133013

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
