### PR TITLE
Bump `azure-sdk-for-go`: v43.3.0 -> v48.2.0

### DIFF
--- a/aci/aci.go
+++ b/aci/aci.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	tm "github.com/buger/goterm"
@@ -198,8 +198,11 @@ func deleteACIContainerGroup(ctx context.Context, aciContext store.AciContext, c
 	if err != nil {
 		return containerinstance.ContainerGroup{}, fmt.Errorf("cannot get container group client: %v", err)
 	}
-
-	return containerGroupsClient.Delete(ctx, aciContext.ResourceGroup, containerGroupName)
+	result, err := containerGroupsClient.Delete(ctx, aciContext.ResourceGroup, containerGroupName)
+	if err != nil {
+		return containerinstance.ContainerGroup{}, fmt.Errorf("cannot delete container group: %v", err)
+	}
+	return result.Result(containerGroupsClient)
 }
 
 func stopACIContainerGroup(ctx context.Context, aciContext store.AciContext, containerGroupName string) error {

--- a/aci/backend.go
+++ b/aci/backend.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 

--- a/aci/containers.go
+++ b/aci/containers.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/pkg/errors"

--- a/aci/convert/convert_test.go
+++ b/aci/convert/convert_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
 	"gotest.tools/v3/assert"

--- a/aci/convert/ports.go
+++ b/aci/convert/ports.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 

--- a/aci/convert/ports_test.go
+++ b/aci/convert/ports_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerinstance/mgmt/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
 	"gotest.tools/v3/assert"

--- a/aci/convert/restartpolicy.go
+++ b/aci/convert/restartpolicy.go
@@ -17,7 +17,7 @@
 package convert
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/pkg/errors"
 
 	"github.com/docker/compose-cli/api/containers"

--- a/aci/convert/restartpolicy_test.go
+++ b/aci/convert/restartpolicy_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/compose-spec/compose-go/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"

--- a/aci/convert/secrets.go
+++ b/aci/convert/secrets.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
 )

--- a/aci/convert/volume.go
+++ b/aci/convert/volume.go
@@ -22,12 +22,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
-	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/compose-spec/compose-go/types"
-	"github.com/docker/compose-cli/aci/login"
 	"github.com/pkg/errors"
 
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/compose-spec/compose-go/types"
+
+	"github.com/docker/compose-cli/aci/login"
 	"github.com/docker/compose-cli/errdefs"
 )
 

--- a/aci/convert/volume_test.go
+++ b/aci/convert/volume_test.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/stretchr/testify/mock"

--- a/aci/login/client.go
+++ b/aci/login/client.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
@@ -100,11 +100,11 @@ func NewGroupsClient(subscriptionID string) (resources.GroupsClient, error) {
 }
 
 // NewContainerClient get client to manipulate containers
-func NewContainerClient(subscriptionID string) (containerinstance.ContainerClient, error) {
-	containerClient := containerinstance.NewContainerClient(subscriptionID)
+func NewContainerClient(subscriptionID string) (containerinstance.ContainersClient, error) {
+	containerClient := containerinstance.NewContainersClient(subscriptionID)
 	err := setupClient(&containerClient.Client)
 	if err != nil {
-		return containerinstance.ContainerClient{}, err
+		return containerinstance.ContainersClient{}, err
 	}
 	return containerClient, nil
 }

--- a/aci/resources.go
+++ b/aci/resources.go
@@ -57,9 +57,8 @@ func (cs *aciResourceService) Prune(ctx context.Context, request resources.Prune
 			_, err := deleteACIContainerGroup(ctx, cs.aciContext, *containerGroup.Name)
 			multierr = multierror.Append(multierr, err)
 		}
-		if err == nil {
-			deleted = append(deleted, *containerGroup.Name)
-		}
+
+		deleted = append(deleted, *containerGroup.Name)
 	}
 	result.DeletedIDs = deleted
 	result.Summary = fmt.Sprintf("Total CPUs reclaimed: %.2f, total memory reclaimed: %.2f GB", cpus, mem)

--- a/aci/volumes.go
+++ b/aci/volumes.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
 	"github.com/Azure/go-autorest/autorest/to"
 

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -57,11 +57,15 @@ func runPrune(ctx context.Context, opts pruneOpts) error {
 	}
 
 	result, err := c.ResourceService().Prune(ctx, resources.PruneRequest{Force: opts.force, DryRun: opts.dryRun})
-	if opts.dryRun {
-		fmt.Println("Resources that would be deleted:")
-	} else {
-		fmt.Println("Deleted resources:")
+	if err != nil {
+		return err
 	}
+	deletedResourcesMsg := "Deleted resources:"
+	if opts.dryRun {
+		deletedResourcesMsg = "Resources that would be deleted:"
+	}
+	fmt.Println(deletedResourcesMsg)
+
 	for _, id := range result.DeletedIDs {
 		fmt.Println(id)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.3
-	github.com/Azure/azure-sdk-for-go v43.3.0+incompatible
+	github.com/Azure/azure-sdk-for-go v48.2.0+incompatible
 	github.com/Azure/azure-storage-file-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.11.12
 	github.com/Azure/go-autorest/autorest/adal v0.9.5

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/AlecAivazis/survey/v2 v2.2.3/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0T
 github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZOMdj5HYo=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v43.3.0+incompatible h1:o0G4JAsOzeVJEwU0Ud9bh+lUHPUc0GkFENJ02dk51Uo=
-github.com/Azure/azure-sdk-for-go v43.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v48.2.0+incompatible h1:+t2P1j1r5N6lYgPiiz7ZbEVZFkWjVe9WhHbMm0gg8hw=
+github.com/Azure/azure-sdk-for-go v48.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-file-go v0.8.0 h1:OX8DGsleWLUE6Mw4R/OeWEZMvsTIpwN94J59zqKQnTI=
 github.com/Azure/azure-storage-file-go v0.8.0/go.mod h1:3w3mufGcMjcOJ3w+4Gs+5wsSgkT7xDwWWqMMIrXtW4c=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=


### PR DESCRIPTION
**What I did**
Bump `azure-sdk-for-go`: v43.3.0 -> v48.2.0

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/954

/test-aci
/test-windows