### PR TITLE
Add container labels to improve compatibility with docker-compose

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -363,10 +363,15 @@ func getContainerCreateOptions(p *types.Project, s types.ServiceConfig, number i
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	//TODO: change oneoffLabel value for containers started with `docker compose run`
 	labels := map[string]string{
 		projectLabel:         p.Name,
 		serviceLabel:         s.Name,
+		versionLabel:         ComposeVersion,
+		oneoffLabel:          "False",
 		configHashLabel:      hash,
+		workingDirLabel:      p.WorkingDir,
+		configFilesLabel:     strings.Join(p.ConfigNames(), ","),
 		containerNumberLabel: strconv.Itoa(number),
 	}
 

--- a/local/labels.go
+++ b/local/labels.go
@@ -25,10 +25,17 @@ import (
 )
 
 const (
-	projectLabel         = "com.docker.compose.project"
-	serviceLabel         = "com.docker.compose.service"
-	configHashLabel      = "com.docker.compose.config-hash"
 	containerNumberLabel = "com.docker.compose.container-number"
+	oneoffLabel          = "com.docker.compose.oneoff"
+	projectLabel         = "com.docker.compose.project"
+	workingDirLabel      = "com.docker.compose.project.working_dir"
+	configFilesLabel     = "com.docker.compose.project.config_files"
+	serviceLabel         = "com.docker.compose.service"
+	versionLabel         = "com.docker.compose.version"
+	configHashLabel      = "com.docker.compose.config-hash"
+
+	//ComposeVersion Compose version
+	ComposeVersion = "1.0-alpha"
 )
 
 func projectFilter(projectName string) filters.KeyValuePair {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Add container labels version, oneoff, workingDir, configfiles

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdnb.artstation.com/p/assets/images/images/006/761/951/large/igor-puskaric-promo-seahorse-water.jpg?1501065305)