### PR TITLE
Avoid panic in some weird cases (debug in VSCode for example)

### DIFF
--- a/progress/tty.go
+++ b/progress/tty.go
@@ -150,7 +150,8 @@ func lineText(event Event, terminalWidth, statusPadding int, color bool) string 
 	// is 2-3 lines long and breaks the line formating
 	maxStatusLen := terminalWidth - textLen - statusPadding - 15
 	status := event.StatusText
-	if len(status) > maxStatusLen {
+	// in some cases (debugging under VS Code), terminalWidth is set to zero by goterm.Width() ; ensuring we don't tweak strings with negative char index
+	if maxStatusLen > 0 && len(status) > maxStatusLen {
 		status = status[:maxStatusLen] + "..."
 	}
 	text := fmt.Sprintf(" %s %s %s%s %s",


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* avoid fiddling with string at negative char index

**Related issue**
```
panic: runtime error: slice bounds out of range [:-44]

goroutine 37 [running]:
github.com/docker/compose-cli/progress.lineText(0xc0002d5ea0, 0xc, 0x0, 0x0, 0x0, 0x3173ac7, 0x6, 0xbfe7c1c84e943168, 0x34418a0, 0x4025c20, ...)
	/Users/gtardif/docker/src/github.com/docker/compose-cli/progress/tty.go:155 +0x974
github.com/docker/compose-cli/progress.(*ttyWriter).print(0xc0004561e0)
	/Users/gtardif/docker/src/github.com/docker/compose-cli/progress/tty.go:127 +0xd65
```
<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
