### PR TITLE
Add compose labels for network

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -55,6 +55,9 @@ func (s *local) Up(ctx context.Context, project *types.Project, detach bool) err
 			network.Name = fmt.Sprintf("%s_%s", project.Name, k)
 			project.Networks[k] = network
 		}
+		network.Labels = network.Labels.Add(networkLabel, k)
+		network.Labels = network.Labels.Add(projectLabel, project.Name)
+		network.Labels = network.Labels.Add(versionLabel, ComposeVersion)
 		err := s.ensureNetwork(ctx, network)
 		if err != nil {
 			return err

--- a/local/labels.go
+++ b/local/labels.go
@@ -33,6 +33,7 @@ const (
 	serviceLabel         = "com.docker.compose.service"
 	versionLabel         = "com.docker.compose.version"
 	configHashLabel      = "com.docker.compose.config-hash"
+	networkLabel         = "com.docker.compose.network"
 
 	//ComposeVersion Compose version
 	ComposeVersion = "1.0-alpha"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Add 3 compose labels for networks created by compose
* Add tests for compose runtime labels 

**Related issue**
https://github.com/docker/compose-cli/issues/963

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
