### PR TITLE
Add compose labels for composefiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/aws/aws-sdk-go v1.35.33
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
-	github.com/compose-spec/compose-go v0.0.0-20201122180821-0f87549cda1e
+	github.com/compose-spec/compose-go v0.0.0-20201126152818-90e602b681e4
 	github.com/containerd/console v1.0.1
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect
 	github.com/docker/buildx v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20201122180821-0f87549cda1e h1:EO6seAKT1UtMjk1RGmuXS1tFkSkWr6FPjQru/mC+r/U=
-github.com/compose-spec/compose-go v0.0.0-20201122180821-0f87549cda1e/go.mod h1:Pm8gjIoib7x9av1XGkijXddjyV4aTHEq9EwVOvWH624=
+github.com/compose-spec/compose-go v0.0.0-20201126152818-90e602b681e4 h1:dN1SwJkUU2sz2udsmvfsSi66stSo7YM9sUy81I22WwU=
+github.com/compose-spec/compose-go v0.0.0-20201126152818-90e602b681e4/go.mod h1:Pm8gjIoib7x9av1XGkijXddjyV4aTHEq9EwVOvWH624=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200217135630-d732e370d46d/go.mod h1:CStdkl05lBnJej94BPFoJ7vB8cELKXwViS+dgfW0/M8=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59 h1:qWj4qVYZ95vLWwqyNJCQg7rDsG5wPdze0UaPolH7DUk=

--- a/local/compose.go
+++ b/local/compose.go
@@ -315,7 +315,7 @@ func getContainerCreateOptions(p *types.Project, s types.ServiceConfig, number i
 		oneoffLabel:          "False",
 		configHashLabel:      hash,
 		workingDirLabel:      p.WorkingDir,
-		configFilesLabel:     strings.Join(p.ConfigNames(), ","),
+		configFilesLabel:     strings.Join(p.ComposeFiles, ","),
 		containerNumberLabel: strconv.Itoa(number),
 	}
 

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -57,7 +57,7 @@ func TestLocalBackendComposeUp(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "compose-e2e-demo"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.oneoff": "False",`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.config-hash":`})
-		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project.config_files":`})
+		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project.config_files": "../../tests/composefiles/demo_multi_port.yaml"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project.working_dir":`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.service": "web"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version":`})


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* Use new field in project struct to set label value with composefiles

**Related issue**
https://github.com/docker/compose-cli/issues/965

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
