### PR TITLE
Ensure images are pulled/build with build first, before creating networks / volumes.

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -54,6 +54,10 @@ type composeService struct {
 }
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, detach bool) error {
+	err := s.ensureImagesExists(ctx, project)
+	if err != nil {
+		return err
+	}
 	for k, network := range project.Networks {
 		if !network.External.External && network.Name != "" {
 			network.Name = fmt.Sprintf("%s_%s", project.Name, k)
@@ -80,11 +84,6 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, detach 
 		if err != nil {
 			return err
 		}
-	}
-
-	err := s.ensureImagesExists(ctx, project)
-	if err != nil {
-		return err
 	}
 
 	err = inDependencyOrder(ctx, project, func(c context.Context, service types.ServiceConfig) error {


### PR DESCRIPTION
Will also avoid mixing build output and compose-cli progress display

Signed-off-by: Guillame Tardif <guillaume.tardif@gmail.com>

**What I did**
* Move call to ensureImagesExist() as fist step in compose up
* did **not** fix display issue: 

```
$ ./bin/docker --context localctx compose up -f tests/composefiles/demo_multi_port.yaml
[+] Running 0/0
[+] Running 3/3"    Create                                                                                                                                         0.0s
 ⠿ Service "web"    Created                                                                                                                                        1.0s
 ⠿ Service "words"  Created                                                                                                                                        1.1s
 ⠿ Service "db"     Created                                                                                                                                        1.1s 
```

**Related issue**
https://github.com/docker/compose-cli/issues/977

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://d329ymm15cr3f3.cloudfront.net/uploads/2015/04/JB_WP_Octopus-2.jpg)