### PR TITLE
Don't start buildx' build with empty opts

### DIFF
--- a/local/build.go
+++ b/local/build.go
@@ -85,6 +85,9 @@ func (s *composeService) needPull(ctx context.Context, service types.ServiceConf
 }
 
 func (s *composeService) build(ctx context.Context, project *types.Project, opts map[string]build.Options) error {
+	if len(opts) == 0 {
+		return nil
+	}
 	const drivername = "default"
 	d, err := driver.GetDriver(ctx, drivername, nil, s.apiClient, nil, nil, "", nil, project.WorkingDir)
 	if err != nil {


### PR DESCRIPTION
**What I did**
Skip build() execution if there's nothing to build
Otherwise progress writer get confused with some `[+] Running 0/0` and breaks

**Related issue**
fix https://github.com/docker/compose-cli/issues/977

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/100453920-2a80c880-30bc-11eb-9b31-7f6a187ae206.png)
