### PR TITLE
filter compose project to remove all services not required by command

### DIFF
--- a/cli/cmd/compose/compose_test.go
+++ b/cli/cmd/compose/compose_test.go
@@ -1,0 +1,53 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"github.com/compose-spec/compose-go/types"
+	"gotest.tools/v3/assert"
+)
+
+func TestFilterServices(t *testing.T) {
+	p := types.Project{
+		Services: []types.ServiceConfig{
+			{
+				Name:  "foo",
+				Links: []string{"bar"},
+			},
+			{
+				Name:        "bar",
+				NetworkMode: "service:zot",
+			},
+			{
+				Name: "zot",
+			},
+			{
+				Name: "qix",
+			},
+		},
+	}
+	err := filter(&p, []string{"bar"})
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(p.Services), 2)
+	_, err = p.GetService("bar")
+	assert.NilError(t, err)
+	_, err = p.GetService("zot")
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
**What I did**
`up` can get a subset of compose services to run as arg.
for this purpose, the compose app model is "filtered" to remove all unrelated services, so that the implementation code doesn't have to handle this.

*(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/100455895-c8c25d80-30bf-11eb-9ba4-f7e0ee8d4bcc.png)
