### PR TITLE
Compose network error

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -558,6 +558,10 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 	_, err := s.apiClient.NetworkInspect(ctx, n.Name, moby.NetworkInspectOptions{})
 	if err != nil {
 		if errdefs.IsNotFound(err) {
+			if n.External.External {
+				return fmt.Errorf("Network %s declared as external, but could not be found", n.Name)
+			}
+
 			createOpts := moby.NetworkCreate{
 				// TODO NameSpace Labels
 				Labels:     n.Labels,

--- a/local/compose.go
+++ b/local/compose.go
@@ -59,7 +59,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, detach 
 		return err
 	}
 	for k, network := range project.Networks {
-		if !network.External.External && network.Name != "" {
+		if !network.External.External && network.Name == k {
 			network.Name = fmt.Sprintf("%s_%s", project.Name, k)
 			project.Networks[k] = network
 		}
@@ -559,9 +559,8 @@ func (s *composeService) ensureNetwork(ctx context.Context, n types.NetworkConfi
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			if n.External.External {
-				return fmt.Errorf("Network %s declared as external, but could not be found", n.Name)
+				return fmt.Errorf("network %s declared as external, but could not be found", n.Name)
 			}
-
 			createOpts := moby.NetworkCreate{
 				// TODO NameSpace Labels
 				Labels:     n.Labels,

--- a/local/convergence.go
+++ b/local/convergence.go
@@ -240,9 +240,9 @@ func (s *composeService) runContainer(ctx context.Context, project *types.Projec
 		return err
 	}
 	id := created.ID
-	for net := range service.Networks {
-		name := fmt.Sprintf("%s_%s", project.Name, net)
-		err = s.connectContainerToNetwork(ctx, id, service.Name, name)
+	for netName := range service.Networks {
+		network := project.Networks[netName]
+		err = s.connectContainerToNetwork(ctx, id, service.Name, network.Name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What I did**
* Detect when external network are not available when doing `docker compose up`
* Avid duplicate prefixing of network name with `myproject_`

**Related issue**
https://github.com/docker/compose-cli/issues/975
https://github.com/docker/compose-cli/issues/990

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.ytimg.com/vi/ByqIiRUuoQ0/maxresdefault.jpg)