### PR TITLE
Attach to container on `up` and pipe logs to stdout

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -56,7 +56,7 @@ func (cs *aciComposeService) Pull(ctx context.Context, project *types.Project) e
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, detach bool) error {
+func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
 	logrus.Debugf("Up on project with name %q", project.Name)
 
 	if err := autocreateFileshares(ctx, project); err != nil {

--- a/aci/compose.go
+++ b/aci/compose.go
@@ -56,7 +56,15 @@ func (cs *aciComposeService) Pull(ctx context.Context, project *types.Project) e
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
+func (cs *aciComposeService) Create(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, detach bool) error {
 	logrus.Debugf("Up on project with name %q", project.Name)
 
 	if err := autocreateFileshares(ctx, project); err != nil {

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -41,7 +41,7 @@ func (c *composeService) Pull(ctx context.Context, project *types.Project) error
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Up(context.Context, *types.Project, bool) error {
+func (c *composeService) Up(context.Context, *types.Project, bool, io.Writer) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -41,7 +41,15 @@ func (c *composeService) Pull(ctx context.Context, project *types.Project) error
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Up(context.Context, *types.Project, bool, io.Writer) error {
+func (c *composeService) Create(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (c *composeService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (c *composeService) Up(context.Context, *types.Project, bool) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -31,8 +31,12 @@ type Service interface {
 	Push(ctx context.Context, project *types.Project) error
 	// Pull executes the equivalent of a `compose pull`
 	Pull(ctx context.Context, project *types.Project) error
+	// Create executes the equivalent to a `compose create`
+	Create(ctx context.Context, project *types.Project) error
+	// Start executes the equivalent to a `compose start`
+	Start(ctx context.Context, project *types.Project, w io.Writer) error
 	// Up executes the equivalent to a `compose up`
-	Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error
+	Up(ctx context.Context, project *types.Project, detach bool) error
 	// Down executes the equivalent to a `compose down`
 	Down(ctx context.Context, projectName string) error
 	// Logs executes the equivalent to a `compose logs`

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -32,7 +32,7 @@ type Service interface {
 	// Pull executes the equivalent of a `compose pull`
 	Pull(ctx context.Context, project *types.Project) error
 	// Up executes the equivalent to a `compose up`
-	Up(ctx context.Context, project *types.Project, detach bool) error
+	Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error
 	// Down executes the equivalent to a `compose down`
 	Down(ctx context.Context, projectName string) error
 	// Logs executes the equivalent to a `compose logs`

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -53,7 +53,7 @@ func (e ecsLocalSimulation) Pull(ctx context.Context, project *types.Project) er
 	return errdefs.ErrNotImplemented
 }
 
-func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project, detach bool) error {
+func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
 	cmd := exec.Command("docker-compose", "version", "--short")
 	b := bytes.Buffer{}
 	b.WriteString("v")

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -28,17 +28,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	types2 "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
-
-	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/errdefs"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/compose-spec/compose-go/types"
+	types2 "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/pkg/errors"
 	"github.com/sanathkr/go-yaml"
 	"golang.org/x/mod/semver"
+
+	"github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/errdefs"
 )
 
 func (e ecsLocalSimulation) Build(ctx context.Context, project *types.Project) error {
@@ -53,7 +52,16 @@ func (e ecsLocalSimulation) Pull(ctx context.Context, project *types.Project) er
 	return errdefs.ErrNotImplemented
 }
 
-func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
+func (e ecsLocalSimulation) Create(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (e ecsLocalSimulation) Up(ctx context.Context, project *types.Project, detach bool) error {
+
 	cmd := exec.Command("docker-compose", "version", "--short")
 	b := bytes.Buffer{}
 	b.WriteString("v")

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -40,7 +40,16 @@ func (b *ecsAPIService) Pull(ctx context.Context, project *types.Project) error 
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
+func (b *ecsAPIService) Create(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, detach bool) error {
+
 	err := b.aws.CheckRequirements(ctx, b.Region)
 	if err != nil {
 		return err

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -19,6 +19,7 @@ package ecs
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -39,7 +40,7 @@ func (b *ecsAPIService) Pull(ctx context.Context, project *types.Project) error 
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, detach bool) error {
+func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
 	err := b.aws.CheckRequirements(ctx, b.Region)
 	if err != nil {
 		return err

--- a/example/backend.go
+++ b/example/backend.go
@@ -151,7 +151,16 @@ func (cs *composeService) Pull(ctx context.Context, project *types.Project) erro
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *composeService) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
+func (cs *composeService) Create(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (cs *composeService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (cs *composeService) Up(ctx context.Context, project *types.Project, detach bool) error {
+
 	fmt.Printf("Up command on project %q", project.Name)
 	return nil
 }

--- a/example/backend.go
+++ b/example/backend.go
@@ -151,7 +151,7 @@ func (cs *composeService) Pull(ctx context.Context, project *types.Project) erro
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *composeService) Up(ctx context.Context, project *types.Project, detach bool) error {
+func (cs *composeService) Up(ctx context.Context, project *types.Project, detach bool, w io.Writer) error {
 	fmt.Printf("Up command on project %q", project.Name)
 	return nil
 }

--- a/formatter/logs.go
+++ b/formatter/logs.go
@@ -18,6 +18,7 @@ package formatter
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -25,8 +26,9 @@ import (
 )
 
 // NewLogConsumer creates a new LogConsumer
-func NewLogConsumer(w io.Writer) LogConsumer {
+func NewLogConsumer(ctx context.Context, w io.Writer) LogConsumer {
 	return LogConsumer{
+		ctx:    ctx,
 		colors: map[string]colorFunc{},
 		width:  0,
 		writer: w,
@@ -35,6 +37,9 @@ func NewLogConsumer(w io.Writer) LogConsumer {
 
 // Log formats a log message as received from service/container
 func (l *LogConsumer) Log(service, container, message string) {
+	if l.ctx.Err() == context.Canceled {
+		return
+	}
 	cf, ok := l.colors[service]
 	if !ok {
 		cf = <-loop
@@ -70,6 +75,7 @@ func (l *LogConsumer) computeWidth() {
 
 // LogConsumer consume logs from services and format them
 type LogConsumer struct {
+	ctx    context.Context
 	colors map[string]colorFunc
 	width  int
 	writer io.Writer

--- a/formatter/logs.go
+++ b/formatter/logs.go
@@ -37,7 +37,7 @@ func NewLogConsumer(ctx context.Context, w io.Writer) LogConsumer {
 
 // Log formats a log message as received from service/container
 func (l *LogConsumer) Log(service, container, message string) {
-	if l.ctx.Err() == context.Canceled {
+	if l.ctx.Err() != nil {
 		return
 	}
 	cf, ok := l.colors[service]

--- a/local/container.go
+++ b/local/container.go
@@ -1,3 +1,5 @@
+// +build local
+
 /*
    Copyright 2020 Docker Compose CLI authors
 
@@ -14,17 +16,14 @@
    limitations under the License.
 */
 
-package ecs
+package local
 
-import (
-	"context"
-	"io"
-
-	"github.com/docker/compose-cli/formatter"
+const (
+	containerCreated    = "created"
+	containerRestarting = "restarting"
+	containerRunning    = "running"
+	containerRemoving   = "removing" //nolint
+	containerPaused     = "paused"   //nolint
+	containerExited     = "exited"   //nolint
+	containerDead       = "dead"     //nolint
 )
-
-func (b *ecsAPIService) Logs(ctx context.Context, project string, w io.Writer) error {
-	consumer := formatter.NewLogConsumer(ctx, w)
-	err := b.aws.GetLogs(ctx, project, consumer.Log)
-	return err
-}

--- a/local/containers.go
+++ b/local/containers.go
@@ -143,7 +143,11 @@ func (cs *containerService) Run(ctx context.Context, r containers.ContainerConfi
 	return cs.apiClient.ContainerStart(ctx, id, types.ContainerStartOptions{})
 }
 
-func (cs *containerService) create(ctx context.Context, containerConfig *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, name string) (string, error) {
+func (cs *containerService) create(ctx context.Context,
+	containerConfig *container.Config,
+	hostConfig *container.HostConfig,
+	networkingConfig *network.NetworkingConfig,
+	platform *specs.Platform, name string) (string, error) {
 	created, err := cs.apiClient.ContainerCreate(ctx, containerConfig, hostConfig, networkingConfig, platform, name)
 
 	if err != nil {

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -45,7 +45,7 @@ func TestLocalBackendComposeUp(t *testing.T) {
 	})
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerCmd("compose", "up", "-f", "../../tests/composefiles/demo_multi_port.yaml", "--project-name", projectName)
+		c.RunDockerCmd("compose", "up", "-f", "../../tests/composefiles/demo_multi_port.yaml", "--project-name", projectName, "-d")
 	})
 
 	t.Run("check running project", func(t *testing.T) {

--- a/local/labels.go
+++ b/local/labels.go
@@ -51,3 +51,7 @@ func serviceFilter(serviceName string) filters.KeyValuePair {
 func hasProjectLabelFilter() filters.KeyValuePair {
 	return filters.Arg("label", projectLabel)
 }
+
+func serviceFilter(serviceName string) filters.KeyValuePair {
+	return filters.Arg("label", fmt.Sprintf("%s=%s", serviceLabel, serviceName))
+}

--- a/local/labels.go
+++ b/local/labels.go
@@ -51,7 +51,3 @@ func serviceFilter(serviceName string) filters.KeyValuePair {
 func hasProjectLabelFilter() filters.KeyValuePair {
 	return filters.Arg("label", projectLabel)
 }
-
-func serviceFilter(serviceName string) filters.KeyValuePair {
-	return filters.Arg("label", fmt.Sprintf("%s=%s", serviceLabel, serviceName))
-}

--- a/progress/event.go
+++ b/progress/event.go
@@ -58,6 +58,21 @@ func CreatingEvent(ID string) Event {
 	return NewEvent(ID, Working, "Creating")
 }
 
+// StartingEvent creates a new Starting in progress Event
+func StartingEvent(ID string) Event {
+	return NewEvent(ID, Working, "Starting")
+}
+
+// StartedEvent creates a new Started in progress Event
+func StartedEvent(ID string) Event {
+	return NewEvent(ID, Done, "Started")
+}
+
+// RunningEvent creates a new Running in progress Event
+func RunningEvent(ID string) Event {
+	return NewEvent(ID, Done, "Running")
+}
+
 // CreatedEvent creates a new Created (done) Event
 func CreatedEvent(ID string) Event {
 	return NewEvent(ID, Done, "Created")

--- a/server/proxy/compose.go
+++ b/server/proxy/compose.go
@@ -30,7 +30,7 @@ func (p *proxy) Up(ctx context.Context, request *composev1.ComposeUpRequest) (*c
 	if err != nil {
 		return nil, err
 	}
-	return &composev1.ComposeUpResponse{ProjectName: project.Name}, Client(ctx).ComposeService().Up(ctx, project, true)
+	return &composev1.ComposeUpResponse{ProjectName: project.Name}, Client(ctx).ComposeService().Up(ctx, project, true, nil)
 }
 
 func (p *proxy) Down(ctx context.Context, request *composev1.ComposeDownRequest) (*composev1.ComposeDownResponse, error) {

--- a/server/proxy/compose.go
+++ b/server/proxy/compose.go
@@ -30,7 +30,7 @@ func (p *proxy) Up(ctx context.Context, request *composev1.ComposeUpRequest) (*c
 	if err != nil {
 		return nil, err
 	}
-	return &composev1.ComposeUpResponse{ProjectName: project.Name}, Client(ctx).ComposeService().Up(ctx, project, true, nil)
+	return &composev1.ComposeUpResponse{ProjectName: project.Name}, Client(ctx).ComposeService().Up(ctx, project, true)
 }
 
 func (p *proxy) Down(ctx context.Context, request *composev1.ComposeDownRequest) (*composev1.ComposeDownResponse, error) {


### PR DESCRIPTION
**What I did**
`up` do (re)create containers, then attach (or collect logs for running ones) and eventually start.
Doing so we reproduce docker-compose behaviour
also handle SIGTERM to run `down`

**Related issue**
https://github.com/docker/compose-cli/issues/970

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/100839108-f61e5b00-3473-11eb-8c77-19ee83b8a8f8.png)
