### PR TITLE
Add compose build flags for file and working dir

### DIFF
--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -38,6 +38,9 @@ func buildCommand() *cobra.Command {
 			return runBuild(cmd.Context(), opts, args)
 		},
 	}
+	buildCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
+	buildCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+
 	return buildCmd
 }
 

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -37,6 +37,13 @@ func TestLocalBackendComposeUp(t *testing.T) {
 
 	networkList := c.RunDockerCmd("--context", "default", "network", "ls")
 
+	t.Run("build", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "build", "-f", "../../tests/composefiles/demo_multi_port.yaml")
+		res.Assert(t, icmd.Expected{Out: "COPY words.sql /docker-entrypoint-initdb.d/"})
+		res.Assert(t, icmd.Expected{Out: "COPY pom.xml ."})
+		res.Assert(t, icmd.Expected{Out: "COPY static /static/"})
+	})
+
 	t.Run("up", func(t *testing.T) {
 		c.RunDockerCmd("compose", "up", "-f", "../../tests/composefiles/demo_multi_port.yaml", "--project-name", projectName)
 	})


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Add flags taken from compose up: --file, --workdir
* Add build step in compose e2e tests

**Related issue**
https://github.com/docker/compose-cli/issues/997

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
