### PR TITLE
In `compose down` progress display: prefix container names with “Container”,

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -261,28 +261,28 @@ func (s *composeService) Down(ctx context.Context, projectName string) error {
 }
 
 func (s *composeService) removeContainers(ctx context.Context, w progress.Writer, eg *errgroup.Group, filter filters.Args) error {
-	cnts, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
+	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
 		Filters: filter,
 	})
 	if err != nil {
 		return err
 	}
-	for _, c := range cnts {
+	for _, c := range containers {
 		eg.Go(func() error {
-			cName := getContainerName(c)
-			w.Event(progress.StoppingEvent(cName))
+			eventName := "Container " + getContainerName(c)
+			w.Event(progress.StoppingEvent(eventName))
 			err := s.apiClient.ContainerStop(ctx, c.ID, nil)
 			if err != nil {
-				w.Event(progress.ErrorMessageEvent(cName, "Error while Stopping"))
+				w.Event(progress.ErrorMessageEvent(eventName, "Error while Stopping"))
 				return err
 			}
-			w.Event(progress.RemovingEvent(cName))
+			w.Event(progress.RemovingEvent(eventName))
 			err = s.apiClient.ContainerRemove(ctx, c.ID, moby.ContainerRemoveOptions{})
 			if err != nil {
-				w.Event(progress.ErrorMessageEvent(cName, "Error while Removing"))
+				w.Event(progress.ErrorMessageEvent(eventName, "Error while Removing"))
 				return err
 			}
-			w.Event(progress.RemovedEvent(cName))
+			w.Event(progress.RemovedEvent(eventName))
 			return nil
 		})
 	}


### PR DESCRIPTION
 same as Services, Networks, homogeneous with `compose up`

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
```
$ ./bin/docker --context localctx compose up -f tests/composefiles/demo_multi_port.yaml
[+] Running 4/4
⠿ Network "composefiles_default"  Created
⠿ Service "db"                    Created
⠿ Service "words"                 Created
⠿ Service "web"                   Created
$ ./bin/docker --context localctx compose down -f tests/composefiles/demo_multi_port.yaml
[+] Running 4/4
⠿ Container composefiles_words_1  Removed
⠿ Container composefiles_web_1    Removed
⠿ Container composefiles_db_1     Removed
⠿ Network "composefiles_default"  Removed
```

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
