### PR TITLE
If compose file has a build section and no image name, build image with the right derived image tag

### DIFF
--- a/local/build.go
+++ b/local/build.go
@@ -52,7 +52,11 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			}
 		}
 		if service.Build != nil {
-			opts[service.Name] = s.toBuildOptions(service, project.WorkingDir)
+			imageName := service.Image
+			if imageName == "" {
+				imageName = project.Name + "_" + service.Name
+			}
+			opts[imageName] = s.toBuildOptions(service, project.WorkingDir)
 			continue
 		}
 


### PR DESCRIPTION
`project_service`, like docker-compose.

See awesome_compose/react-express-mongodb example

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* set image name as docker-compose
* test `compose_up` on awsome_compose (modified, had to remove node_modues volumes from compose files to skip other issue with volumes)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
