### PR TITLE
Compose fix relative volume

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -873,28 +873,36 @@ func buildContainerMountOptions(p *types.Project, s types.ServiceConfig, inherit
 		if contains(inherited, v.Target) {
 			continue
 		}
-		source := v.Source
-		if v.Type == "bind" && !filepath.IsAbs(source) {
-			// volume source has already been prefixed with workdir if required, by compose-go project loader
-			var err error
-			source, err = filepath.Abs(source)
-			if err != nil {
-				return nil, err
-			}
+		mount, err := buildMount(v)
+		if err != nil {
+			return nil, err
 		}
-
-		mounts = append(mounts, mount.Mount{
-			Type:          mount.Type(v.Type),
-			Source:        source,
-			Target:        v.Target,
-			ReadOnly:      v.ReadOnly,
-			Consistency:   mount.Consistency(v.Consistency),
-			BindOptions:   buildBindOption(v.Bind),
-			VolumeOptions: buildVolumeOptions(v.Volume),
-			TmpfsOptions:  buildTmpfsOptions(v.Tmpfs),
-		})
+		mounts = append(mounts, mount)
 	}
 	return mounts, nil
+}
+
+func buildMount(volume types.ServiceVolumeConfig) (mount.Mount, error) {
+	source := volume.Source
+	if volume.Type == "bind" && !filepath.IsAbs(source) {
+		// volume source has already been prefixed with workdir if required, by compose-go project loader
+		var err error
+		source, err = filepath.Abs(source)
+		if err != nil {
+			return mount.Mount{}, err
+		}
+	}
+
+	return mount.Mount{
+		Type:          mount.Type(volume.Type),
+		Source:        source,
+		Target:        volume.Target,
+		ReadOnly:      volume.ReadOnly,
+		Consistency:   mount.Consistency(volume.Consistency),
+		BindOptions:   buildBindOption(volume.Bind),
+		VolumeOptions: buildVolumeOptions(volume.Volume),
+		TmpfsOptions:  buildTmpfsOptions(volume.Tmpfs),
+	}, nil
 }
 
 func buildBindOption(bind *types.ServiceVolumeBind) *mount.BindOptions {

--- a/local/compose_test.go
+++ b/local/compose_test.go
@@ -19,9 +19,13 @@
 package local
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	composetypes "github.com/compose-spec/compose-go/types"
 	"github.com/docker/docker/api/types"
+	mountTypes "github.com/docker/docker/api/types/mount"
 	"gotest.tools/v3/assert"
 
 	"github.com/docker/compose-cli/api/compose"
@@ -106,4 +110,18 @@ func TestStacksMixedStatus(t *testing.T) {
 	assert.Equal(t, combinedStatus([]string{"running"}), "running(1)")
 	assert.Equal(t, combinedStatus([]string{"running", "running", "running"}), "running(3)")
 	assert.Equal(t, combinedStatus([]string{"running", "exited", "running"}), "exited(1), running(2)")
+}
+
+func TestBuildBindMount(t *testing.T) {
+	volume := composetypes.ServiceVolumeConfig{
+		Type:   composetypes.VolumeTypeBind,
+		Source: "e2e/volume-test",
+		Target: "/data",
+	}
+	mount, err := buildMount(volume)
+	assert.NilError(t, err)
+	assert.Assert(t, filepath.IsAbs(mount.Source))
+	_, err = os.Stat(mount.Source)
+	assert.NilError(t, err)
+	assert.Equal(t, mount.Type, mountTypes.TypeBind)
 }

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -45,7 +45,7 @@ func TestLocalComposeUp(t *testing.T) {
 	})
 
 	t.Run("up", func(t *testing.T) {
-		c.RunDockerCmd("compose", "up", "-f", "../../tests/composefiles/demo_multi_port.yaml", "--project-name", projectName, "-d")
+		c.RunDockerCmd("compose", "up", "-d", "-f", "../../tests/composefiles/demo_multi_port.yaml", "--project-name", projectName, "-d")
 	})
 
 	t.Run("check running project", func(t *testing.T) {
@@ -95,7 +95,7 @@ func TestLocalComposeVolume(t *testing.T) {
 	const projectName = "compose-e2e-volume"
 
 	t.Run("up with volume", func(t *testing.T) {
-		c.RunDockerCmd("compose", "up", "--workdir", "volume-test", "--project-name", projectName)
+		c.RunDockerCmd("compose", "up", "-d", "--workdir", "volume-test", "--project-name", projectName)
 
 		output := HTTPGetWithRetry(t, "http://localhost:8090", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, "Hello from Nginx container"))

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/docker/compose-cli/tests/framework"
 )
 
-func TestLocalBackendComposeUp(t *testing.T) {
+func TestLocalComposeUp(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 	c.RunDockerCmd("context", "create", "local", "test-context").Assert(t, icmd.Success)
 	c.RunDockerCmd("context", "use", "test-context").Assert(t, icmd.Success)
@@ -84,5 +84,22 @@ func TestLocalBackendComposeUp(t *testing.T) {
 	t.Run("check compose labels", func(t *testing.T) {
 		networksAfterDown := c.RunDockerCmd("--context", "default", "network", "ls")
 		assert.Equal(t, networkList.Stdout(), networksAfterDown.Stdout())
+	})
+}
+
+func TestLocalComposeVolume(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+	c.RunDockerCmd("context", "create", "local", "test-context").Assert(t, icmd.Success)
+	c.RunDockerCmd("context", "use", "test-context").Assert(t, icmd.Success)
+
+	const projectName = "compose-e2e-volume"
+
+	t.Run("up with volume", func(t *testing.T) {
+		c.RunDockerCmd("compose", "up", "--workdir", "volume-test", "--project-name", projectName)
+
+		output := HTTPGetWithRetry(t, "http://localhost:8090", http.StatusOK, 2*time.Second, 20*time.Second)
+		assert.Assert(t, strings.Contains(output, "Hello from Nginx container"))
+
+		_ = c.RunDockerCmd("compose", "down", "--project-name", projectName)
 	})
 }

--- a/local/e2e/volume-test/docker-compose.yml
+++ b/local/e2e/volume-test/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  nginx:
+    image: nginx
+    volumes:
+      - ./static:/usr/share/nginx/html
+    ports:
+      - 8090:80

--- a/local/e2e/volume-test/static/index.html
+++ b/local/e2e/volume-test/static/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Docker Nginx</title>
+</head>
+<body>
+  <h2>Hello from Nginx container</h2>
+</body>
+</html>


### PR DESCRIPTION
**What I did**
* avoid double appending of working dir when setting up volumes, instead resolve absolute path if required
* Added unit test & first compose volume e2e test

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1007

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/c7/67/45/c7674589641c97def0193aa07fee9fe1.jpg)