### PR TITLE
Give progress its own context

### DIFF
--- a/local/build.go
+++ b/local/build.go
@@ -103,8 +103,15 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opts
 			Driver: d,
 		},
 	}
+
+	// Progress needs its own context that lives longer than the
+	// build one otherwise it won't read all the messages from
+	// build and will lock
+	progressCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := progress.NewPrinter(progressCtx, os.Stdout, "auto")
+
 	// We rely on buildx "docker" builder integrated in docker engine, so don't need a DockerAPI here
-	w := progress.NewPrinter(ctx, os.Stdout, "auto")
 	_, err = build.Build(ctx, driverInfo, opts, nil, nil, w)
 	return err
 }


### PR DESCRIPTION
**What I did**

Fixed ctrl+c on build

The build and progress can't share the same context, the progress context
needs to live longer for the progress to be able to read all the messages
from build.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

Fixes #992 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/99933/101153514-d7ab9180-3624-11eb-9659-eca6f042647c.png)
