### PR TITLE
Fix compose up build when no image name in compose file

### DIFF
--- a/local/build.go
+++ b/local/build.go
@@ -56,7 +56,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			if imageName == "" {
 				imageName = project.Name + "_" + service.Name
 			}
-			opts[imageName] = s.toBuildOptions(service, project.WorkingDir)
+			opts[imageName] = s.toBuildOptions(service, project.WorkingDir, imageName)
 			continue
 		}
 
@@ -116,11 +116,9 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opts
 	return err
 }
 
-func (s *composeService) toBuildOptions(service types.ServiceConfig, contextPath string) build.Options {
+func (s *composeService) toBuildOptions(service types.ServiceConfig, contextPath string, imageTag string) build.Options {
 	var tags []string
-	if service.Image != "" {
-		tags = append(tags, service.Image)
-	}
+	tags = append(tags, imageTag)
 
 	if service.Build.Dockerfile == "" {
 		service.Build.Dockerfile = "Dockerfile"

--- a/local/compose.go
+++ b/local/compose.go
@@ -66,7 +66,11 @@ func (s *composeService) Build(ctx context.Context, project *types.Project) erro
 	opts := map[string]build.Options{}
 	for _, service := range project.Services {
 		if service.Build != nil {
-			opts[service.Name] = s.toBuildOptions(service, project.WorkingDir)
+			imageName := service.Image
+			if imageName == "" {
+				imageName = project.Name + "_" + service.Name
+			}
+			opts[imageName] = s.toBuildOptions(service, project.WorkingDir, imageName)
 		}
 	}
 

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -94,7 +94,9 @@ func TestLocalComposeVolume(t *testing.T) {
 
 	const projectName = "compose-e2e-volume"
 
-	t.Run("up with volume", func(t *testing.T) {
+	t.Run("up with build and no image name, volume", func(t *testing.T) {
+		//ensure local test run does not reuse previously build image
+		c.RunDockerOrExitError("--context", "default", "rmi", "compose-e2e-volume_nginx")
 		c.RunDockerCmd("compose", "up", "-d", "--workdir", "volume-test", "--project-name", projectName)
 
 		output := HTTPGetWithRetry(t, "http://localhost:8090", http.StatusOK, 2*time.Second, 20*time.Second)

--- a/local/e2e/volume-test/docker-compose.yml
+++ b/local/e2e/volume-test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    image: nginx
+    build: nginx-build
     volumes:
       - ./static:/usr/share/nginx/html
     ports:

--- a/local/e2e/volume-test/nginx-build/Dockerfile
+++ b/local/e2e/volume-test/nginx-build/Dockerfile
@@ -1,0 +1,15 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM nginx


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Correctly tag compose image during `compose up` build phase, if service has no image  section
* Add this in existing E2E test case

**Related issue**
https://docker.slack.com/archives/C0111G2RCE4/p1607098325467700

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
