### PR TITLE
Revisit logs/up API to pass a LogConsumer vs io.Writer

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -19,7 +19,6 @@ package aci
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/compose-spec/compose-go/types"
@@ -60,7 +59,7 @@ func (cs *aciComposeService) Create(ctx context.Context, project *types.Project)
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 
@@ -176,7 +175,7 @@ func (cs *aciComposeService) List(ctx context.Context, project string) ([]compos
 	return stacks, nil
 }
 
-func (cs *aciComposeService) Logs(ctx context.Context, project string, w io.Writer) error {
+func (cs *aciComposeService) Logs(ctx context.Context, projectName string, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -18,12 +18,11 @@ package client
 
 import (
 	"context"
-	"io"
-
-	"github.com/compose-spec/compose-go/types"
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/errdefs"
+
+	"github.com/compose-spec/compose-go/types"
 )
 
 type composeService struct {
@@ -45,7 +44,7 @@ func (c *composeService) Create(ctx context.Context, project *types.Project) err
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+func (c *composeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 
@@ -57,7 +56,7 @@ func (c *composeService) Down(context.Context, string) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Logs(context.Context, string, io.Writer) error {
+func (c *composeService) Logs(context.Context, string, compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -18,7 +18,6 @@ package compose
 
 import (
 	"context"
-	"io"
 
 	"github.com/compose-spec/compose-go/types"
 )
@@ -34,13 +33,13 @@ type Service interface {
 	// Create executes the equivalent to a `compose create`
 	Create(ctx context.Context, project *types.Project) error
 	// Start executes the equivalent to a `compose start`
-	Start(ctx context.Context, project *types.Project, w io.Writer) error
+	Start(ctx context.Context, project *types.Project, consumer LogConsumer) error
 	// Up executes the equivalent to a `compose up`
 	Up(ctx context.Context, project *types.Project, detach bool) error
 	// Down executes the equivalent to a `compose down`
 	Down(ctx context.Context, projectName string) error
 	// Logs executes the equivalent to a `compose logs`
-	Logs(ctx context.Context, projectName string, w io.Writer) error
+	Logs(ctx context.Context, projectName string, consumer LogConsumer) error
 	// Ps executes the equivalent to a `compose ps`
 	Ps(ctx context.Context, projectName string) ([]ServiceStatus, error)
 	// List executes the equivalent to a `docker stack ls`
@@ -88,4 +87,9 @@ type Stack struct {
 	Name   string
 	Status string
 	Reason string
+}
+
+// LogConsumer is a callback to process log messages from services
+type LogConsumer interface {
+	Log(service, container, message string)
 }

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/formatter"
+
+	"github.com/spf13/cobra"
 )
 
 func logsCommand() *cobra.Command {
@@ -50,5 +51,6 @@ func runLogs(ctx context.Context, opts composeOptions) error {
 	if err != nil {
 		return err
 	}
-	return c.ComposeService().Logs(ctx, projectName, os.Stdout)
+	consumer := formatter.NewLogConsumer(ctx, os.Stdout)
+	return c.ComposeService().Logs(ctx, projectName, consumer)
 }

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -20,16 +20,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
+
+	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/context/store"
+	"github.com/docker/compose-cli/formatter"
+	"github.com/docker/compose-cli/progress"
 
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
-
-	"github.com/docker/compose-cli/api/client"
-	"github.com/docker/compose-cli/context/store"
-	"github.com/docker/compose-cli/progress"
 )
 
 func upCommand(contextType string) *cobra.Command {
@@ -83,12 +84,12 @@ func runCreateStart(ctx context.Context, opts composeOptions, services []string)
 		return err
 	}
 
-	var w io.Writer
+	var consumer compose.LogConsumer
 	if !opts.Detach {
-		w = os.Stdout
+		consumer = formatter.NewLogConsumer(ctx, os.Stdout)
 	}
 
-	err = c.ComposeService().Start(ctx, project, w)
+	err = c.ComposeService().Start(ctx, project, consumer)
 	if errors.Is(ctx.Err(), context.Canceled) {
 		fmt.Println("Gracefully stopping...")
 		ctx = context.Background()

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func (e ecsLocalSimulation) Create(ctx context.Context, project *types.Project) 
 	return errdefs.ErrNotImplemented
 }
 
-func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 
@@ -181,7 +180,7 @@ services:
 	return cmd.Run()
 }
 
-func (e ecsLocalSimulation) Logs(ctx context.Context, projectName string, w io.Writer) error {
+func (e ecsLocalSimulation) Logs(ctx context.Context, projectName string, consumer compose.LogConsumer) error {
 	list, err := e.moby.ContainerList(ctx, types2.ContainerListOptions{
 		Filters: filters.NewArgs(filters.Arg("label", "com.docker.compose.project="+projectName)),
 	})

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -18,13 +18,11 @@ package ecs
 
 import (
 	"context"
-	"io"
 
-	"github.com/docker/compose-cli/formatter"
+	"github.com/docker/compose-cli/api/compose"
 )
 
-func (b *ecsAPIService) Logs(ctx context.Context, project string, w io.Writer) error {
-	consumer := formatter.NewLogConsumer(ctx, w)
-	err := b.aws.GetLogs(ctx, project, consumer.Log)
+func (b *ecsAPIService) Logs(ctx context.Context, projectName string, consumer compose.LogConsumer) error {
+	err := b.aws.GetLogs(ctx, projectName, consumer.Log)
 	return err
 }

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -19,13 +19,14 @@ package ecs
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/errdefs"
+
+	"github.com/compose-spec/compose-go/types"
 )
 
 func (b *ecsAPIService) Build(ctx context.Context, project *types.Project) error {
@@ -44,7 +45,7 @@ func (b *ecsAPIService) Create(ctx context.Context, project *types.Project) erro
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/example/backend.go
+++ b/example/backend.go
@@ -22,9 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-
-	"github.com/compose-spec/compose-go/types"
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
@@ -34,6 +31,8 @@ import (
 	"github.com/docker/compose-cli/backend"
 	"github.com/docker/compose-cli/context/cloud"
 	"github.com/docker/compose-cli/errdefs"
+
+	"github.com/compose-spec/compose-go/types"
 )
 
 type apiService struct {
@@ -155,7 +154,7 @@ func (cs *composeService) Create(ctx context.Context, project *types.Project) er
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *composeService) Start(ctx context.Context, project *types.Project, w io.Writer) error {
+func (cs *composeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 
@@ -176,7 +175,7 @@ func (cs *composeService) Ps(ctx context.Context, project string) ([]compose.Ser
 func (cs *composeService) List(ctx context.Context, project string) ([]compose.Stack, error) {
 	return nil, errdefs.ErrNotImplemented
 }
-func (cs *composeService) Logs(ctx context.Context, project string, w io.Writer) error {
+func (cs *composeService) Logs(ctx context.Context, projectName string, consumer compose.LogConsumer) error {
 	return errdefs.ErrNotImplemented
 }
 


### PR DESCRIPTION
**What I did**
Refactored the compose API to use a `LogConsumer` callback vs a raw `io.Writer`. Log message then get typed by service/container and can be processed by consumer for output (raw, colored, prefixed, filtered ...)

This refactoring started with the intent to introduce `attachContainerStreams` so we can define `compose.Attach` API method that will be required to implement `compose run`, see https://github.com/docker/compose-cli/issues/940#issuecomment-739770823


/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/101326223-411de100-386d-11eb-9655-524c419ec804.png)
