### PR TITLE
Remove stopped containers on `down`

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -502,6 +502,7 @@ func (s *composeService) Down(ctx context.Context, projectName string) error {
 func (s *composeService) removeContainers(ctx context.Context, w progress.Writer, eg *errgroup.Group, filter filters.Args) error {
 	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
 		Filters: filter,
+		All: true,
 	})
 	if err != nil {
 		return err
@@ -533,6 +534,7 @@ func (s *composeService) projectFromContainerLabels(ctx context.Context, project
 		Filters: filters.NewArgs(
 			projectFilter(projectName),
 		),
+		All: true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What I did**
List containers with `all` option so we also remove the stopped ones.

**Related issue**
https://github.com/docker/compose-cli/issues/993

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/101341340-3ec58200-3881-11eb-8aec-0c10de1dce79.png)
