### PR TITLE
`compose up` and other compose commands running on “Moby” context type.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,12 @@ jobs:
 
       - name: Test
         env:
-          BUILD_TAGS: example,local
+          BUILD_TAGS: example
         run: make -f builder.Makefile test
 
       - name: Build for local E2E
         env:
-          BUILD_TAGS: example,local,e2e
+          BUILD_TAGS: example,e2e
         run: make -f builder.Makefile cli
 
       - name: E2E Test

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ protos: ## Generate go code from .proto files
 cli: ## Compile the cli
 	@docker build . --target cli \
 	--platform local \
-	--build-arg BUILD_TAGS=example,local,e2e \
+	--build-arg BUILD_TAGS=example,e2e \
 	--build-arg GIT_TAG=$(GIT_TAG) \
 	--output ./bin
 
@@ -63,7 +63,7 @@ cross: ## Compile the CLI for linux, darwin and windows
 
 test: ## Run unit tests
 	@docker build . \
-	--build-arg BUILD_TAGS=example,local \
+	--build-arg BUILD_TAGS=example \
 	--build-arg GIT_TAG=$(GIT_TAG) \
 	--target test
 
@@ -72,7 +72,7 @@ cache-clear: ## Clear the builder cache
 
 lint: ## run linter(s)
 	@docker build . \
-	--build-arg BUILD_TAGS=example,local,e2e \
+	--build-arg BUILD_TAGS=example,e2e \
 	--build-arg GIT_TAG=$(GIT_TAG) \
 	--target lint
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -32,6 +32,15 @@ import (
 
 // New returns a backend client associated with current context
 func New(ctx context.Context) (*Client, error) {
+	return newWithDefaultBackend(ctx, "")
+}
+
+// NewWithDefaultLocalBackend returns a backend client associated with current context or local backend if on default context type
+func NewWithDefaultLocalBackend(ctx context.Context) (*Client, error) {
+	return newWithDefaultBackend(ctx, store.LocalContextType)
+}
+
+func newWithDefaultBackend(ctx context.Context, defaultBackend string) (*Client, error) {
 	currentContext := apicontext.CurrentContext(ctx)
 	s := store.ContextStore(ctx)
 
@@ -40,7 +49,12 @@ func New(ctx context.Context) (*Client, error) {
 		return nil, err
 	}
 
-	service, err := backend.Get(ctx, cc.Type())
+	backendName := cc.Type()
+	if backendName == store.DefaultContextType && defaultBackend != "" {
+		backendName = defaultBackend
+	}
+
+	service, err := backend.Get(ctx, backendName)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -45,7 +45,7 @@ func buildCommand() *cobra.Command {
 }
 
 func runBuild(ctx context.Context, opts buildOptions, services []string) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -17,16 +17,12 @@
 package compose
 
 import (
-	"context"
-
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/context/store"
-	"github.com/docker/compose-cli/errdefs"
 )
 
 type composeOptions struct {
@@ -76,9 +72,6 @@ func Command(contextType string) *cobra.Command {
 	command := &cobra.Command{
 		Short: "Docker Compose",
 		Use:   "compose",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkComposeSupport(cmd.Context())
-		},
 	}
 
 	command.AddCommand(
@@ -90,7 +83,7 @@ func Command(contextType string) *cobra.Command {
 		convertCommand(),
 	)
 
-	if contextType == store.LocalContextType {
+	if contextType == store.LocalContextType || contextType == store.DefaultContextType {
 		command.AddCommand(
 			buildCommand(),
 			pushCommand(),
@@ -99,15 +92,6 @@ func Command(contextType string) *cobra.Command {
 	}
 
 	return command
-}
-
-func checkComposeSupport(ctx context.Context) error {
-	_, err := client.New(ctx)
-	if errdefs.IsNotFoundError(err) {
-		return errdefs.ErrNotImplemented
-	}
-
-	return err
 }
 
 //

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -46,7 +46,7 @@ func convertCommand() *cobra.Command {
 
 func runConvert(ctx context.Context, opts composeOptions) error {
 	var json []byte
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -41,7 +41,7 @@ func downCommand() *cobra.Command {
 }
 
 func runDown(ctx context.Context, opts composeOptions) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -43,7 +43,7 @@ func listCommand() *cobra.Command {
 }
 
 func runList(ctx context.Context, opts composeOptions) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -41,7 +41,7 @@ func logsCommand() *cobra.Command {
 }
 
 func runLogs(ctx context.Context, opts composeOptions) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -45,7 +45,7 @@ func psCommand() *cobra.Command {
 }
 
 func runPs(ctx context.Context, opts composeOptions) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -46,7 +46,7 @@ func pullCommand() *cobra.Command {
 }
 
 func runPull(ctx context.Context, opts pullOptions, services []string) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -46,7 +46,7 @@ func pushCommand() *cobra.Command {
 }
 
 func runPush(ctx context.Context, opts pushOptions, services []string) error {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -38,7 +38,7 @@ func upCommand(contextType string) *cobra.Command {
 		Use: "up [SERVICE...]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch contextType {
-			case store.LocalContextType:
+			case store.LocalContextType, store.DefaultContextType:
 				return runCreateStart(cmd.Context(), opts, args)
 			default:
 				return runUp(cmd.Context(), opts, args)
@@ -100,7 +100,7 @@ func runCreateStart(ctx context.Context, opts composeOptions, services []string)
 }
 
 func setup(ctx context.Context, opts composeOptions, services []string) (*client.Client, *types.Project, error) {
-	c, err := client.New(ctx)
+	c, err := client.NewWithDefaultLocalBackend(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/local/backend.go
+++ b/local/backend.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/build.go
+++ b/local/build.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/compose.go
+++ b/local/compose.go
@@ -804,7 +804,7 @@ func getContainerCreateOptions(p *types.Project, s types.ServiceConfig, number i
 		StopTimeout: toSeconds(s.StopGracePeriod),
 	}
 
-	mountOptions, err := buildContainerMountOptions(p, s, inherit)
+	mountOptions, err := buildContainerMountOptions(s, inherit)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -851,7 +851,7 @@ func buildContainerBindingOptions(s types.ServiceConfig) nat.PortMap {
 	return bindings
 }
 
-func buildContainerMountOptions(p *types.Project, s types.ServiceConfig, inherit *moby.Container) ([]mount.Mount, error) {
+func buildContainerMountOptions(s types.ServiceConfig, inherit *moby.Container) ([]mount.Mount, error) {
 	mounts := []mount.Mount{}
 	var inherited []string
 	if inherit != nil {

--- a/local/compose.go
+++ b/local/compose.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 
@@ -502,7 +500,7 @@ func (s *composeService) Down(ctx context.Context, projectName string) error {
 func (s *composeService) removeContainers(ctx context.Context, w progress.Writer, eg *errgroup.Group, filter filters.Args) error {
 	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
 		Filters: filter,
-		All: true,
+		All:     true,
 	})
 	if err != nil {
 		return err

--- a/local/compose_test.go
+++ b/local/compose_test.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/container.go
+++ b/local/container.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/containers.go
+++ b/local/containers.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/convergence.go
+++ b/local/convergence.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/convert.go
+++ b/local/convert.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/convert_test.go
+++ b/local/convert_test.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/dependencies.go
+++ b/local/dependencies.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/dependencies_test.go
+++ b/local/dependencies_test.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -30,8 +30,6 @@ import (
 
 func TestLocalComposeUp(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
-	c.RunDockerCmd("context", "create", "local", "test-context").Assert(t, icmd.Success)
-	c.RunDockerCmd("context", "use", "test-context").Assert(t, icmd.Success)
 
 	const projectName = "compose-e2e-demo"
 
@@ -54,12 +52,12 @@ func TestLocalComposeUp(t *testing.T) {
 		output := HTTPGetWithRetry(t, endpoint+"/words/noun", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, `"word":`))
 
-		res = c.RunDockerCmd("--context", "default", "network", "ls")
+		res = c.RunDockerCmd("network", "ls")
 		res.Assert(t, icmd.Expected{Out: projectName + "_default"})
 	})
 
 	t.Run("check compose labels", func(t *testing.T) {
-		res := c.RunDockerCmd("--context", "default", "inspect", projectName+"_web_1")
+		res := c.RunDockerCmd("inspect", projectName+"_web_1")
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.container-number": "1"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "compose-e2e-demo"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.oneoff": "False",`})
@@ -69,7 +67,7 @@ func TestLocalComposeUp(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.service": "web"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version":`})
 
-		res = c.RunDockerCmd("--context", "default", "network", "inspect", projectName+"_default")
+		res = c.RunDockerCmd("network", "inspect", projectName+"_default")
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.network": "default"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": `})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version": `})
@@ -85,15 +83,13 @@ func TestLocalComposeUp(t *testing.T) {
 	})
 
 	t.Run("check networks after down", func(t *testing.T) {
-		res := c.RunDockerCmd("--context", "default", "network", "ls")
+		res := c.RunDockerCmd("network", "ls")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
 }
 
 func TestLocalComposeVolume(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
-	c.RunDockerCmd("context", "create", "local", "test-context").Assert(t, icmd.Success)
-	c.RunDockerCmd("context", "use", "test-context").Assert(t, icmd.Success)
 
 	const projectName = "compose-e2e-volume"
 

--- a/local/labels.go
+++ b/local/labels.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/util.go
+++ b/local/util.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/local/volumes.go
+++ b/local/volumes.go
@@ -1,5 +1,3 @@
-// +build local
-
 /*
    Copyright 2020 Docker Compose CLI authors
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -47,23 +47,6 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func TestComposeNotImplemented(t *testing.T) {
-	c := NewParallelE2eCLI(t, binDir)
-	res := c.RunDockerCmd("context", "show")
-	res.Assert(t, icmd.Expected{Out: "default"})
-	res = c.RunDockerOrExitError("compose", "up")
-	res.Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      `Command "compose up" not available in current context (default)`,
-	})
-
-	res = c.RunDockerOrExitError("compose", "-f", "titi.yaml", "up")
-	res.Assert(t, icmd.Expected{
-		ExitCode: 1,
-		Err:      `Command "compose up" not available in current context (default)`,
-	})
-}
-
 func TestContextDefault(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* in compose command, do not warn command is not available on default context type, rather use "local" backend when on "moby" context type.
* change e2e tests to not require a local context.
* local backend is not behind a feature flag anymore

**Related issue**
https://github.com/docker/dev-tooling-team/issues/244

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdna.artstation.com/p/assets/images/images/013/339/096/4k/vijay-pratap-singh-bpr-render-4.jpg?1539155130)