### PR TITLE
Ensure down continues (removes networks) even if containers have been removed already

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -472,7 +472,7 @@ func (s *composeService) Down(ctx context.Context, projectName string) error {
 	w := progress.ContextWriter(ctx)
 
 	project, err := s.projectFromContainerLabels(ctx, projectName)
-	if err != nil || project == nil {
+	if err != nil {
 		return err
 	}
 
@@ -547,17 +547,17 @@ func (s *composeService) projectFromContainerLabels(ctx context.Context, project
 	if err != nil {
 		return nil, err
 	}
+	fakeProject := &types.Project{
+		Name: projectName,
+	}
 	if len(containers) == 0 {
-		return nil, nil
+		return fakeProject, nil
 	}
 	options, err := loadProjectOptionsFromLabels(containers[0])
 	if err != nil {
 		return nil, err
 	}
 	if options.ConfigPaths[0] == "-" {
-		fakeProject := &types.Project{
-			Name: projectName,
-		}
 		for _, container := range containers {
 			fakeProject.Services = append(fakeProject.Services, types.ServiceConfig{
 				Name: container.Labels[serviceLabel],


### PR DESCRIPTION


Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Avoid returning nil error and nil project in `projectFromContainerLabels`, return project with a name and no service if there are no containers
* Test compose networks get removed after deleting compose containers separately (or compose up that created the network and failed on containers)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
