### PR TITLE
Display compose experimental disclaimer only for local context type or moby (default) context type

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -75,7 +75,9 @@ func Command(contextType string) *cobra.Command {
 		Short: "Docker Compose",
 		Use:   "compose",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("The new 'docker compose' command is currently experimental. To provide feedback or request new features please open issues at https://github.com/docker/compose-cli")
+			if contextType == store.DefaultContextType || contextType == store.LocalContextType {
+				fmt.Println("The new 'docker compose' command is currently experimental. To provide feedback or request new features please open issues at https://github.com/docker/compose-cli")
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
Fixes ACI / ECS e2e tests

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
display disclaimer only if context type is local or default("moby")

**Related issue**
https://github.com/docker/compose-cli/runs/1511471331

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
/test-aci