### PR TITLE
Pass the target to buildkit

### DIFF
--- a/local/build.go
+++ b/local/build.go
@@ -130,6 +130,7 @@ func (s *composeService) toBuildOptions(service types.ServiceConfig, contextPath
 		},
 		BuildArgs: flatten(mergeArgs(service.Build.Args, buildArgs)),
 		Tags:      tags,
+		Target:    service.Build.Target,
 	}
 }
 


### PR DESCRIPTION
**What I did**
Fixed `docker compose up` when the build section has the `target` defined.
