### PR TITLE
Fix volume ensure when creating local volume before running services

### DIFF
--- a/local/compose.go
+++ b/local/compose.go
@@ -1086,24 +1086,24 @@ func (s *composeService) ensureVolume(ctx context.Context, volume types.VolumeCo
 	// TODO could identify volume by label vs name
 	_, err := s.apiClient.VolumeInspect(ctx, volume.Name)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			eventName := fmt.Sprintf("Volume %q", volume.Name)
-			w := progress.ContextWriter(ctx)
-			w.Event(progress.CreatingEvent(eventName))
-			// TODO we miss support for driver_opts and labels
-			_, err := s.apiClient.VolumeCreate(ctx, mobyvolume.VolumeCreateBody{
-				Labels:     volume.Labels,
-				Name:       volume.Name,
-				Driver:     volume.Driver,
-				DriverOpts: volume.DriverOpts,
-			})
-			if err != nil {
-				w.Event(progress.ErrorEvent(eventName))
-				return err
-			}
-			w.Event(progress.CreatedEvent(eventName))
+		if !errdefs.IsNotFound(err) {
+			return err
 		}
-		return err
+		eventName := fmt.Sprintf("Volume %q", volume.Name)
+		w := progress.ContextWriter(ctx)
+		w.Event(progress.CreatingEvent(eventName))
+		// TODO we miss support for driver_opts and labels
+		_, err := s.apiClient.VolumeCreate(ctx, mobyvolume.VolumeCreateBody{
+			Labels:     volume.Labels,
+			Name:       volume.Name,
+			Driver:     volume.Driver,
+			DriverOpts: volume.DriverOpts,
+		})
+		if err != nil {
+			w.Event(progress.ErrorEvent(eventName))
+			return err
+		}
+		w.Event(progress.CreatedEvent(eventName))
 	}
 	return nil
 }

--- a/local/e2e/compose_test.go
+++ b/local/e2e/compose_test.go
@@ -95,12 +95,14 @@ func TestLocalComposeVolume(t *testing.T) {
 
 	t.Run("up with build and no image name, volume", func(t *testing.T) {
 		//ensure local test run does not reuse previously build image
-		c.RunDockerOrExitError("--context", "default", "rmi", "compose-e2e-volume_nginx")
+		c.RunDockerOrExitError("rmi", "compose-e2e-volume_nginx")
+		c.RunDockerOrExitError("volume", "rm", projectName+"_staticVol")
 		c.RunDockerCmd("compose", "up", "-d", "--workdir", "volume-test", "--project-name", projectName)
 
 		output := HTTPGetWithRetry(t, "http://localhost:8090", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, "Hello from Nginx container"))
 
 		_ = c.RunDockerCmd("compose", "down", "--project-name", projectName)
+		_ = c.RunDockerCmd("volume", "rm", projectName+"_staticVol")
 	})
 }

--- a/local/e2e/volume-test/docker-compose.yml
+++ b/local/e2e/volume-test/docker-compose.yml
@@ -5,3 +5,13 @@ services:
       - ./static:/usr/share/nginx/html
     ports:
       - 8090:80
+
+  nginx2:
+    build: nginx-build
+    volumes:
+      - staticVol:/usr/share/nginx/html
+    ports:
+      - 9090:80
+
+volumes:
+  staticVol:


### PR DESCRIPTION
**What I did**
* when creating volumes, don't return previous error of the check to see if volume exists ...
* Add volume creation in compose e2e volume test

**Related issue**
Found in several awesome compose examples

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
