### PR TITLE
Trying to fix ACI flakyness on docker prune --force

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -485,7 +485,11 @@ func TestContainerRunAttached(t *testing.T) {
 	t.Run("prune dry run", func(t *testing.T) {
 		res := c.RunDockerCmd("prune", "--dry-run")
 		assert.Equal(t, "Resources that would be deleted:\nTotal CPUs reclaimed: 0.00, total memory reclaimed: 0.00 GB\n", res.Stdout())
-		res = c.RunDockerCmd("prune", "--dry-run", "--force")
+		res = c.RunDockerOrExitError("prune", "--dry-run", "--force")
+		if strings.Contains(res.Stderr(), "unsupported protocol scheme") { //Flaky strange error on azure SDK call happening only during prune --force
+			time.Sleep(1 * time.Second)
+			res = c.RunDockerCmd("prune", "--dry-run", "--force")
+		}
 		assert.Equal(t, "Resources that would be deleted:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n", res.Stdout())
 	})
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Wait 1 sec and retry on ACI `docker prune --force` when we hit this specific SDK error

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/974

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
