### PR TITLE
Trying to fix flakyness on metrics e2e tests

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -151,7 +151,7 @@ func TestContextMetrics(t *testing.T) {
 		c.RunDockerCmd("--help")
 		c.RunDockerCmd("run", "--help")
 
-		usage := s.GetUsage()
+		usage := s.GetUsage(3)
 		assert.DeepEqual(t, []string{
 			`{"command":"help run","context":"moby","source":"cli","status":"success"}`,
 			`{"command":"--help","context":"moby","source":"cli","status":"success"}`,
@@ -166,7 +166,7 @@ func TestContextMetrics(t *testing.T) {
 		c.RunDockerCmd("version")
 		c.RunDockerOrExitError("version", "--xxx")
 
-		usage := s.GetUsage()
+		usage := s.GetUsage(3)
 		assert.DeepEqual(t, []string{
 			`{"command":"ps","context":"moby","source":"cli","status":"success"}`,
 			`{"command":"version","context":"moby","source":"cli","status":"success"}`,
@@ -185,7 +185,7 @@ func TestContextMetrics(t *testing.T) {
 		c.RunDockerCmd("context", "use", "default")
 		c.RunDockerCmd("--context", "test-example", "ps")
 
-		usage := s.GetUsage()
+		usage := s.GetUsage(7)
 		assert.DeepEqual(t, []string{
 			`{"command":"context create","context":"moby","source":"cli","status":"success"}`,
 			`{"command":"ps","context":"moby","source":"cli","status":"success"}`,

--- a/tests/framework/mockmetrics.go
+++ b/tests/framework/mockmetrics.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo"
 )
@@ -53,7 +54,10 @@ func (s *MockMetricsServer) hello(c echo.Context) error {
 }
 
 // GetUsage get usage
-func (s *MockMetricsServer) GetUsage() []string {
+func (s *MockMetricsServer) GetUsage(expectedCommands int) []string {
+	if len(s.usage) < expectedCommands {
+		time.Sleep(1 * time.Second) // a simple sleep 1s here should be enough, if not there are real issues
+	}
 	return s.usage
 }
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
If not getting all expected metrics the first time, wait 1 sec and get metrics again

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1033

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
