### PR TITLE
Adding short description to improve help on compose subcommands

### DIFF
--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -33,7 +33,8 @@ type buildOptions struct {
 func buildCommand() *cobra.Command {
 	opts := buildOptions{}
 	buildCmd := &cobra.Command{
-		Use: "build [SERVICE...]",
+		Use:   "build [SERVICE...]",
+		Short: "Build or rebuild services",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBuild(cmd.Context(), opts, args)
 		},

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -28,7 +28,8 @@ import (
 func downCommand() *cobra.Command {
 	opts := composeOptions{}
 	downCmd := &cobra.Command{
-		Use: "down",
+		Use:   "down",
+		Short: "Stop and remove containers, networks",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDown(cmd.Context(), opts)
 		},

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -33,7 +33,8 @@ import (
 func listCommand() *cobra.Command {
 	opts := composeOptions{}
 	lsCmd := &cobra.Command{
-		Use: "ls",
+		Use:   "ls",
+		Short: "List running compose projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd.Context(), opts)
 		},

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -29,7 +29,8 @@ import (
 func logsCommand() *cobra.Command {
 	opts := composeOptions{}
 	logsCmd := &cobra.Command{
-		Use: "logs",
+		Use:   "logs",
+		Short: "View output from containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLogs(cmd.Context(), opts)
 		},

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -33,7 +33,8 @@ import (
 func psCommand() *cobra.Command {
 	opts := composeOptions{}
 	psCmd := &cobra.Command{
-		Use: "ps",
+		Use:   "ps",
+		Short: "List containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPs(cmd.Context(), opts)
 		},

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -33,7 +33,8 @@ type pullOptions struct {
 func pullCommand() *cobra.Command {
 	opts := pullOptions{}
 	pullCmd := &cobra.Command{
-		Use: "pull [SERVICE...]",
+		Use:   "pull [SERVICE...]",
+		Short: "Pull service images",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPull(cmd.Context(), opts, args)
 		},

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -33,7 +33,8 @@ type pushOptions struct {
 func pushCommand() *cobra.Command {
 	opts := pushOptions{}
 	pushCmd := &cobra.Command{
-		Use: "push [SERVICE...]",
+		Use:   "push [SERVICE...]",
+		Short: "Push service images",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPush(cmd.Context(), opts, args)
 		},

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -36,7 +36,8 @@ import (
 func upCommand(contextType string) *cobra.Command {
 	opts := composeOptions{}
 	upCmd := &cobra.Command{
-		Use: "up [SERVICE...]",
+		Use:   "up [SERVICE...]",
+		Short: "Create and start containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType:


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Mainly take help labels from docker-compose
```
Available Commands:
  build       Build or rebuild services
  convert     Converts the compose file to a cloud format (default: cloudformation)
  down        Stop and remove containers, networks
  logs        View output from containers
  ls          List running compose projects
  ps          List containers
  pull        Pull service images
  push        Push service images
  up          Create and start containers
```

**Related issue**
Fixes #1035 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://i.pinimg.com/originals/1c/ba/f1/1cbaf1b8d10eb7453d302f6c3c91c31b.jpg)