### PR TITLE
No rebuild on compose up if image already exists by default

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -35,6 +35,7 @@ type composeOptions struct {
 	Environment []string
 	Format      string
 	Detach      bool
+	Build       bool
 	Quiet       bool
 }
 

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -51,7 +51,8 @@ func upCommand(contextType string) *cobra.Command {
 	upCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
 	upCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	upCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")
-	upCmd.Flags().BoolVarP(&opts.Detach, "detach", "d", false, " Detached mode: Run containers in the background")
+	upCmd.Flags().BoolVarP(&opts.Detach, "detach", "d", false, "Detached mode: Run containers in the background")
+	upCmd.Flags().BoolVar(&opts.Build, "build", false, "Build images before starting containers.")
 
 	if contextType == store.AciContextType {
 		upCmd.Flags().StringVar(&opts.DomainName, "domainname", "", "Container NIS domain name")
@@ -118,6 +119,11 @@ func setup(ctx context.Context, opts composeOptions, services []string) (*client
 	if opts.DomainName != "" {
 		// arbitrarily set the domain name on the first service ; ACI backend will expose the entire project
 		project.Services[0].DomainName = opts.DomainName
+	}
+	if opts.Build {
+		for _, service := range project.Services {
+			service.PullPolicy = types.PullPolicyBuild
+		}
 	}
 
 	err = filter(project, services)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/aws/aws-sdk-go v1.35.33
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
-	github.com/compose-spec/compose-go v0.0.0-20201208135325-bcfd1e07a97e
+	github.com/compose-spec/compose-go v0.0.0-20201210155915-b5ef325e9175
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.0-0
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e h1:Qux+lbuMaRzkQy
 github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20201208135325-bcfd1e07a97e h1:sfRp4eLv+F9ml4Yh49DPkIlEj07N0p/56FzCLbbROJ0=
-github.com/compose-spec/compose-go v0.0.0-20201208135325-bcfd1e07a97e/go.mod h1:rz7rjxJGA/pWpLdBmDdqymGm2okEDYgBE7yx569xW+I=
+github.com/compose-spec/compose-go v0.0.0-20201210155915-b5ef325e9175 h1:6ZE967wCKnx4h+OIUsjnS113itBlncF3ls/Ia7rKcbc=
+github.com/compose-spec/compose-go v0.0.0-20201210155915-b5ef325e9175/go.mod h1:rz7rjxJGA/pWpLdBmDdqymGm2okEDYgBE7yx569xW+I=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200217135630-d732e370d46d/go.mod h1:CStdkl05lBnJej94BPFoJ7vB8cELKXwViS+dgfW0/M8=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59 h1:qWj4qVYZ95vLWwqyNJCQg7rDsG5wPdze0UaPolH7DUk=

--- a/tests/compose-e2e/compose_test.go
+++ b/tests/compose-e2e/compose_test.go
@@ -123,6 +123,9 @@ func TestLocalComposeBuild(t *testing.T) {
 		c.RunDockerOrExitError("rmi", "custom-nginx")
 
 		res := c.RunDockerCmd("compose", "up", "-d", "--workdir", "fixtures/build-test")
+		t.Cleanup(func() {
+			c.RunDockerCmd("compose", "down", "--workdir", "fixtures/build-test")
+		})
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
 
@@ -131,6 +134,12 @@ func TestLocalComposeBuild(t *testing.T) {
 
 		c.RunDockerCmd("image", "inspect", "build-test_nginx")
 		c.RunDockerCmd("image", "inspect", "custom-nginx")
+	})
+
+	t.Run("no rebuild when up again", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "up", "-d", "--workdir", "fixtures/build-test")
+
+		assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static /usr/share/nginx/html"), res.Stdout())
 	})
 
 	t.Run("cleanup build project", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* do not rebuild by default if not needed
* Added first use of compose pull_policy and `compose up --build` to allow to force rebuild.
* extended e2e tests

**Related issue**
Fixes #1025 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
