### PR TITLE
Check if stdin is nil before closing

### DIFF
--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -80,7 +80,9 @@ func (s *composeService) attachContainerStreams(ctx context.Context, container m
 	go func() {
 		<-ctx.Done()
 		stdout.Close() //nolint:errcheck
-		stdin.Close()  //nolint:errcheck
+		if stdin != nil {
+			stdin.Close() //nolint:errcheck
+		}
 	}()
 
 	if r != nil && stdin != nil {


### PR DESCRIPTION
**What I did**

Check if stdin is nil before closing, `getContainerStreams` returns a `nil` `stdin` if the container is already running
