### PR TITLE
Do not unnecessarily export images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 export DOCKER_BUILDKIT=1
+export BUILDX_NO_DEFAULT_LOAD=1
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
**What I did**

set `BUILDX_NO_DEFAULT_LOAD=1` in the Makefile.

When we do not require an image output from a `docker build` command, we should not export an image as this just wastes time.

This requires that build uses buildx which can be enabled with `docker buildx install`
