### PR TITLE
ACI: Allow setting protocol when publishing ports

### DIFF
--- a/aci/convert/container.go
+++ b/aci/convert/container.go
@@ -32,6 +32,7 @@ func ContainerToComposeProject(r containers.ContainerConfig) (types.Project, err
 		ports = append(ports, types.ServicePortConfig{
 			Target:    p.ContainerPort,
 			Published: p.HostPort,
+			Protocol:  p.Protocol,
 		})
 	}
 

--- a/aci/convert/ports.go
+++ b/aci/convert/ports.go
@@ -37,12 +37,25 @@ func convertPortsToAci(service serviceConfigAciHelper) ([]containerinstance.Cont
 			return nil, nil, nil, errors.New(msg)
 		}
 		portNumber := int32(portConfig.Target)
+		var groupProtocol containerinstance.ContainerGroupNetworkProtocol
+		var containerProtocol containerinstance.ContainerNetworkProtocol
+		switch portConfig.Protocol {
+		case "tcp", "":
+			groupProtocol = containerinstance.TCP
+			containerProtocol = containerinstance.ContainerNetworkProtocolTCP
+		case "udp":
+			groupProtocol = containerinstance.UDP
+			containerProtocol = containerinstance.ContainerNetworkProtocolUDP
+		default:
+			return nil, nil, nil, fmt.Errorf("unknown protocol %q in exposed port for service %q", portConfig.Protocol, service.Name)
+		}
 		containerPorts = append(containerPorts, containerinstance.ContainerPort{
-			Port: to.Int32Ptr(portNumber),
+			Port:     to.Int32Ptr(portNumber),
+			Protocol: containerProtocol,
 		})
 		groupPorts = append(groupPorts, containerinstance.Port{
 			Port:     to.Int32Ptr(portNumber),
-			Protocol: containerinstance.TCP,
+			Protocol: groupProtocol,
 		})
 	}
 	var dnsLabelName *string = nil


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Add protocol conversion when creating ACI container group for tcp/udp
* deploy and check runtime `docker inspect` also returns the correct port protocol.
* added an error for unknown protocols

**Related issue**
Fixes #985 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
