### PR TITLE
Compose unit test networks + image names

### DIFF
--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -388,7 +388,7 @@ func (b *ecsAPIService) ensureVolumes(r *awsResources, project *types.Project, t
 				},
 				{
 					Key:   "Name",
-					Value: fmt.Sprintf("%s_%s", project.Name, name),
+					Value: volume.Name,
 				},
 			},
 			KmsKeyId:                        kmsKeyID,

--- a/ecs/volumes.go
+++ b/ecs/volumes.go
@@ -72,7 +72,7 @@ func (b *ecsAPIService) createAccessPoints(project *types.Project, r awsResource
 				},
 				{
 					Key:   "Name",
-					Value: fmt.Sprintf("%s_%s", project.Name, name),
+					Value: volume.Name,
 				},
 			},
 			FileSystemId: r.filesystems[name].ID(),

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go v1.35.33
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
-	github.com/compose-spec/compose-go v0.0.0-20210106202047-687be5e0e320
+	github.com/compose-spec/compose-go v0.0.0-20210113150448-e0b1ffe70cc5
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/cloudflare/cfssl v0.0.0-20181213083726-b94e044bb51e/go.mod h1:yMWuSON
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20210106202047-687be5e0e320 h1:PjwzjUYqjto8PLdHLtPX2/JtCbYYsKMs1Zof7/h29YA=
-github.com/compose-spec/compose-go v0.0.0-20210106202047-687be5e0e320/go.mod h1:rz7rjxJGA/pWpLdBmDdqymGm2okEDYgBE7yx569xW+I=
+github.com/compose-spec/compose-go v0.0.0-20210113150448-e0b1ffe70cc5 h1:YBR7Ds5WrY+FNxN2aRRZyEB1E86PD+g1O5RjK++acx8=
+github.com/compose-spec/compose-go v0.0.0-20210113150448-e0b1ffe70cc5/go.mod h1:rz7rjxJGA/pWpLdBmDdqymGm2okEDYgBE7yx569xW+I=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=

--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -36,20 +36,12 @@ func (s *composeService) Build(ctx context.Context, project *types.Project) erro
 	opts := map[string]build.Options{}
 	for _, service := range project.Services {
 		if service.Build != nil {
-			imageName := getImageName(service, project)
+			imageName := getImageName(service, project.Name)
 			opts[imageName] = s.toBuildOptions(service, project.WorkingDir, imageName)
 		}
 	}
 
 	return s.build(ctx, project, opts)
-}
-
-func getImageName(service types.ServiceConfig, project *types.Project) string {
-	imageName := service.Image
-	if imageName == "" {
-		imageName = project.Name + "_" + service.Name
-	}
-	return imageName
 }
 
 func (s *composeService) ensureImagesExists(ctx context.Context, project *types.Project) error {
@@ -59,7 +51,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			return fmt.Errorf("invalid service %q. Must specify either image or build", service.Name)
 		}
 
-		imageName := getImageName(service, project)
+		imageName := getImageName(service, project.Name)
 		localImagePresent, err := s.localImagePresent(ctx, imageName)
 		if err != nil {
 			return err

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -48,7 +48,9 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 		return err
 	}
 
-	if err := s.ensureProjectNetworks(ctx, project); err != nil {
+	prepareNetworks(project)
+
+	if err := s.ensureNetworks(ctx, project.Networks); err != nil {
 		return err
 	}
 
@@ -89,15 +91,17 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 	})
 }
 
-func (s *composeService) ensureProjectNetworks(ctx context.Context, project *types.Project) error {
+func prepareNetworks(project *types.Project) {
 	for k, network := range project.Networks {
-		if !network.External.External && network.Name != "" {
-			network.Name = fmt.Sprintf("%s_%s", project.Name, k)
-			project.Networks[k] = network
-		}
 		network.Labels = network.Labels.Add(networkLabel, k)
 		network.Labels = network.Labels.Add(projectLabel, project.Name)
 		network.Labels = network.Labels.Add(versionLabel, ComposeVersion)
+		project.Networks[k] = network
+	}
+}
+
+func (s *composeService) ensureNetworks(ctx context.Context, networks types.Networks) error {
+	for _, network := range networks {
 		err := s.ensureNetwork(ctx, network)
 		if err != nil {
 			return err
@@ -108,10 +112,6 @@ func (s *composeService) ensureProjectNetworks(ctx context.Context, project *typ
 
 func (s *composeService) ensureProjectVolumes(ctx context.Context, project *types.Project) error {
 	for k, volume := range project.Volumes {
-		if !volume.External.External && volume.Name != "" {
-			volume.Name = fmt.Sprintf("%s_%s", project.Name, k)
-			project.Volumes[k] = volume
-		}
 		volume.Labels = volume.Labels.Add(volumeLabel, k)
 		volume.Labels = volume.Labels.Add(projectLabel, project.Name)
 		volume.Labels = volume.Labels.Add(versionLabel, ComposeVersion)

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -123,6 +123,14 @@ func (s *composeService) ensureProjectVolumes(ctx context.Context, project *type
 	return nil
 }
 
+func getImageName(service types.ServiceConfig, projectName string) string {
+	imageName := service.Image
+	if imageName == "" {
+		imageName = projectName + "_" + service.Name
+	}
+	return imageName
+}
+
 func getCreateOptions(p *types.Project, s types.ServiceConfig, number int, inherit *moby.Container, autoRemove bool) (*container.Config, *container.HostConfig, *network.NetworkingConfig, error) {
 	hash, err := jsonHash(s)
 	if err != nil {
@@ -155,10 +163,6 @@ func getCreateOptions(p *types.Project, s types.ServiceConfig, number int, inher
 	if len(s.Entrypoint) > 0 {
 		entrypoint = strslice.StrSlice(s.Entrypoint)
 	}
-	image := s.Image
-	if s.Image == "" {
-		image = fmt.Sprintf("%s_%s", p.Name, s.Name)
-	}
 
 	var (
 		tty         = s.Tty
@@ -178,7 +182,7 @@ func getCreateOptions(p *types.Project, s types.ServiceConfig, number int, inher
 		AttachStderr:    true,
 		AttachStdout:    true,
 		Cmd:             runCmd,
-		Image:           image,
+		Image:           getImageName(s, p.Name),
 		WorkingDir:      s.WorkingDir,
 		Entrypoint:      entrypoint,
 		NetworkDisabled: s.NetworkMode == "disabled",

--- a/local/compose/create_test.go
+++ b/local/compose/create_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/compose-spec/compose-go/types"
 	composetypes "github.com/compose-spec/compose-go/types"
 	mountTypes "github.com/docker/docker/api/types/mount"
 	"gotest.tools/v3/assert"
@@ -59,4 +60,9 @@ func TestBuildVolumeMount(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, mount.Source, "myProject_myVolume")
 	assert.Equal(t, mount.Type, mountTypes.TypeVolume)
+}
+
+func TestServiceImageName(t *testing.T) {
+	assert.Equal(t, getImageName(types.ServiceConfig{Image: "myImage"}, "myProject"), "myImage")
+	assert.Equal(t, getImageName(types.ServiceConfig{Name: "aService"}, "myProject"), "myProject_aService")
 }

--- a/local/compose/create_test.go
+++ b/local/compose/create_test.go
@@ -66,3 +66,16 @@ func TestServiceImageName(t *testing.T) {
 	assert.Equal(t, getImageName(types.ServiceConfig{Image: "myImage"}, "myProject"), "myImage")
 	assert.Equal(t, getImageName(types.ServiceConfig{Name: "aService"}, "myProject"), "myProject_aService")
 }
+
+func TestPrepareNetworkLabels(t *testing.T) {
+	project := types.Project{
+		Name:     "myProject",
+		Networks: types.Networks(map[string]types.NetworkConfig{"skynet": {}}),
+	}
+	prepareNetworks(&project)
+	assert.DeepEqual(t, project.Networks["skynet"].Labels, types.Labels(map[string]string{
+		"com.docker.compose.network": "skynet",
+		"com.docker.compose.project": "myProject",
+		"com.docker.compose.version": "1.0-alpha",
+	}))
+}

--- a/tests/compose-e2e/fixtures/network-test/docker-compose.yaml
+++ b/tests/compose-e2e/fixtures/network-test/docker-compose.yaml
@@ -1,0 +1,25 @@
+services:
+  db:
+    image: gtardif/sentences-db
+    networks:
+      - dbnet
+  words:
+    image: gtardif/sentences-api
+    ports:
+      - "8080:8080"
+    networks:
+      - dbnet
+      - servicenet
+  web:
+    image: gtardif/sentences-web
+    ports:
+      - "80:80"
+    labels:
+      - "my-label=test"
+    networks:
+      - servicenet
+
+networks:
+  dbnet:
+  servicenet:
+    name: microservices


### PR DESCRIPTION
**What I did**
* added unit tests on image names & removed duplicate name compute
* added unit tests on network labels and names
* found bug in networks with given names
* added e2e test on network

There are still cases not fixed here, due to compose-go setting network names to map keys by default. 
We need to do all the name setting in one place, compose-go or compose-cli. Still, fixing what I can here and adding e2e test will ensure we don't regress.

**Related issue**
https://github.com/docker/dev-tooling-team/issues/257

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
