### PR TITLE
Make Moby command detection (based on help output) more robust.

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"strings"
+	"regexp"
 
 	"github.com/spf13/cobra"
 
@@ -112,9 +112,7 @@ func IsDefaultContextCommand(dockerCommand string) bool {
 	if e != nil {
 		fmt.Println(e)
 	}
-	output := string(b)
-	contains := strings.Contains(output, "Usage:\tdocker "+dockerCommand)
-	return contains
+	return regexp.MustCompile("Usage:\\s*docker\\s*" + dockerCommand).Match(b)
 }
 
 // ExecSilent executes a command and do redirect output to stdOut, return output


### PR DESCRIPTION
 It seems some tabs have been replaced by spaces in CLI 20.10.

We need to install docker CLI ourselves in Github actions nodes, local e2e was failing locally, I assume this is since CLI 20.10.

symptom: `docker --context aci images` was returning 
`unknown command "images" for "docker"` 
instead of 
`Command "images" not available in current context (test-example), you can use the "default" context to run this command`

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* replace exact tab matching by regex matching any space

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
