### PR TITLE
Ensure local compose E2E are run in CI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 export DOCKER_BUILDKIT=1
-export BUILDX_NO_DEFAULT_LOAD=1
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -45,10 +44,10 @@ cli: ## Compile the cli
 	--output ./bin
 
 e2e-local: ## Run End to end local tests. Set E2E_TEST=TestName to run a single test
-	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e ./tests/skip-win-ci-e2e ./local/e2e
+	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e ./tests/compose-e2e ./tests/skip-win-ci-e2e ./local/e2e
 
 e2e-win-ci: ## Run end to end local tests on Windows CI, no Docker for Linux containers available ATM. Set E2E_TEST=TestName to run a single test
-	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e
+	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e ./tests/compose-e2e
 
 e2e-aci: ## Run End to end ACI tests. Set E2E_TEST=TestName to run a single test
 	go test -count=1 -v $(TEST_FLAGS) ./tests/aci-e2e

--- a/tests/compose-e2e/compose_test.go
+++ b/tests/compose-e2e/compose_test.go
@@ -57,7 +57,7 @@ func TestLocalComposeUp(t *testing.T) {
 		res := c.RunDockerCmd("compose", "ps", "-p", projectName)
 		res.Assert(t, icmd.Expected{Out: `web`})
 
-		endpoint := "http://localhost:80"
+		endpoint := "http://localhost:90"
 		output := HTTPGetWithRetry(t, endpoint+"/words/noun", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, `"word":`))
 

--- a/tests/compose-e2e/fixtures/sentences/docker-compose.yaml
+++ b/tests/compose-e2e/fixtures/sentences/docker-compose.yaml
@@ -4,10 +4,10 @@ services:
   words:
     image: gtardif/sentences-api
     ports:
-      - "8080:8080"
+      - "95:8080"
   web:
     image: gtardif/sentences-web
     ports:
-      - "80:80"
+      - "90:80"
     labels:
       - "my-label=test"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Add compose e2e folder in e2e makefile invocation.

We could move e2e tests closer to each backend code (unrelated to fixing this CI issue here) : aci E2E tests under `/aci/e2e` , local E2E under `/local/e2e` (that already has some), ... . WDYT @rumpl @ndeloof ?

**Related issue**
Compose local E2E tests not run in CI

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
