### PR TITLE
Avoiding more ACI flakyness

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -500,7 +500,12 @@ func TestContainerRunAttached(t *testing.T) {
 		l := Lines(res.Stdout())
 		assert.Equal(t, 2, len(l))
 
-		res = c.RunDockerCmd("prune", "--force")
+		res = c.RunDockerOrExitError("prune", "--force")
+		if strings.Contains(res.Stderr(), "unsupported protocol scheme") { //Flaky strange error on azure SDK call happening only during prune --force
+			time.Sleep(1 * time.Second)
+			res = c.RunDockerCmd("prune", "--force")
+		}
+
 		assert.Equal(t, "Deleted resources:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n", res.Stdout())
 
 		res = c.RunDockerCmd("ps", "--all")


### PR DESCRIPTION
some fixed in a804136b1c395f3a7d958d2516c8eec45b126ce7 (fixing `docker prune --dry-run --force` , exact same issue here with `docker prune --force`)

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* detect strange ACI error message and retry docker prune --force one sec later

**Related issue**
https://github.com/docker/compose-cli/runs/1557354494#step:6:196

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
