### PR TITLE
Do not run compose local e2e tests on windows GHA nodes for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ e2e-local: ## Run End to end local tests. Set E2E_TEST=TestName to run a single 
 	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e ./tests/compose-e2e ./tests/skip-win-ci-e2e ./local/e2e
 
 e2e-win-ci: ## Run end to end local tests on Windows CI, no Docker for Linux containers available ATM. Set E2E_TEST=TestName to run a single test
-	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e ./tests/compose-e2e
+	go test -count=1 -v $(TEST_FLAGS) ./tests/e2e
 
 e2e-aci: ## Run End to end ACI tests. Set E2E_TEST=TestName to run a single test
 	go test -count=1 -v $(TEST_FLAGS) ./tests/aci-e2e


### PR DESCRIPTION
 (buildkit failing with `failed to mount C:\ProgramData\docker\tmp\buildkit-mount370086869: [{Type:bind Source:C:\ProgramData\docker\windowsfilter\y3952h88q6ikevun9li41hjcb Options:[rbind ro]}]: invalid windows mount type: 'bind’`).

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

**Related issue**
https://github.com/docker/compose-cli/runs/1557667137#step:7:465

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
