### PR TITLE
create Services with image digests when known

### DIFF
--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -80,6 +80,11 @@ func (b *ecsAPIService) convert(ctx context.Context, project *types.Project) (*c
 	b.createAccessPoints(project, resources, template)
 
 	for _, service := range project.Services {
+		service.Image, err = b.resolveDigest(ctx, service.Image)
+		if err != nil {
+			return nil, err
+		}
+
 		err := b.createService(project, service, template, resources)
 		if err != nil {
 			return nil, err

--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/docker/docker/client"
+
 	"github.com/docker/compose-cli/api/compose"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -570,8 +572,12 @@ func convertYaml(t *testing.T, yaml string, fn ...func(m *MockAPIMockRecorder)) 
 		f(m.EXPECT())
 	}
 
+	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	assert.NilError(t, err)
+
 	backend := &ecsAPIService{
-		aws: m,
+		apiClient: apiClient,
+		aws:       m,
 	}
 	template, err := backend.convert(context.TODO(), project)
 	assert.NilError(t, err)


### PR DESCRIPTION
**What I did**
Update image in service definition with RepoDigests when known by local engine and non ambiguous.
This "quick fix" prevent `compose up` to fail with "_no change detected_" for the expected scenario a user rebuilds a service image then push and update his app on ECS.

**Related issue**
https://github.com/docker/compose-cli/issues/1074

/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
