### PR TITLE
Fix metrics flakyness

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -151,7 +151,7 @@ func TestContextMetrics(t *testing.T) {
 		c.RunDockerCmd("--help")
 		c.RunDockerCmd("run", "--help")
 
-		usage := s.GetUsage(3)
+		usage := s.GetUsage()
 		assert.DeepEqual(t, []string{
 			`{"command":"help run","context":"moby","source":"cli","status":"success"}`,
 			`{"command":"--help","context":"moby","source":"cli","status":"success"}`,
@@ -166,7 +166,7 @@ func TestContextMetrics(t *testing.T) {
 		c.RunDockerCmd("version")
 		c.RunDockerOrExitError("version", "--xxx")
 
-		usage := s.GetUsage(3)
+		usage := s.GetUsage()
 		assert.DeepEqual(t, []string{
 			`{"command":"ps","context":"moby","source":"cli","status":"success"}`,
 			`{"command":"version","context":"moby","source":"cli","status":"success"}`,
@@ -185,7 +185,7 @@ func TestContextMetrics(t *testing.T) {
 		c.RunDockerCmd("context", "use", "default")
 		c.RunDockerCmd("--context", "test-example", "ps")
 
-		usage := s.GetUsage(7)
+		usage := s.GetUsage()
 		assert.DeepEqual(t, []string{
 			`{"command":"context create","context":"moby","source":"cli","status":"success"}`,
 			`{"command":"ps","context":"moby","source":"cli","status":"success"}`,

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -144,6 +144,18 @@ func TestContextMetrics(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
+	started := false
+	for i := 0; i < 30; i++ {
+		c.RunDockerCmd("help", "ps")
+		if len(s.GetUsage()) > 0 {
+			started = true
+			fmt.Printf("	[%s] Server up in %d ms\n", t.Name(), i*100)
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Assert(t, started, "Metrics mock server not available after 3 secs")
+
 	t.Run("send metrics on help commands", func(t *testing.T) {
 		s.ResetUsage()
 

--- a/tests/framework/mockmetrics.go
+++ b/tests/framework/mockmetrics.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/labstack/echo"
 )
@@ -42,8 +41,7 @@ func NewMetricsServer(socket string) *MockMetricsServer {
 	}
 }
 
-// Handler
-func (s *MockMetricsServer) hello(c echo.Context) error {
+func (s *MockMetricsServer) handlePostUsage(c echo.Context) error {
 	body, error := ioutil.ReadAll(c.Request().Body)
 	if error != nil {
 		return error
@@ -54,10 +52,7 @@ func (s *MockMetricsServer) hello(c echo.Context) error {
 }
 
 // GetUsage get usage
-func (s *MockMetricsServer) GetUsage(expectedCommands int) []string {
-	if len(s.usage) < expectedCommands {
-		time.Sleep(1 * time.Second) // a simple sleep 1s here should be enough, if not there are real issues
-	}
+func (s *MockMetricsServer) GetUsage() []string {
 	return s.usage
 }
 
@@ -79,7 +74,7 @@ func (s *MockMetricsServer) Start() {
 			log.Fatal(err)
 		}
 		s.e.Listener = listener
-		s.e.POST("/usage", s.hello)
+		s.e.POST("/usage", s.handlePostUsage)
 		_ = s.e.Start(":1323")
 	}()
 }

--- a/tests/framework/mockmetrics.go
+++ b/tests/framework/mockmetrics.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo"
 )
@@ -77,4 +78,7 @@ func (s *MockMetricsServer) Start() {
 		s.e.POST("/usage", s.handlePostUsage)
 		_ = s.e.Start(":1323")
 	}()
+
+	// wait a bit for the mock metrics server to actually listen
+	time.Sleep(500 * time.Millisecond)
 }

--- a/tests/framework/mockmetrics.go
+++ b/tests/framework/mockmetrics.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/labstack/echo"
 )
@@ -78,7 +77,4 @@ func (s *MockMetricsServer) Start() {
 		s.e.POST("/usage", s.handlePostUsage)
 		_ = s.e.Start(":1323")
 	}()
-
-	// wait a bit for the mock metrics server to actually listen
-	time.Sleep(500 * time.Millisecond)
 }


### PR DESCRIPTION
**What I did**
* cleanup previous fix (#1038) that didn't correct the root cause
* realised the metrics mock server was started totally async, need to wait a bit
* could not find an easy API to check the server is ready, wait for 500 ms, other solutions would loop and wait anyway... 

**Related issue**
Fixes #1033 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://p1.hiclipart.com/preview/592/668/16/steampunk-gray-octopus-designed-analog-watch-thumbnail.jpg)