### PR TITLE
Use `container_name` property on service

### DIFF
--- a/formatter/logs.go
+++ b/formatter/logs.go
@@ -48,7 +48,7 @@ func (l *logConsumer) Log(service, container, message string) {
 		l.colors[service] = cf
 		l.computeWidth()
 	}
-	prefix := fmt.Sprintf("%-"+strconv.Itoa(l.width)+"s |", service)
+	prefix := fmt.Sprintf("%-"+strconv.Itoa(l.width)+"s |", container)
 
 	for _, line := range strings.Split(message, "\n") {
 		buf := bytes.NewBufferString(fmt.Sprintf("%s %s\n", cf(prefix), line))

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -61,7 +61,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 
 func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.LogConsumer, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
-	w := getWriter(serviceName, container.ID, consumer)
+	w := getWriter(serviceName, getContainerName(container), consumer)
 
 	service, err := project.GetService(serviceName)
 	if err != nil {

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -45,7 +45,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 
 	var names []string
 	for _, c := range containers {
-		names = append(names, getContainerName(c))
+		names = append(names, getCanonicalContainerName(c))
 	}
 	fmt.Printf("Attaching to %s\n", strings.Join(names, ", "))
 
@@ -61,7 +61,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 
 func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.LogConsumer, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
-	w := getWriter(serviceName, getContainerName(container), consumer)
+	w := getWriter(serviceName, getCanonicalContainerName(container), consumer)
 
 	service, err := project.GetService(serviceName)
 	if err != nil {

--- a/local/compose/compose.go
+++ b/local/compose/compose.go
@@ -25,10 +25,11 @@ import (
 	"github.com/docker/compose-cli/api/compose"
 
 	"github.com/compose-spec/compose-go/types"
-	errdefs2 "github.com/docker/compose-cli/errdefs"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/sanathkr/go-yaml"
+
+	errdefs2 "github.com/docker/compose-cli/errdefs"
 )
 
 // NewComposeService create a local implementation of the compose.Service API
@@ -44,7 +45,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 	return errdefs2.ErrNotImplemented
 }
 
-func getContainerName(c moby.Container) string {
+func getCanonicalContainerName(c moby.Container) string {
 	// Names return container canonical name /foo  + link aliases /linked_by/foo
 	for _, name := range c.Names {
 		if strings.LastIndex(name, "/") == 0 {

--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -66,7 +66,7 @@ func (containers Containers) split(predicate containerPredicate) (Containers, Co
 func (containers Containers) names() []string {
 	var names []string
 	for _, c := range containers {
-		names = append(names, getContainerName(c))
+		names = append(names, getCanonicalContainerName(c))
 	}
 	return names
 }

--- a/local/compose/convergence_test.go
+++ b/local/compose/convergence_test.go
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/compose-spec/compose-go/types"
+	"gotest.tools/assert"
+)
+
+func TestContainerName(t *testing.T) {
+	var replicas uint64 = 1
+	s := types.ServiceConfig{
+		Name:          "testservicename",
+		ContainerName: "testcontainername",
+		Scale:         1,
+		Deploy:        &types.DeployConfig{},
+	}
+	ret, err := getScale(s)
+	assert.NilError(t, err)
+	assert.Equal(t, ret, s.Scale)
+
+	s.Scale = 0
+	s.Deploy.Replicas = &replicas
+	ret, err = getScale(s)
+	assert.NilError(t, err)
+	assert.Equal(t, ret, int(*s.Deploy.Replicas))
+
+	s.Deploy.Replicas = nil
+	s.Scale = 2
+	_, err = getScale(s)
+	assert.Error(t, err, fmt.Sprintf(doubledContainerNameWarning, s.Name, s.ContainerName))
+
+	replicas = 2
+	s.Deploy.Replicas = &replicas
+	s.Scale = 0
+	_, err = getScale(s)
+	assert.Error(t, err, fmt.Sprintf(doubledContainerNameWarning, s.Name, s.ContainerName))
+}

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -213,7 +213,7 @@ func getCreateOptions(p *types.Project, s types.ServiceConfig, number int, inher
 		Resources:    resources,
 	}
 
-	networkConfig := buildDefaultNetworkConfig(s, networkMode)
+	networkConfig := buildDefaultNetworkConfig(s, networkMode, getContainerName(p.Name, s, number))
 	return &containerConfig, &hostConfig, networkConfig, nil
 }
 
@@ -359,11 +359,11 @@ func buildTmpfsOptions(tmpfs *types.ServiceVolumeTmpfs) *mount.TmpfsOptions {
 	}
 }
 
-func buildDefaultNetworkConfig(s types.ServiceConfig, networkMode container.NetworkMode) *network.NetworkingConfig {
+func buildDefaultNetworkConfig(s types.ServiceConfig, networkMode container.NetworkMode, containerName string) *network.NetworkingConfig {
 	config := map[string]*network.EndpointSettings{}
 	net := string(networkMode)
 	config[net] = &network.EndpointSettings{
-		Aliases: getAliases(s, s.Networks[net]),
+		Aliases: append(getAliases(s, s.Networks[net]), containerName),
 	}
 
 	return &network.NetworkingConfig{

--- a/local/compose/down.go
+++ b/local/compose/down.go
@@ -94,7 +94,7 @@ func (s *composeService) removeContainers(ctx context.Context, w progress.Writer
 	for _, container := range containers {
 		toDelete := container
 		eg.Go(func() error {
-			eventName := "Container " + getContainerName(toDelete)
+			eventName := "Container " + getCanonicalContainerName(toDelete)
 			w.Event(progress.StoppingEvent(eventName))
 			err := s.apiClient.ContainerStop(ctx, toDelete.ID, nil)
 			if err != nil {

--- a/local/compose/ps.go
+++ b/local/compose/ps.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/docker/compose-cli/api/compose"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/docker/compose-cli/api/compose"
 )
 
 func (s *composeService) Ps(ctx context.Context, projectName string) ([]compose.ContainerSummary, error) {
@@ -54,7 +55,7 @@ func (s *composeService) Ps(ctx context.Context, projectName string) ([]compose.
 
 		summary = append(summary, compose.ContainerSummary{
 			ID:         c.ID,
-			Name:       getContainerName(c),
+			Name:       getCanonicalContainerName(c),
 			Project:    c.Labels[projectLabel],
 			Service:    c.Labels[serviceLabel],
 			State:      c.State,


### PR DESCRIPTION
**What I did**
This applies `container_name` when available in the service definition.

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/1046