### PR TITLE
Build tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,13 @@ e2e-aci: ## Run End to end ACI tests. Set E2E_TEST=TestName to run a single test
 e2e-ecs: ## Run End to end ECS tests. Set E2E_TEST=TestName to run a single test
 	go test -timeout 20m -count=1 -v $(TEST_FLAGS) ./tests/ecs-e2e
 
+cross-%:
+	@docker build . --target cross-single \
+	--platform $(subst -,/,$*) \
+	--build-arg BUILD_TAGS \
+	--build-arg GIT_TAG=$(GIT_TAG) \
+	--output ./bin \
+
 cross: ## Compile the CLI for linux, darwin and windows
 	@docker build . --target cross \
 	--build-arg BUILD_TAGS \

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -61,7 +61,7 @@ cli:
 
 cross-%:
 	GOOS=$(word 1,$(subst -, ,$(*))) GOARCH=$(word 2,$(subst -, ,$(*))) \
-	$(GO_BUILD) $(TAGS) -o $(BINARY)-$(*)$(if $(filter windows,$(word 1,$(subst -, ,$(*)))),.exe,) ./cli;
+	$(GO_BUILD) $(TAGS) -o $(BINARY)-$(*)$(if $(filter windows,$(word 1,$(subst -, ,$(*)))),.exe,) ./cli
 
 .PHONY: cross
 cross: $(foreach plat,$(CROSS_PLATFORMS),cross-$(subst /,-,$(plat)))


### PR DESCRIPTION
**What I did**
* Used loops and logic for cross compiles rather than hard coding each platform
* Added the ability to cross compile a single platform
* Added builds for linux/arm

This should make it really easy to add darwin/arm64 when Go 1.16 is GA

Manually tested that the tarballs generated by this contain what we're expecting.