### PR TITLE
Make --file and --project-name options global

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -71,7 +71,7 @@ type ConvertOptions struct {
 
 // RunOptions options to execute compose run
 type RunOptions struct {
-	Name       string
+	Service    string
 	Command    []string
 	Detach     bool
 	AutoRemove bool

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -30,9 +30,9 @@ type buildOptions struct {
 	composeOptions
 }
 
-func buildCommand(composeOpts composeOptions) *cobra.Command {
+func buildCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := buildOptions{
-		composeOptions: composeOpts,
+		composeOptions: *composeOpts,
 	}
 
 	buildCmd := &cobra.Command{

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -27,12 +27,12 @@ import (
 )
 
 type buildOptions struct {
-	composeOptions
+	*composeOptions
 }
 
 func buildCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := buildOptions{
-		composeOptions: *composeOpts,
+		composeOptions: composeOpts,
 	}
 
 	buildCmd := &cobra.Command{

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -30,9 +30,9 @@ type buildOptions struct {
 	composeOptions
 }
 
-func buildCommand(globalOpts composeOptions) *cobra.Command {
+func buildCommand(composeOpts composeOptions) *cobra.Command {
 	opts := buildOptions{
-		composeOptions: globalOpts,
+		composeOptions: composeOpts,
 	}
 
 	buildCmd := &cobra.Command{

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -30,8 +30,11 @@ type buildOptions struct {
 	composeOptions
 }
 
-func buildCommand() *cobra.Command {
-	opts := buildOptions{}
+func buildCommand(globalOpts composeOptions) *cobra.Command {
+	opts := buildOptions{
+		composeOptions: globalOpts,
+	}
+
 	buildCmd := &cobra.Command{
 		Use:   "build [SERVICE...]",
 		Short: "Build or rebuild services",
@@ -39,8 +42,8 @@ func buildCommand() *cobra.Command {
 			return runBuild(cmd.Context(), opts, args)
 		},
 	}
+
 	buildCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	buildCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return buildCmd
 }

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -85,20 +85,20 @@ func Command(contextType string) *cobra.Command {
 	}
 
 	command.AddCommand(
-		upCommand(composeOpts, contextType),
-		downCommand(composeOpts),
-		psCommand(composeOpts),
-		listCommand(composeOpts),
-		logsCommand(composeOpts),
-		convertCommand(composeOpts),
-		runCommand(composeOpts),
+		upCommand(&composeOpts, contextType),
+		downCommand(&composeOpts),
+		psCommand(&composeOpts),
+		listCommand(&composeOpts),
+		logsCommand(&composeOpts),
+		convertCommand(&composeOpts),
+		runCommand(&composeOpts),
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {
 		command.AddCommand(
-			buildCommand(composeOpts),
-			pushCommand(composeOpts),
-			pullCommand(composeOpts),
+			buildCommand(&composeOpts),
+			pushCommand(&composeOpts),
+			pullCommand(&composeOpts),
 		)
 	}
 

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -86,11 +86,11 @@ func Command(contextType string) *cobra.Command {
 
 	command.AddCommand(
 		upCommand(contextType),
-		downCommand(),
-		psCommand(),
-		listCommand(),
-		logsCommand(),
-		convertCommand(),
+		downCommand(globalOpts),
+		psCommand(globalOpts),
+		listCommand(globalOpts),
+		logsCommand(globalOpts),
+		convertCommand(globalOpts),
 		runCommand(),
 	)
 

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -72,7 +72,7 @@ func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 
 // Command returns the compose command with its child commands
 func Command(contextType string) *cobra.Command {
-	globalOpts := composeOptions{}
+	composeOpts := composeOptions{}
 	command := &cobra.Command{
 		Short: "Docker Compose",
 		Use:   "compose",
@@ -86,25 +86,25 @@ func Command(contextType string) *cobra.Command {
 
 	command.AddCommand(
 		upCommand(contextType),
-		downCommand(globalOpts),
-		psCommand(globalOpts),
-		listCommand(globalOpts),
-		logsCommand(globalOpts),
-		convertCommand(globalOpts),
-		runCommand(globalOpts),
+		downCommand(composeOpts),
+		psCommand(composeOpts),
+		listCommand(composeOpts),
+		logsCommand(composeOpts),
+		convertCommand(composeOpts),
+		runCommand(composeOpts),
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {
 		command.AddCommand(
-			buildCommand(globalOpts),
-			pushCommand(globalOpts),
-			pullCommand(globalOpts),
+			buildCommand(composeOpts),
+			pushCommand(composeOpts),
+			pullCommand(composeOpts),
 		)
 	}
 
 	command.Flags().SetInterspersed(false)
-	command.PersistentFlags().StringArrayVarP(&globalOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
-	command.PersistentFlags().StringVarP(&globalOpts.Name, "project-name", "p", "", "Project name")
+	command.PersistentFlags().StringArrayVarP(&composeOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	command.PersistentFlags().StringVarP(&composeOpts.Name, "project-name", "p", "", "Project name")
 
 	return command
 }

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -91,7 +91,7 @@ func Command(contextType string) *cobra.Command {
 		listCommand(globalOpts),
 		logsCommand(globalOpts),
 		convertCommand(globalOpts),
-		runCommand(),
+		runCommand(globalOpts),
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -104,7 +104,7 @@ func Command(contextType string) *cobra.Command {
 
 	command.Flags().SetInterspersed(false)
 	command.PersistentFlags().StringArrayVarP(&composeOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
-	command.PersistentFlags().StringVarP(&composeOpts.Name, "project-name", "p", "", "Project name")
+	command.PersistentFlags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")
 
 	return command
 }

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -72,7 +72,7 @@ func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 
 // Command returns the compose command with its child commands
 func Command(contextType string) *cobra.Command {
-	opts := composeOptions{}
+	globalOpts := composeOptions{}
 	command := &cobra.Command{
 		Short: "Docker Compose",
 		Use:   "compose",
@@ -96,15 +96,15 @@ func Command(contextType string) *cobra.Command {
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {
 		command.AddCommand(
-			buildCommand(),
-			pushCommand(),
-			pullCommand(),
+			buildCommand(globalOpts),
+			pushCommand(globalOpts),
+			pullCommand(globalOpts),
 		)
 	}
 
 	command.Flags().SetInterspersed(false)
-	command.PersistentFlags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
-	command.PersistentFlags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	command.PersistentFlags().StringArrayVarP(&globalOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	command.PersistentFlags().StringVarP(&globalOpts.Name, "project-name", "p", "", "Project name")
 
 	return command
 }

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -85,7 +85,7 @@ func Command(contextType string) *cobra.Command {
 	}
 
 	command.AddCommand(
-		upCommand(contextType),
+		upCommand(composeOpts, contextType),
 		downCommand(composeOpts),
 		psCommand(composeOpts),
 		listCommand(composeOpts),

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -72,6 +72,7 @@ func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 
 // Command returns the compose command with its child commands
 func Command(contextType string) *cobra.Command {
+	opts := composeOptions{}
 	command := &cobra.Command{
 		Short: "Docker Compose",
 		Use:   "compose",
@@ -100,7 +101,11 @@ func Command(contextType string) *cobra.Command {
 			pullCommand(),
 		)
 	}
+
 	command.Flags().SetInterspersed(false)
+	command.PersistentFlags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	command.PersistentFlags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+
 	return command
 }
 

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -28,7 +28,7 @@ import (
 )
 
 type composeOptions struct {
-	Name        string
+	ProjectName string
 	DomainName  string
 	WorkingDir  string
 	ConfigPaths []string
@@ -40,14 +40,14 @@ type composeOptions struct {
 }
 
 func addComposeCommonFlags(f *pflag.FlagSet, opts *composeOptions) {
-	f.StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	f.StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
 	f.StringVar(&opts.Format, "format", "", "Format the output. Values: [pretty | json]. (Default: pretty)")
 	f.BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs")
 }
 
 func (o *composeOptions) toProjectName() (string, error) {
-	if o.Name != "" {
-		return o.Name, nil
+	if o.ProjectName != "" {
+		return o.ProjectName, nil
 	}
 
 	options, err := o.toProjectOptions()
@@ -67,7 +67,7 @@ func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 		cli.WithOsEnv,
 		cli.WithEnv(o.Environment),
 		cli.WithWorkingDirectory(o.WorkingDir),
-		cli.WithName(o.Name))
+		cli.WithName(o.ProjectName))
 }
 
 // Command returns the compose command with its child commands

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -37,7 +37,7 @@ func convertCommand() *cobra.Command {
 			return runConvert(cmd.Context(), opts)
 		},
 	}
-	convertCmd.Flags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	convertCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
 	convertCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
 	convertCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	convertCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -28,12 +28,12 @@ import (
 	"github.com/docker/compose-cli/api/client"
 )
 
-func convertCommand(composeOpts composeOptions) *cobra.Command {
+func convertCommand(composeOpts *composeOptions) *cobra.Command {
 	convertCmd := &cobra.Command{
 		Use:   "convert",
 		Short: "Converts the compose file to a cloud format (default: cloudformation)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runConvert(cmd.Context(), composeOpts)
+			return runConvert(cmd.Context(), *composeOpts)
 		},
 	}
 	convertCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -28,13 +28,12 @@ import (
 	"github.com/docker/compose-cli/api/client"
 )
 
-func convertCommand() *cobra.Command {
-	opts := composeOptions{}
+func convertCommand(globalOpts composeOptions) *cobra.Command {
 	convertCmd := &cobra.Command{
 		Use:   "convert",
 		Short: "Converts the compose file to a cloud format (default: cloudformation)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runConvert(cmd.Context(), opts)
+			return runConvert(cmd.Context(), globalOpts)
 		},
 	}
 	convertCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -28,19 +28,19 @@ import (
 	"github.com/docker/compose-cli/api/client"
 )
 
-func convertCommand(globalOpts composeOptions) *cobra.Command {
+func convertCommand(composeOpts composeOptions) *cobra.Command {
 	convertCmd := &cobra.Command{
 		Use:   "convert",
 		Short: "Converts the compose file to a cloud format (default: cloudformation)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runConvert(cmd.Context(), globalOpts)
+			return runConvert(cmd.Context(), composeOpts)
 		},
 	}
-	convertCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
-	convertCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	convertCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
-	convertCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")
-	convertCmd.Flags().StringVar(&opts.Format, "format", "yaml", "Format the output. Values: [yaml | json]")
+	convertCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")
+	convertCmd.Flags().StringVar(&composeOpts.WorkingDir, "workdir", "", "Work dir")
+	convertCmd.Flags().StringArrayVarP(&composeOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	convertCmd.Flags().StringArrayVarP(&composeOpts.Environment, "environment", "e", []string{}, "Environment variables")
+	convertCmd.Flags().StringVar(&composeOpts.Format, "format", "yaml", "Format the output. Values: [yaml | json]")
 
 	return convertCmd
 }

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -36,7 +36,7 @@ func downCommand() *cobra.Command {
 			return runDown(cmd.Context(), opts)
 		},
 	}
-	downCmd.Flags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	downCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
 	downCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
 	downCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -27,17 +27,17 @@ import (
 	"github.com/docker/compose-cli/progress"
 )
 
-func downCommand(globalOpts composeOptions) *cobra.Command {
+func downCommand(composeOpts composeOptions) *cobra.Command {
 	downCmd := &cobra.Command{
 		Use:   "down",
 		Short: "Stop and remove containers, networks",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDown(cmd.Context(), globalOpts)
+			return runDown(cmd.Context(), composeOpts)
 		},
 	}
-	downCmd.Flags().StringVarP(&globalOpts.ProjectName, "project-name", "p", "", "Project name")
-	downCmd.Flags().StringVar(&globalOpts.WorkingDir, "workdir", "", "Work dir")
-	downCmd.Flags().StringArrayVarP(&globalOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	downCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")
+	downCmd.Flags().StringVar(&composeOpts.WorkingDir, "workdir", "", "Work dir")
+	downCmd.Flags().StringArrayVarP(&composeOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return downCmd
 }

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -27,12 +27,12 @@ import (
 	"github.com/docker/compose-cli/progress"
 )
 
-func downCommand(composeOpts composeOptions) *cobra.Command {
+func downCommand(composeOpts *composeOptions) *cobra.Command {
 	downCmd := &cobra.Command{
 		Use:   "down",
 		Short: "Stop and remove containers, networks",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDown(cmd.Context(), composeOpts)
+			return runDown(cmd.Context(), *composeOpts)
 		},
 	}
 	downCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -27,18 +27,17 @@ import (
 	"github.com/docker/compose-cli/progress"
 )
 
-func downCommand() *cobra.Command {
-	opts := composeOptions{}
+func downCommand(globalOpts composeOptions) *cobra.Command {
 	downCmd := &cobra.Command{
 		Use:   "down",
 		Short: "Stop and remove containers, networks",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDown(cmd.Context(), opts)
+			return runDown(cmd.Context(), globalOpts)
 		},
 	}
-	downCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
-	downCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	downCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	downCmd.Flags().StringVarP(&globalOpts.ProjectName, "project-name", "p", "", "Project name")
+	downCmd.Flags().StringVar(&globalOpts.WorkingDir, "workdir", "", "Work dir")
+	downCmd.Flags().StringArrayVarP(&globalOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return downCmd
 }

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -48,7 +48,7 @@ func runList(ctx context.Context, opts composeOptions) error {
 	if err != nil {
 		return err
 	}
-	stackList, err := c.ComposeService().List(ctx, opts.Name)
+	stackList, err := c.ComposeService().List(ctx, opts.ProjectName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -30,16 +30,17 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func listCommand() *cobra.Command {
-	opts := composeOptions{}
+func listCommand(globalOpts composeOptions) *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:   "ls",
 		Short: "List running compose projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), opts)
+			return runList(cmd.Context(), globalOpts)
 		},
 	}
-	addComposeCommonFlags(lsCmd.Flags(), &opts)
+
+	addComposeCommonFlags(lsCmd.Flags(), &globalOpts)
+
 	return lsCmd
 }
 

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -30,16 +30,16 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func listCommand(composeOpts composeOptions) *cobra.Command {
+func listCommand(composeOpts *composeOptions) *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:   "ls",
 		Short: "List running compose projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), composeOpts)
+			return runList(cmd.Context(), *composeOpts)
 		},
 	}
 
-	addComposeCommonFlags(lsCmd.Flags(), &composeOpts)
+	addComposeCommonFlags(lsCmd.Flags(), composeOpts)
 
 	return lsCmd
 }

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -30,16 +30,16 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func listCommand(globalOpts composeOptions) *cobra.Command {
+func listCommand(composeOpts composeOptions) *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:   "ls",
 		Short: "List running compose projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), globalOpts)
+			return runList(cmd.Context(), composeOpts)
 		},
 	}
 
-	addComposeCommonFlags(lsCmd.Flags(), &globalOpts)
+	addComposeCommonFlags(lsCmd.Flags(), &composeOpts)
 
 	return lsCmd
 }

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/formatter"
-	"github.com/spf13/cobra"
 )
 
 func logsCommand() *cobra.Command {
@@ -35,7 +36,7 @@ func logsCommand() *cobra.Command {
 			return runLogs(cmd.Context(), opts, args)
 		},
 	}
-	logsCmd.Flags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	logsCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
 	logsCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
 	logsCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -27,18 +27,17 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func logsCommand() *cobra.Command {
-	opts := composeOptions{}
+func logsCommand(globalOpts composeOptions) *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "logs [service...]",
 		Short: "View output from containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogs(cmd.Context(), opts, args)
+			return runLogs(cmd.Context(), globalOpts, args)
 		},
 	}
-	logsCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
-	logsCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	logsCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	logsCmd.Flags().StringVarP(&globalOpts.ProjectName, "project-name", "p", "", "Project name")
+	logsCmd.Flags().StringVar(&globalOpts.WorkingDir, "workdir", "", "Work dir")
+	logsCmd.Flags().StringArrayVarP(&globalOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return logsCmd
 }

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -27,12 +27,12 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func logsCommand(composeOpts composeOptions) *cobra.Command {
+func logsCommand(composeOpts *composeOptions) *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "logs [service...]",
 		Short: "View output from containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogs(cmd.Context(), composeOpts, args)
+			return runLogs(cmd.Context(), *composeOpts, args)
 		},
 	}
 	logsCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -27,17 +27,17 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func logsCommand(globalOpts composeOptions) *cobra.Command {
+func logsCommand(composeOpts composeOptions) *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "logs [service...]",
 		Short: "View output from containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogs(cmd.Context(), globalOpts, args)
+			return runLogs(cmd.Context(), composeOpts, args)
 		},
 	}
-	logsCmd.Flags().StringVarP(&globalOpts.ProjectName, "project-name", "p", "", "Project name")
-	logsCmd.Flags().StringVar(&globalOpts.WorkingDir, "workdir", "", "Work dir")
-	logsCmd.Flags().StringArrayVarP(&globalOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	logsCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")
+	logsCmd.Flags().StringVar(&composeOpts.WorkingDir, "workdir", "", "Work dir")
+	logsCmd.Flags().StringArrayVarP(&composeOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return logsCmd
 }

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -30,16 +30,16 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func psCommand(globalOpts composeOptions) *cobra.Command {
+func psCommand(composeOpts composeOptions) *cobra.Command {
 	psCmd := &cobra.Command{
 		Use:   "ps",
 		Short: "List containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPs(cmd.Context(), globalOpts)
+			return runPs(cmd.Context(), composeOpts)
 		},
 	}
-	psCmd.Flags().StringVar(&globalOpts.WorkingDir, "workdir", "", "Work dir")
-	addComposeCommonFlags(psCmd.Flags(), &globalOpts)
+	psCmd.Flags().StringVar(&composeOpts.WorkingDir, "workdir", "", "Work dir")
+	addComposeCommonFlags(psCmd.Flags(), &composeOpts)
 
 	return psCmd
 }

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -30,16 +30,16 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func psCommand(composeOpts composeOptions) *cobra.Command {
+func psCommand(composeOpts *composeOptions) *cobra.Command {
 	psCmd := &cobra.Command{
 		Use:   "ps",
 		Short: "List containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPs(cmd.Context(), composeOpts)
+			return runPs(cmd.Context(), *composeOpts)
 		},
 	}
 	psCmd.Flags().StringVar(&composeOpts.WorkingDir, "workdir", "", "Work dir")
-	addComposeCommonFlags(psCmd.Flags(), &composeOpts)
+	addComposeCommonFlags(psCmd.Flags(), composeOpts)
 
 	return psCmd
 }

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -30,18 +30,17 @@ import (
 	"github.com/docker/compose-cli/formatter"
 )
 
-func psCommand() *cobra.Command {
-	opts := composeOptions{}
+func psCommand(globalOpts composeOptions) *cobra.Command {
 	psCmd := &cobra.Command{
 		Use:   "ps",
 		Short: "List containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPs(cmd.Context(), opts)
+			return runPs(cmd.Context(), globalOpts)
 		},
 	}
-	psCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	psCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
-	addComposeCommonFlags(psCmd.Flags(), &opts)
+	psCmd.Flags().StringVar(&globalOpts.WorkingDir, "workdir", "", "Work dir")
+	addComposeCommonFlags(psCmd.Flags(), &globalOpts)
+
 	return psCmd
 }
 

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -30,9 +30,9 @@ type pullOptions struct {
 	composeOptions
 }
 
-func pullCommand(composeOpts composeOptions) *cobra.Command {
+func pullCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := pullOptions{
-		composeOptions: composeOpts,
+		composeOptions: *composeOpts,
 	}
 
 	pullCmd := &cobra.Command{

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -30,9 +30,9 @@ type pullOptions struct {
 	composeOptions
 }
 
-func pullCommand(globalOptions composeOptions) *cobra.Command {
+func pullCommand(composeOpts composeOptions) *cobra.Command {
 	opts := pullOptions{
-		composeOptions: globalOptions,
+		composeOptions: composeOpts,
 	}
 
 	pullCmd := &cobra.Command{

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -30,8 +30,11 @@ type pullOptions struct {
 	composeOptions
 }
 
-func pullCommand() *cobra.Command {
-	opts := pullOptions{}
+func pullCommand(globalOptions composeOptions) *cobra.Command {
+	opts := pullOptions{
+		composeOptions: globalOptions,
+	}
+
 	pullCmd := &cobra.Command{
 		Use:   "pull [SERVICE...]",
 		Short: "Pull service images",
@@ -41,7 +44,6 @@ func pullCommand() *cobra.Command {
 	}
 
 	pullCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	pullCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return pullCmd
 }

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -27,12 +27,12 @@ import (
 )
 
 type pullOptions struct {
-	composeOptions
+	*composeOptions
 }
 
 func pullCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := pullOptions{
-		composeOptions: *composeOpts,
+		composeOptions: composeOpts,
 	}
 
 	pullCmd := &cobra.Command{

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -30,8 +30,11 @@ type pushOptions struct {
 	composeOptions
 }
 
-func pushCommand() *cobra.Command {
-	opts := pushOptions{}
+func pushCommand(globalOpts composeOptions) *cobra.Command {
+	opts := pushOptions{
+		composeOptions: globalOpts,
+	}
+
 	pushCmd := &cobra.Command{
 		Use:   "push [SERVICE...]",
 		Short: "Push service images",
@@ -41,7 +44,6 @@ func pushCommand() *cobra.Command {
 	}
 
 	pushCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	pushCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 
 	return pushCmd
 }

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -27,12 +27,12 @@ import (
 )
 
 type pushOptions struct {
-	composeOptions
+	*composeOptions
 }
 
 func pushCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := pushOptions{
-		composeOptions: *composeOpts,
+		composeOptions: composeOpts,
 	}
 
 	pushCmd := &cobra.Command{

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -30,9 +30,9 @@ type pushOptions struct {
 	composeOptions
 }
 
-func pushCommand(globalOpts composeOptions) *cobra.Command {
+func pushCommand(composeOpts composeOptions) *cobra.Command {
 	opts := pushOptions{
-		composeOptions: globalOpts,
+		composeOptions: composeOpts,
 	}
 
 	pushCmd := &cobra.Command{

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -30,9 +30,9 @@ type pushOptions struct {
 	composeOptions
 }
 
-func pushCommand(composeOpts composeOptions) *cobra.Command {
+func pushCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := pushOptions{
-		composeOptions: composeOpts,
+		composeOptions: *composeOpts,
 	}
 
 	pushCmd := &cobra.Command{

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -30,6 +30,7 @@ import (
 
 type runOptions struct {
 	Name        string
+	Service     string
 	Command     []string
 	WorkingDir  string
 	ConfigPaths []string
@@ -48,7 +49,7 @@ func runCommand() *cobra.Command {
 			if len(args) > 1 {
 				opts.Command = args[1:]
 			}
-			opts.Name = args[0]
+			opts.Service = args[0]
 			return runRun(cmd.Context(), opts)
 		},
 	}
@@ -68,14 +69,14 @@ func runRun(ctx context.Context, opts runOptions) error {
 		WorkingDir:  opts.WorkingDir,
 		Environment: opts.Environment,
 	}
-	c, project, err := setup(ctx, projectOpts, []string{opts.Name})
+	c, project, err := setup(ctx, projectOpts, []string{opts.Service})
 	if err != nil {
 		return err
 	}
 
 	originalServices := project.Services
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", startDependencies(ctx, c, project, opts.Name)
+		return "", startDependencies(ctx, c, project, opts.Service)
 	})
 	if err != nil {
 		return err
@@ -84,7 +85,7 @@ func runRun(ctx context.Context, opts runOptions) error {
 	project.Services = originalServices
 	// start container and attach to container streams
 	runOpts := compose.RunOptions{
-		Name:       opts.Name,
+		Service:    opts.Service,
 		Command:    opts.Command,
 		Detach:     opts.Detach,
 		AutoRemove: opts.Remove,

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -29,18 +29,19 @@ import (
 )
 
 type runOptions struct {
-	Name        string
+	Name    string
 	Service     string
-	Command     []string
-	WorkingDir  string
-	ConfigPaths []string
-	Environment []string
-	Detach      bool
-	Remove      bool
+	Command []string
+	Detach  bool
+	Remove  bool
+	composeOptions
 }
 
-func runCommand() *cobra.Command {
-	opts := runOptions{}
+func runCommand(globalOpts composeOptions) *cobra.Command {
+	opts := runOptions{
+		composeOptions: globalOpts,
+	}
+
 	runCmd := &cobra.Command{
 		Use:   "run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l KEY=VALUE...] SERVICE [COMMAND] [ARGS...]",
 		Short: "Run a one-off command on a service.",
@@ -54,7 +55,6 @@ func runCommand() *cobra.Command {
 		},
 	}
 	runCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	runCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	runCmd.Flags().BoolVarP(&opts.Detach, "detach", "d", false, "Run container in background and print container ID")
 	runCmd.Flags().StringArrayVarP(&opts.Environment, "env", "e", []string{}, "Set environment variables")
 	runCmd.Flags().BoolVar(&opts.Remove, "rm", false, "Automatically remove the container when it exits")
@@ -64,12 +64,7 @@ func runCommand() *cobra.Command {
 }
 
 func runRun(ctx context.Context, opts runOptions) error {
-	projectOpts := composeOptions{
-		ConfigPaths: opts.ConfigPaths,
-		WorkingDir:  opts.WorkingDir,
-		Environment: opts.Environment,
-	}
-	c, project, err := setup(ctx, projectOpts, []string{opts.Service})
+	c, project, err := setup(ctx, opts.composeOptions, []string{opts.Service})
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -79,7 +79,7 @@ func runRun(ctx context.Context, opts runOptions) error {
 	project.Services = originalServices
 	// start container and attach to container streams
 	runOpts := compose.RunOptions{
-		Name:       opts.Name,
+		Service:    opts.Service,
 		Command:    opts.Command,
 		Detach:     opts.Detach,
 		AutoRemove: opts.Remove,

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -34,12 +34,12 @@ type runOptions struct {
 	Command []string
 	Detach  bool
 	Remove  bool
-	composeOptions
+	*composeOptions
 }
 
 func runCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := runOptions{
-		composeOptions: *composeOpts,
+		composeOptions: composeOpts,
 	}
 
 	runCmd := &cobra.Command{
@@ -64,7 +64,7 @@ func runCommand(composeOpts *composeOptions) *cobra.Command {
 }
 
 func runRun(ctx context.Context, opts runOptions) error {
-	c, project, err := setup(ctx, opts.composeOptions, []string{opts.Service})
+	c, project, err := setup(ctx, *opts.composeOptions, []string{opts.Service})
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -32,7 +32,6 @@ type runOptions struct {
 	Name    string
 	Service     string
 	Command []string
-	Detach  bool
 	Remove  bool
 	*composeOptions
 }

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -37,9 +37,9 @@ type runOptions struct {
 	composeOptions
 }
 
-func runCommand(globalOpts composeOptions) *cobra.Command {
+func runCommand(composeOpts composeOptions) *cobra.Command {
 	opts := runOptions{
-		composeOptions: globalOpts,
+		composeOptions: composeOpts,
 	}
 
 	runCmd := &cobra.Command{

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -30,7 +30,7 @@ import (
 
 type runOptions struct {
 	Name    string
-	Service     string
+	Service string
 	Command []string
 	Remove  bool
 	*composeOptions
@@ -79,7 +79,7 @@ func runRun(ctx context.Context, opts runOptions) error {
 	project.Services = originalServices
 	// start container and attach to container streams
 	runOpts := compose.RunOptions{
-		Service:    opts.Service,
+		Name:       opts.Name,
 		Command:    opts.Command,
 		Detach:     opts.Detach,
 		AutoRemove: opts.Remove,

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -37,9 +37,9 @@ type runOptions struct {
 	composeOptions
 }
 
-func runCommand(composeOpts composeOptions) *cobra.Command {
+func runCommand(composeOpts *composeOptions) *cobra.Command {
 	opts := runOptions{
-		composeOptions: composeOpts,
+		composeOptions: *composeOpts,
 	}
 
 	runCmd := &cobra.Command{

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -47,7 +47,7 @@ func upCommand(contextType string) *cobra.Command {
 			}
 		},
 	}
-	upCmd.Flags().StringVarP(&opts.Name, "project-name", "p", "", "Project name")
+	upCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
 	upCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
 	upCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	upCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -33,29 +33,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func upCommand(contextType string) *cobra.Command {
-	opts := composeOptions{}
+func upCommand(composeOpts composeOptions, contextType string) *cobra.Command {
 	upCmd := &cobra.Command{
 		Use:   "up [SERVICE...]",
 		Short: "Create and start containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
-				return runCreateStart(cmd.Context(), opts, args)
+				return runCreateStart(cmd.Context(), composeOpts, args)
 			default:
-				return runUp(cmd.Context(), opts, args)
+				return runUp(cmd.Context(), composeOpts, args)
 			}
 		},
 	}
-	upCmd.Flags().StringVarP(&opts.ProjectName, "project-name", "p", "", "Project name")
-	upCmd.Flags().StringVar(&opts.WorkingDir, "workdir", "", "Work dir")
-	upCmd.Flags().StringArrayVarP(&opts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
-	upCmd.Flags().StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")
-	upCmd.Flags().BoolVarP(&opts.Detach, "detach", "d", false, "Detached mode: Run containers in the background")
-	upCmd.Flags().BoolVar(&opts.Build, "build", false, "Build images before starting containers.")
+	upCmd.Flags().StringVarP(&composeOpts.ProjectName, "project-name", "p", "", "Project name")
+	upCmd.Flags().StringVar(&composeOpts.WorkingDir, "workdir", "", "Work dir")
+	upCmd.Flags().StringArrayVarP(&composeOpts.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
+	upCmd.Flags().StringArrayVarP(&composeOpts.Environment, "environment", "e", []string{}, "Environment variables")
+	upCmd.Flags().BoolVarP(&composeOpts.Detach, "detach", "d", false, "Detached mode: Run containers in the background")
+	upCmd.Flags().BoolVar(&composeOpts.Build, "build", false, "Build images before starting containers.")
 
 	if contextType == store.AciContextType {
-		upCmd.Flags().StringVar(&opts.DomainName, "domainname", "", "Container NIS domain name")
+		upCmd.Flags().StringVar(&composeOpts.DomainName, "domainname", "", "Container NIS domain name")
 	}
 
 	return upCmd

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -33,16 +33,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func upCommand(composeOpts composeOptions, contextType string) *cobra.Command {
+func upCommand(composeOpts *composeOptions, contextType string) *cobra.Command {
 	upCmd := &cobra.Command{
 		Use:   "up [SERVICE...]",
 		Short: "Create and start containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
-				return runCreateStart(cmd.Context(), composeOpts, args)
+				return runCreateStart(cmd.Context(), *composeOpts, args)
 			default:
-				return runUp(cmd.Context(), composeOpts, args)
+				return runUp(cmd.Context(), *composeOpts, args)
 			}
 		},
 	}

--- a/local/compose/run.go
+++ b/local/compose/run.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 
 	"github.com/compose-spec/compose-go/types"
-	"github.com/docker/compose-cli/api/compose"
 	apitypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose-cli/api/compose"
 
 	moby "github.com/docker/docker/pkg/stringid"
 )
@@ -33,7 +34,7 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 	originalServices := project.Services
 	var requestedService types.ServiceConfig
 	for _, service := range originalServices {
-		if service.Name == opts.Name {
+		if service.Name == opts.Service {
 			requestedService = service
 		}
 	}

--- a/server/proxy/compose.go
+++ b/server/proxy/compose.go
@@ -66,11 +66,11 @@ func (p *proxy) Services(ctx context.Context, request *composev1.ComposeServices
 	/* FIXME need to create `docker service ls` command to re-introduce this feature
 	for _, service := range services {
 		response = append(response, &composev1.Service{
-			Id:       service.ID,
-			Name:     service.Name,
-			Replicas: uint32(service.Replicas),
-			Desired:  uint32(service.Desired),
-			Ports:    service.Ports,
+			Id:              service.ID,
+			ProjectName:     service.ProjectName,
+			Replicas:        uint32(service.Replicas),
+			Desired:         uint32(service.Desired),
+			Ports:           service.Ports,
 		})
 	}*/
 	return &composev1.ComposeServicesResponse{Services: response}, nil


### PR DESCRIPTION
**What I did**

This PR adds global `--file` and `--project-name` to the `compose` command and removes them from all sub-commands. Some command-specific options like `runOptions` have been extended in order to embed global compose options.

I'm available on Slack for discussions around this.

**Related issue**

Fixes #1069.
