### PR TITLE
Add support for .env file when loading compose files

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -65,6 +65,7 @@ func (o *composeOptions) toProjectName() (string, error) {
 func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 	return cli.NewProjectOptions(o.ConfigPaths,
 		cli.WithOsEnv,
+		cli.WithDotEnv,
 		cli.WithEnv(o.Environment),
 		cli.WithWorkingDirectory(o.WorkingDir),
 		cli.WithName(o.Name))


### PR DESCRIPTION
**What I did**
Added support for `.env` files when loading a compose file to align with docker-compose

**Related issue**
https://github.com/docker/compose-cli/issues/635

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/103518051-62c1b680-4e73-11eb-9c10-b765e3fcac69.png)
