### PR TITLE
Add metadata for docs included in docs.docker.com 

### DIFF
--- a/docs/aci-compose-features.md
+++ b/docs/aci-compose-features.md
@@ -1,3 +1,9 @@
+---
+title: ACI integration Compose features
+description: Reference list of compose ACI features
+keywords: Docker, Azure, Integration, ACI, Compose, cli, deploy, cloud
+---
+
 # Compose - Azure Container Instances mapping
 
 This document outlines the conversion of an application defined in a Compose file to ACI objects.

--- a/docs/aci-container-features.md
+++ b/docs/aci-container-features.md
@@ -1,3 +1,8 @@
+---
+title: ACI integration container features
+description: Reference list of container ACI features
+keywords: Docker, Azure, Integration, ACI, container, cli, deploy, cloud
+---
 # Azure Container Instances: running single containerrs
 
 Single containers can be executed on ACI with the `docker run` command.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,9 @@
+---
+title: Compose cli architecture
+description: General Compose cli architecture
+keywords: Docker, Amazon, Azure, Integration, ECS, ACI, Compose, architecture, mapping
+---
+
 # Architecture
 
 This CLI has the following high level design goals:

--- a/docs/ecs-architecture.md
+++ b/docs/ecs-architecture.md
@@ -1,3 +1,8 @@
+---
+title: ECS integration architecture
+description: Mapping of Docker compose entities to Amazon constructs
+keywords: Docker, Amazon, Integration, ECS, Compose, architecture, mapping
+---
 # Architecture
 
 ECS integration relies on CloudFormation to manage AWS resrouces as an atomic operation.
@@ -12,13 +17,13 @@ This diagram shows compose model and on same line AWS components that get create
 | Project  |  . . . . . . . . . . . . . .   | Cluster     |    . . . . . . .             | LoadBalancer      |
 +-+--------+                                +-------------+                              +-------------------+
   |
-  |    +----------+                         +-------------++-------------------+         +-------------------+  
-  +----+ Service  |   . . . . . . . . . .   | Service     || TaskDefinition    |         | TargetGroup       |  
-  |    +--+-------+                         +-------------++-------------------+-+       +-------------------+  
-  |       |                                                  | TaskRole          |                          
-  |       |                                                  +-------------------+-+                         
-  |       |  x-aws-role, x-aws-policies     . . . . . . . .    | TaskExecutionRole |                        
-  |       |                                                    +-------------------+                        
+  |    +----------+                         +-------------++-------------------+         +-------------------+
+  +----+ Service  |   . . . . . . . . . .   | Service     || TaskDefinition    |         | TargetGroup       |
+  |    +--+-------+                         +-------------++-------------------+-+       +-------------------+
+  |       |                                                  | TaskRole          |
+  |       |                                                  +-------------------+-+
+  |       |  x-aws-role, x-aws-policies     . . . . . . . .    | TaskExecutionRole |
+  |       |                                                    +-------------------+
   |       |  +---------+
   |       +--+ Deploy  |
   |       |  +---------+                    +-------------------+
@@ -54,11 +59,11 @@ This diagram shows compose model and on same line AWS components that get create
       +------------+                        +---------------+
 ```
 
-Each compose application service is mapped to an ECS `Service`. A `TaksDefinition` is created according to compose definition. 
+Each compose application service is mapped to an ECS `Service`. A `TaksDefinition` is created according to compose definition.
 Actual mapping is constrained by both Cloud platform and Fargate limitations. Such a `TaskDefinition` is set with a single container,
 according to the compose model which doesn't offer a syntax to support sidecar containers.
 
-An IAM Role is created and configured as `TaskRole` to grant service access to additional AWS resources when required. For this 
+An IAM Role is created and configured as `TaskRole` to grant service access to additional AWS resources when required. For this
 purpose, user can set `x-aws-policies` or define a fine grained `x-aws-role` IAM role document.
 
 Service's ports get mapped into security group's `IngressRule`s and load balancer `Listener`s.
@@ -75,5 +80,3 @@ Services using a GPU (`DeviceRequest`) get the `Cluster` extended with an EC2 `C
 EC2 resources allocation based on a `LaunchConfiguration`. The latter uses ECS recommended AMI and machine type for GPU.
 
 Service to declare `deploy.x-aws-autoscaling` get a `ScalingPolicy` created targeting specified the configured CPU usage metric
-
-

--- a/docs/ecs-compose-examples.md
+++ b/docs/ecs-compose-examples.md
@@ -1,8 +1,13 @@
+---
+title: ECS integration composefile examples
+description: Examples of ECS compose files
+keywords: Docker, Amazon, Integration, ECS, Compose, cli, deploy, cloud, sample
+---
 # Compose file samples - ECS specific
 
 
 
-## Service 
+## Service
 
 A service mapping may define a Docker image and runtime constraints and container requirements.
 
@@ -206,7 +211,7 @@ services:
   test:
     image: nginx
 volumes:
-  db-data: 
+  db-data:
     driver_opts:
         backup_policy: ENABLED
         lifecycle_policy: AFTER_30_DAYS
@@ -248,7 +253,7 @@ services:
       - mysecret
 
 secrets:
-  mysecret: 
+  mysecret:
     file: ./secrets/mysecret.txt
 ```
 
@@ -294,6 +299,3 @@ services:
     ports:
       - 80:80
 ```
-
-
-

--- a/docs/ecs-compose-features.md
+++ b/docs/ecs-compose-features.md
@@ -1,3 +1,8 @@
+---
+title: ECS integration Compose features
+description: Reference list of compose ECS features
+keywords: Docker, Amazon, Integration, ECS, Compose, cli, deploy, cloud
+---
 # Compose - Amazon ECS mapping
 
 This document outlines the conversion of an application defined in a Compose file to AWS resources.
@@ -18,10 +23,10 @@ __Legend:__
 | __Service__                    | ✓ |
 | service.service.build          | x |  Ignored. No image build support on AWS.
 | service.cap_add, cap_drop      | ✓ |  Supported with [Fargate limitations](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_KernelCapabilities.html)
-| service.command                | ✓ |  
+| service.command                | ✓ |
 | service.configs                | x |
 | service.cgroup_parent          | x |
-| service.container_name         | x |  
+| service.container_name         | x |
 | service.credential_spec        | x |
 | service.deploy                 | ✓ |
 | service.deploy.endpoint_mode   | x |
@@ -30,15 +35,15 @@ __Legend:__
 | service.deploy.placement       | ✓ |  Used with EC2 support to select a machine type and AMI
 | service.deploy.update_config   | ✓ |
 | service.deploy.resources       | ✓ |  Fargate resource is selected with the lowest instance type for configured memory and cpu
-| service.deploy.restart_policy  | ✓ |  
-| service.deploy.labels          | ✓ |  
+| service.deploy.restart_policy  | ✓ |
+| service.deploy.labels          | ✓ |
 | service.devices                | x |
 | service.depends_on             | ✓ |  Implemented using CloudFormation Depends_on
 | service.dns                    | x |
 | service.dns_search             | x |
-| service.domainname             | x |  
+| service.domainname             | x |
 | service.tmpfs                  | x |  Not supported on Fargate, see https://github.com/docker/compose-cli/issues/839
-| service.entrypoint             | ✓ | 
+| service.entrypoint             | ✓ |
 | service.env_file               | ✓ |
 | service.environment            | ✓ |
 | service.expose                 | x |
@@ -50,7 +55,7 @@ __Legend:__
 | service.hostname               | x |
 | service.image                  | ✓ |  Private images will be accessible by passing x-aws-pull_policy with ARN of a username+password secret
 | service.isolation              | x |
-| service.labels                 | x |  
+| service.labels                 | x |
 | service.links                  | x |
 | service.logging                | ✓ |  Can be used to customize CloudWatch Logs configuration
 | service.network_mode           | x |
@@ -101,7 +106,7 @@ by passing configuration attributes prefixed with `awslogs-`.
 When one or more services expose ports, a Load Balancer is created for the application.
 As all services are expose through the same Load Balancer, only one service can expose a given port number.
 The source and target ports defined in the Compose file MUST be the same, as service-to-service communication don't go trought the Load Balancer and could not
-benefit from Listeners abstraction to assign a distinct published port. 
+benefit from Listeners abstraction to assign a distinct published port.
 
 If services in the Compose file only expose ports 80 or 443, an Application Load Balancer is created, otherwise ECS integration will provision a Network Load Balancer.
 HTTP services using distinct ports can force use of an ALB by claiming the http protocol with `x-aws-protocol` custom extension within the port declaration:
@@ -134,7 +139,7 @@ services:
 volumes:
   mydata:
     driver_opts:
-      performance-mode: maxIO 
+      performance-mode: maxIO
       throughput-mode: bursting
       uid: 0
       gid: 0
@@ -173,4 +178,4 @@ services:
             limits:
               cpu: 0.5
               memory: 2Gb
-```          
+```


### PR DESCRIPTION
Metadata required to include these docs in docs.docker.com

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

**Related issue**
https://github.com/docker/docker.github.io/pull/11865

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
