### PR TITLE
ignore services without image attribute

### DIFF
--- a/local/compose/pull.go
+++ b/local/compose/pull.go
@@ -55,6 +55,14 @@ func (s *composeService) Pull(ctx context.Context, project *types.Project) error
 
 	for _, srv := range project.Services {
 		service := srv
+		if service.Image == "" {
+			w.Event(progress.Event{
+				ID:     service.Name,
+				Status: progress.Done,
+				Text:   "Skipped",
+			})
+			continue
+		}
 		eg.Go(func() error {
 			w.Event(progress.Event{
 				ID:     service.Name,


### PR DESCRIPTION
**What I did**
ignore service which have no `image` attribute on push/pull
to align with docker-compose:
https://github.com/docker/compose/blob/2e273c50293726a7f8cc5751e90e788613052594/compose/service.py#L1249
https://github.com/docker/compose/blob/2e273c50293726a7f8cc5751e90e788613052594/compose/service.py#L1272

report to user as "skipped"

**Related issue**
close https://github.com/docker/compose-cli/issues/1040

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/103549322-72f38900-4ea7-11eb-8eb5-1e774a645761.png)

