### PR TITLE
Remove unnecessary retry in ECS secrets test

### DIFF
--- a/tests/ecs-e2e/e2e-ecs_test.go
+++ b/tests/ecs-e2e/e2e-ecs_test.go
@@ -62,10 +62,6 @@ func TestSecrets(t *testing.T) {
 
 	t.Run("list secrets", func(t *testing.T) {
 		res := cmd.RunDockerCmd("secret", "list")
-		if !strings.Contains(res.Stdout(), secretName) { // test sometimes fail, it seems things might need a bit of time on the AWS side, trying once morez
-			time.Sleep(1 * time.Second)
-			res = cmd.RunDockerCmd("secret", "list")
-		}
 		assert.Check(t, strings.Contains(res.Stdout(), secretName), res.Stdout())
 	})
 
@@ -91,7 +87,6 @@ func TestCompose(t *testing.T) {
 	var webURL, wordsURL, secretsURL string
 	t.Run("compose ps", func(t *testing.T) {
 		res := c.RunDockerCmd("compose", "ps", "--project-name", stack)
-		fmt.Println(strings.TrimSpace(res.Stdout()))
 		lines := strings.Split(strings.TrimSpace(res.Stdout()), "\n")
 
 		assert.Equal(t, 5, len(lines))


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* secrets E2E test failure was not due to race condition after creating secrets, but AWS secrets needed some cleanup
see https://github.com/docker/compose-cli/runs/1651760200#step:7:32
* removed newly added retry, only confusing

**Related issue**
https://github.com/docker/compose-cli/runs/1651760200#step:7:32
This reproduced for every build in the CI, I manually removed these `Mysecret1Secret-xxxx` secrets, and the issue went away. 
Not sure what is the underlying reason in ECS, do we need to manage pagination when listing ECS secrets ?

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
