### PR TITLE
ECS: Parse DeviceRequest struct for GPU access setup

### DIFF
--- a/docs/ecs-compose-examples.md
+++ b/docs/ecs-compose-examples.md
@@ -108,9 +108,9 @@ services:
           memory: 32Gb
           cpus: "32"
           generic_resources:
-          - discrete_resource_spec:
-            kind: gpus
-            value: 2
+            - discrete_resource_spec:
+                kind: gpus
+                value: 2
 ```
 
 

--- a/ecs/compatibility.go
+++ b/ecs/compatibility.go
@@ -66,7 +66,9 @@ var compatibleComposeAttributes = []string{
 	"services.deploy.resources.reservations.cpus",
 	"services.deploy.resources.reservations.memory",
 	"services.deploy.resources.reservations.devices",
+	"services.deploy.resources.reservations.devices.capabilities",
 	"services.deploy.resources.reservations.devices.count",
+	"services.deploy.resources.reservations.devices.driver",
 	"services.deploy.resources.reservations.generic_resources",
 	"services.deploy.resources.reservations.generic_resources.discrete_resource_spec",
 	"services.deploy.update_config",
@@ -165,5 +167,11 @@ func (c *fargateCompatibilityChecker) CheckDeployResourcesDevicesCapabilities(s 
 		if cap != "gpu" {
 			c.Unsupported("services.deploy.resources.%s.devices.capabilities = %s", s, cap)
 		}
+	}
+}
+
+func (c *fargateCompatibilityChecker) CheckDeployResourcesDevicesDriver(s string, r types.DeviceRequest) {
+	if r.Driver != "" && r.Driver != "nvidia" {
+		c.Unsupported("services.deploy.resources.%s.devices.driver = %s", s, r.Driver)
 	}
 }

--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -181,6 +181,25 @@ func toTaskResourceRequirements(reservations *types.Resource) []ecs.TaskDefiniti
 			})
 		}
 	}
+	for _, r := range reservations.Devices {
+		hasGpuCap := false
+		for _, c := range r.Capabilities {
+			if c == "gpu" {
+				hasGpuCap = true
+				break
+			}
+		}
+		if hasGpuCap {
+			count := r.Count
+			if count <= 0 {
+				count = 1
+			}
+			requirements = append(requirements, ecs.TaskDefinition_ResourceRequirement{
+				Type:  ecsapi.ResourceTypeGpu,
+				Value: fmt.Sprint(count),
+			})
+		}
+	}
 	return requirements
 }
 


### PR DESCRIPTION
Fixes https://github.com/docker/dev-tooling-team/issues/262

```yaml
...
reservations:
  memory: 16Gb
  cpus: "8"
  generic_resources:
    - discrete_resource_spec:
        kind: gpus
        value: 4
```
must be equivalent to 
```yaml
...
reservations:
  memory: 16Gb
  cpus: "8"
  devices:
    - driver: nvidia
      count: 4
      capabilities: [gpu]
```


/test-ecs