### PR TITLE
When running compose down, remove containers with Force=true 

### DIFF
--- a/local/compose/down.go
+++ b/local/compose/down.go
@@ -101,7 +101,7 @@ func (s *composeService) removeContainers(ctx context.Context, w progress.Writer
 				return err
 			}
 			w.Event(progress.RemovingEvent(eventName))
-			err = s.apiClient.ContainerRemove(ctx, toDelete.ID, moby.ContainerRemoveOptions{})
+			err = s.apiClient.ContainerRemove(ctx, toDelete.ID, moby.ContainerRemoveOptions{Force: true})
 			if err != nil {
 				w.Event(progress.ErrorMessageEvent(eventName, "Error while Removing"))
 				return err


### PR DESCRIPTION
in case some container is still up for any reason (happened in some E2E test once)

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* set remove (Force = true)

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1097

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
