### PR TITLE
Improving ACI E2E tests with platform flakyness

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ or Microsoft Azure Container Instances
 using the Docker commands you already know.
 
 To get started, all you need is:
+
 * An [AWS](https://aws.amazon.com) or [Azure](https://azure.microsoft.com)
   account
 * Windows: The Stable or Edge release of

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -478,6 +478,11 @@ func TestContainerRunAttached(t *testing.T) {
 
 	t.Run("restart container", func(t *testing.T) {
 		res := c.RunDockerCmd("start", container)
+		//Flaky errors on restart : Code="ContainerGroupTransitioning" Message="The container group 'test-container' is still transitioning, please retry later."
+		if res.ExitCode != 0 && strings.Contains(res.Stderr(), `Code="ContainerGroupTransitioning"`) {
+			time.Sleep(3 * time.Second)
+			res = c.RunDockerCmd("start", container)
+		}
 		res.Assert(t, icmd.Expected{Out: container})
 		waitForStatus(t, c, container, convert.StatusRunning)
 	})

--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -504,9 +504,12 @@ func TestContainerRunAttached(t *testing.T) {
 		if strings.Contains(res.Stderr(), "unsupported protocol scheme") { //Flaky strange error on azure SDK call happening only during prune --force
 			time.Sleep(1 * time.Second)
 			res = c.RunDockerCmd("prune", "--force")
+			// After the retry, it seems prune has sometimes actually been executed, and we get zero thigs to delete again...
+			assert.Assert(t, res.Stdout() == "Deleted resources:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n" ||
+				res.Stdout() == "Deleted resources:\nTotal CPUs reclaimed: 0.00, total memory reclaimed: 0.00 GB\n", res.Stdout())
+		} else {
+			assert.Equal(t, "Deleted resources:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n", res.Stdout())
 		}
-
-		assert.Equal(t, "Deleted resources:\n"+container+"\nTotal CPUs reclaimed: 0.10, total memory reclaimed: 0.10 GB\n", res.Stdout())
 
 		res = c.RunDockerCmd("ps", "--all")
 		l = Lines(res.Stdout())


### PR DESCRIPTION
**What I did**
* Fix assertion when retrying docker prune after flaky error
* Try to fix "ContainerGroupTransitioning" flaky error on container restart, with a retry

**Related issue**
https://github.com/docker/compose-cli/runs/1655479475#step:6:227

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
