### PR TITLE
Implement secrets via bind-mounts for local compose

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -310,6 +310,16 @@ func buildContainerMountOptions(p types.Project, s types.ServiceConfig, inherit 
 		if definedSecret.External.External {
 			return nil, fmt.Errorf("unsupported external secret %s", definedSecret.Name)
 		}
+
+		if contains(inherited, target) {
+			// remove inherited mount
+			pos := indexOf(inherited, target)
+			if pos >= 0 {
+				mounts = append(mounts[:pos], mounts[pos+1])
+				inherited = append(inherited[:pos], inherited[pos+1])
+			}
+		}
+
 		mount, err := buildMount(p, types.ServiceVolumeConfig{
 			Type:   types.VolumeTypeBind,
 			Source: definedSecret.File,

--- a/local/compose/util.go
+++ b/local/compose/util.go
@@ -38,3 +38,12 @@ func contains(slice []string, item string) bool {
 	}
 	return false
 }
+
+func indexOf(slice []string, item string) int {
+	for i, v := range slice {
+		if v == item {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Implement compose secrets via bind mounts. 
 
```yaml
services:
  test:
    image: nginx
    secrets:
      - my_secret
secrets:
  my_secret:
    file: ./my_secret.txt
```
```shell
$ cat my_secret.txt 
blabla bbla ba
```
```
docker compose up -d
The new 'docker compose' command is currently experimental. To provide feedback or request new features please open issues at https://github.com/docker/compose-cli
[+] Running 2/1
 ⠿ Network "test_default"  Created                                                               0.5s
 ⠿ test_test_1             Created                                                               0.0s

```
```
$ docker exec -it test_test_1 cat /run/secrets/my_secret
blabla bbla ba

```



Closes https://github.com/docker/compose-cli/issues/934