### PR TITLE
Do not send metrics if executed as CLI backend

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"os"
 	"strings"
 
 	"github.com/docker/compose-cli/utils"
@@ -24,6 +25,9 @@ import (
 
 // Track sends the tracking analytics to Docker Desktop
 func Track(context string, args []string, status string) {
+	if isInvokedAsCliBackend() {
+		return
+	}
 	command := GetCommand(args)
 	if command != "" {
 		c := NewClient()
@@ -34,6 +38,11 @@ func Track(context string, args []string, status string) {
 			Status:  status,
 		})
 	}
+}
+
+func isInvokedAsCliBackend() bool {
+	executable := os.Args[0]
+	return strings.HasSuffix(executable, "-backend")
 }
 
 func isCommand(word string) bool {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* stop sending metrics when compose-cli is executed as a CLI backend, as Docker CLI will handle metrics in this case

manually tested with local build of CLI including backend capabilities and metrics.
This is zero impact on the behavior of the compose cli if not used as a CLI backend

**Related issue**
https://github.com/docker/dev-tooling-team/issues/248

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
