### PR TITLE
Do not fil on first error on ACI restart, allow trying a second time

### DIFF
--- a/tests/aci-e2e/e2e-aci_test.go
+++ b/tests/aci-e2e/e2e-aci_test.go
@@ -477,7 +477,7 @@ func TestContainerRunAttached(t *testing.T) {
 	})
 
 	t.Run("restart container", func(t *testing.T) {
-		res := c.RunDockerCmd("start", container)
+		res := c.RunDockerOrExitError("start", container)
 		//Flaky errors on restart : Code="ContainerGroupTransitioning" Message="The container group 'test-container' is still transitioning, please retry later."
 		if res.ExitCode != 0 && strings.Contains(res.Stderr(), `Code="ContainerGroupTransitioning"`) {
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Change call to restart ACI container to allow checking error and restarting if the first invocation fails

**Related issue**
https://github.com/docker/compose-cli/runs/1670059596#step:9:227

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
