### PR TITLE
Support container_name in ACI and add network alias in dns sidecar.

### DIFF
--- a/tests/compose-e2e/fixtures/volume-test/docker-compose.yml
+++ b/tests/compose-e2e/fixtures/volume-test/docker-compose.yml
@@ -16,3 +16,4 @@ services:
 
 volumes:
   staticVol:
+    name: myVolume

--- a/tests/composefiles/demo_multi_port.yaml
+++ b/tests/composefiles/demo_multi_port.yaml
@@ -3,7 +3,8 @@ services:
     build: aci-demo/db
     image: gtardif/sentences-db
 
-  words:
+  service1:
+    container_name: words
     build: aci-demo/words
     image: gtardif/sentences-api
     ports:


### PR DESCRIPTION
Not supporting container name also has the side effect of network names not being resolved.
(Note container_name is used in several MSFT examples, this is likely to be used just because of examples and documentation)

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Set ACI container name to `container_name` if specified in compose file
* Add network alias `container_name` (if specified) in addition to service name, same behaviour as docker-compose

**Related issue**
Quite possibly the reason for https://github.com/docker/compose-cli/issues/986

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://images-na.ssl-images-amazon.com/images/I/61OwHwnhr-L._AC_SL1200_.jpg)