### PR TITLE
Move check that container exited after inspecting container

### DIFF
--- a/tests/compose-e2e/compose_test.go
+++ b/tests/compose-e2e/compose_test.go
@@ -126,7 +126,6 @@ func TestLocalComposeRun(t *testing.T) {
 				assert.Assert(t, strings.HasPrefix(containerID, "run-test_back_run_"), containerID)
 				truncatedSlug = strings.Replace(containerID, "run-test_back_run_", "", 1)
 				runContainerID = containerID
-				assert.Assert(t, strings.Contains(line, "Exited"), line)
 			}
 			if strings.HasPrefix(containerID, "run-test_db_1") {
 				assert.Assert(t, strings.Contains(line, "Up"), line)
@@ -134,6 +133,7 @@ func TestLocalComposeRun(t *testing.T) {
 		}
 		assert.Assert(t, runContainerID != "")
 		res = c.RunDockerCmd("inspect", runContainerID)
+		res.Assert(t, icmd.Expected{Out: ` "Status": "exited"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.container-number": "1"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "run-test"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.oneoff": "True",`})


### PR DESCRIPTION
Hopefully this will fix flakyness ont his test

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1121

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
