### PR TITLE
We actually support volume labels and driver_opts

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -512,7 +512,6 @@ func (s *composeService) ensureVolume(ctx context.Context, volume types.VolumeCo
 		eventName := fmt.Sprintf("Volume %q", volume.Name)
 		w := progress.ContextWriter(ctx)
 		w.Event(progress.CreatingEvent(eventName))
-		// TODO we miss support for driver_opts and labels
 		_, err := s.apiClient.VolumeCreate(ctx, volume_api.VolumeCreateBody{
 			Labels:     volume.Labels,
 			Name:       volume.Name,


### PR DESCRIPTION
**What I did**
removed TODO
feature was actually introduced by https://github.com/docker/compose-cli/commit/f65a0d372024426896a4034eb741508e7722de8c

**Related issue**
Close https://github.com/docker/compose-cli/issues/932

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
