### PR TITLE
Local: Volumes implementation - align with docker-compose

### DIFF
--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -93,7 +93,6 @@ func (s *composeService) ensureService(ctx context.Context, observedState Contai
 	}
 
 	for _, container := range actual {
-		container := container
 		name := getCanonicalContainerName(container)
 
 		diverged := container.Labels[configHashLabel] != expected

--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -251,7 +251,7 @@ func (s *composeService) restartContainer(ctx context.Context, container moby.Co
 }
 
 func (s *composeService) createMobyContainer(ctx context.Context, project *types.Project, service types.ServiceConfig, name string, number int, container *moby.Container, autoRemove bool) error {
-	containerConfig, hostConfig, networkingConfig, err := getCreateOptions(project, service, number, container, autoRemove)
+	containerConfig, hostConfig, networkingConfig, err := s.getCreateOptions(ctx, project, service, number, container, autoRemove)
 	if err != nil {
 		return err
 	}

--- a/local/compose/util.go
+++ b/local/compose/util.go
@@ -38,12 +38,3 @@ func contains(slice []string, item string) bool {
 	}
 	return false
 }
-
-func indexOf(slice []string, item string) int {
-	for i, v := range slice {
-		if v == item {
-			return i
-		}
-	}
-	return -1
-}

--- a/tests/compose-e2e/compose_test.go
+++ b/tests/compose-e2e/compose_test.go
@@ -261,9 +261,18 @@ func TestLocalComposeVolume(t *testing.T) {
 	})
 
 	t.Run("check container volume specs", func(t *testing.T) {
-		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx2_1", "--format", "{{ json .HostConfig.Mounts }}")
+		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx2_1", "--format", "{{ json .Mounts }}")
+		output := res.Stdout()
 		//nolint
-		res.Assert(t, icmd.Expected{Out: `[{"Type":"volume","Source":"compose-e2e-volume_staticVol","Target":"/usr/share/nginx/html","ReadOnly":true},{"Type":"volume","Target":"/usr/src/app/node_modules"},{"Type":"volume","Source":"myVolume","Target":"/usr/share/nginx/test"}]`})
+		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"","RW":true,"Propagation":""`))
+	})
+
+	t.Run("check container bind-mounts specs", func(t *testing.T) {
+		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx_1", "--format", "{{ json .HostConfig.Mounts }}")
+		output := res.Stdout()
+		//nolint
+		assert.Assert(t, strings.Contains(output, `"Type":"bind"`))
+		assert.Assert(t, strings.Contains(output, `"Target":"/usr/share/nginx/html"`))
 	})
 
 	t.Run("cleanup volume project", func(t *testing.T) {


### PR DESCRIPTION
Align with docker-compose volume setup.

Fixes https://github.com/docker/compose-cli/issues/1117

_docker-compose.yml_
```
version: "3.8"
services:
  test:
    image: test/hello
    build: ./backend
    ports:
      - 80:8080
    secrets:
      - my_secret                        # bind-mount
    volumes:
      - testvolume:/vol                  # named volume
      - type: bind                       # bind-mount
        source: ../nginx
        target: /compose
      - ./backend/creds:/src/creds.txt   # bind-mount
      - /anonymous                       # anonymous volume
      - externalvolume:/external         # external volume
      - type: tmpfs                      # tmpfs mount
        target: /temp
      

volumes:
  testvolume:
  externalvolume:
    external: True
    name: myvol
secrets:
  my_secret:
    file: ./secrets/mysecret.txt

```

```
$ docker-compose up -d

$ docker inspect hello_test_1 | jq '.[0].Config.Volumes, .[0].Mounts, .[0].HostConfig.Binds, .[0].HostConfig.Mounts'
{
  "/anonymous": {},
  "/data": {},
  "/external": {},
  "/src/creds.txt": {},
  "/vol": {}
}
[
  {
    "Type": "volume",
    "Name": "0cff20f55042c559881196a517f43596a4a990115fb093f0a43718300c019781",
    "Source": "/docker/volumes/0cff20f55042c559881196a517f43596a4a990115fb093f0a43718300c019781/_data",
    "Destination": "/anonymous",
    "Driver": "local",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "volume",
    "Name": "4168b061865866ca9900ad15c0f3b70785187c109e5eaa6346be69845656bc17",
    "Source": "/docker/volumes/4168b061865866ca9900ad15c0f3b70785187c109e5eaa6346be69845656bc17/_data",
    "Destination": "/data",
    "Driver": "local",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "volume",
    "Name": "myvol",
    "Source": "/docker/volumes/myvol/_data",
    "Destination": "/external",
    "Driver": "local",
    "Mode": "rw",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "bind",
    "Source": "/test/hello/backend/creds",
    "Destination": "/src/creds.txt",
    "Mode": "rw",
    "RW": true,
    "Propagation": "rprivate"
  },
  {
    "Type": "volume",
    "Name": "hello_testvolume",
    "Source": "/docker/volumes/hello_testvolume/_data",
    "Destination": "/vol",
    "Driver": "local",
    "Mode": "rw",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "tmpfs",
    "Source": "",
    "Destination": "/temp",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "bind",
    "Source": "/test/nginx",
    "Destination": "/compose",
    "Mode": "",
    "RW": true,
    "Propagation": "rprivate"
  },
  {
    "Type": "bind",
    "Source": "/test/hello/secrets/mysecret.txt",
    "Destination": "/run/secrets/my_secret",
    "Mode": "",
    "RW": false,
    "Propagation": "rprivate"
  }
]
[
  "myvol:/external:rw",
  /test/hello/backend/creds:/src/creds.txt:rw",
  "hello_testvolume:/vol:rw"
]
[
  {
    "Type": "tmpfs",
    "Target": "/temp"
  },
  {
    "Type": "bind",
    "Source": "/test/nginx",
    "Target": "/compose"
  },
  {
    "Type": "bind",
    "Source": "/test/hello/secrets/mysecret.txt",
    "Target": "/run/secrets/my_secret",
    "ReadOnly": true
  }
]

```



```
$ docker compose up -d

$ docker inspect hello_test_1 | jq '.[0].Config.Volumes, .[0].Mounts, .[0].HostConfig.Binds, .[0].HostConfig.Mounts'
{
  "/anonymous": {},
  "/data": {},
  "/external": {},
  "/vol": {}
}
[
  {
    "Type": "bind",
    "Source": "/test/nginx",
    "Destination": "/compose",
    "Mode": "",
    "RW": true,
    "Propagation": "rprivate"
  },
  {
    "Type": "volume",
    "Name": "f06a5c997f924bf7a8ef900bff4209239330c60c411468f16cd7e95484581090",
    "Source": "/docker/volumes/f06a5c997f924bf7a8ef900bff4209239330c60c411468f16cd7e95484581090/_data",
    "Destination": "/anonymous",
    "Driver": "local",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "volume",
    "Name": "11c2f88dcff366572e223412694ed5099e4a82f861494c6a4d245d575426383b",
    "Source": "/docker/volumes/11c2f88dcff366572e223412694ed5099e4a82f861494c6a4d245d575426383b/_data",
    "Destination": "/data",
    "Driver": "local",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "volume",
    "Name": "myvol",
    "Source": "/docker/volumes/myvol/_data",
    "Destination": "/external",
    "Driver": "local",
    "Mode": "rw",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "volume",
    "Name": "hello_testvolume",
    "Source": "/docker/volumes/hello_testvolume/_data",
    "Destination": "/vol",
    "Driver": "local",
    "Mode": "rw",
    "RW": true,
    "Propagation": ""
  },
  {
    "Type": "bind",
    "Source": "/test/hello/secrets/mysecret.txt",
    "Destination": "/run/secrets/my_secret",
    "Mode": "",
    "RW": true,
    "Propagation": "rprivate"
  },
  {
    "Type": "bind",
    "Source": "/test/hello/backend/creds",
    "Destination": "/src/creds.txt",
    "Mode": "",
    "RW": true,
    "Propagation": "rprivate"
  },
  {
    "Type": "tmpfs",
    "Source": "",
    "Destination": "/temp",
    "Mode": "",
    "RW": true,
    "Propagation": ""
  }
]
[
  "myvol:/external:rw",
  "hello_testvolume:/vol:rw"
]
[
  {
    "Type": "bind",
    "Source": "/test/hello/secrets/mysecret.txt",
    "Target": "/run/secrets/my_secret"
  },
  {
    "Type": "bind",
    "Source": "/test/hello/backend/creds",
    "Target": "/src/creds.txt"
  },
  {
    "Type": "tmpfs",
    "Target": "/temp"
  },
  {
    "Type": "bind",
    "Source": "/test/nginx",
    "Target": "/compose"
  }
]



```






