### PR TITLE
run "down" using project if it was set for command

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -67,6 +67,8 @@ type UpOptions struct {
 type DownOptions struct {
 	// RemoveOrphans will cleanup containers that are not declared on the compose model but own the same labels
 	RemoveOrphans bool
+	// Project is the compose project used to define this app. Might be nil if user ran `down` just with project name
+	Project *types.Project
 }
 
 // ConvertOptions group options of the Convert API

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -19,7 +19,6 @@ package compose
 import (
 	"context"
 
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
@@ -52,11 +51,7 @@ func runBuild(ctx context.Context, opts buildOptions, services []string) error {
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		options, err := opts.toProjectOptions()
-		if err != nil {
-			return "", err
-		}
-		project, err := cli.ProjectFromOptions(options)
+		project, err := opts.toProject()
 		if err != nil {
 			return "", err
 		}

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -50,16 +50,24 @@ func (o *composeOptions) toProjectName() (string, error) {
 		return o.ProjectName, nil
 	}
 
-	options, err := o.toProjectOptions()
-	if err != nil {
-		return "", err
-	}
-
-	project, err := cli.ProjectFromOptions(options)
+	project, err := o.toProject()
 	if err != nil {
 		return "", err
 	}
 	return project.Name, nil
+}
+
+func (o *composeOptions) toProject() (*types.Project, error) {
+	options, err := o.toProjectOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := cli.ProjectFromOptions(options)
+	if err != nil {
+		return nil, err
+	}
+	return project, nil
 }
 
 func (o *composeOptions) toProjectOptions() (*cli.ProjectOptions, error) {

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
@@ -53,12 +52,7 @@ func runConvert(ctx context.Context, opts composeOptions) error {
 		return err
 	}
 
-	options, err := opts.toProjectOptions()
-	if err != nil {
-		return err
-	}
-
-	project, err := cli.ProjectFromOptions(options)
+	project, err := opts.toProject()
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -19,6 +19,8 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/types"
+
 	"github.com/docker/compose-cli/api/compose"
 
 	"github.com/spf13/cobra"
@@ -50,12 +52,20 @@ func runDown(ctx context.Context, opts composeOptions) error {
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		projectName, err := opts.toProjectName()
-		if err != nil {
-			return "", err
+		name := opts.ProjectName
+		var project *types.Project
+		if opts.ProjectName == "" {
+			p, err := opts.toProject()
+			if err != nil {
+				return "", err
+			}
+			project = p
+			name = p.Name
 		}
-		return projectName, c.ComposeService().Down(ctx, projectName, compose.DownOptions{
+
+		return name, c.ComposeService().Down(ctx, name, compose.DownOptions{
 			RemoveOrphans: false,
+			Project:       project,
 		})
 	})
 	return err

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -19,7 +19,6 @@ package compose
 import (
 	"context"
 
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
@@ -53,11 +52,7 @@ func runPull(ctx context.Context, opts pullOptions, services []string) error {
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		options, err := opts.toProjectOptions()
-		if err != nil {
-			return "", err
-		}
-		project, err := cli.ProjectFromOptions(options)
+		project, err := opts.toProject()
 		if err != nil {
 			return "", err
 		}

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -19,7 +19,6 @@ package compose
 import (
 	"context"
 
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
@@ -53,11 +52,7 @@ func runPush(ctx context.Context, opts pushOptions, services []string) error {
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		options, err := opts.toProjectOptions()
-		if err != nil {
-			return "", err
-		}
-		project, err := cli.ProjectFromOptions(options)
+		project, err := opts.toProject()
 		if err != nil {
 			return "", err
 		}

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -28,7 +28,6 @@ import (
 	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/formatter"
 
-	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
 )
@@ -118,11 +117,7 @@ func setup(ctx context.Context, opts composeOptions, services []string) (*client
 		return nil, nil, err
 	}
 
-	options, err := opts.toProjectOptions()
-	if err != nil {
-		return nil, nil, err
-	}
-	project, err := cli.ProjectFromOptions(options)
+	project, err := opts.toProject()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**What I did**

Pass `Project` to Down if it was set on command line, so we ddon't need to search for compose files

**Related issue**
https://github.com/docker/compose-cli/issues/1141

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
