### PR TITLE
introduce event queue concept as `x-queues`

### DIFF
--- a/api/lambdas/queues.go
+++ b/api/lambdas/queues.go
@@ -1,0 +1,61 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lambdas
+
+import (
+	"github.com/compose-spec/compose-go/types"
+	"github.com/mitchellh/mapstructure"
+)
+
+type Queue struct {
+	External bool   `yaml:",omitempty" json:"external,omitempty"`
+	Name     string `yaml:",omitempty" json:"name,omitempty"`
+}
+
+type Queues map[string]Queue
+
+// TODO to be moved to compose-go loader.Load once compose-spec has approved `queues` design
+func LoadQueues(project *types.Project) error {
+	x, ok := project.Extensions["x-queues"]
+	if !ok {
+		return nil
+	}
+
+	queues := Queues{}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: &queues,
+	})
+	if err != nil {
+		return err
+	}
+	err = decoder.Decode(x)
+	if err != nil {
+		return err
+	}
+	project.Extensions["x-queues"] = queues
+	return nil
+}
+
+// GetQueues returns project's queues.
+// TODO replace use of this with direct access `project.Queues` once compose-spec approvec `queues` concept
+func GetQueues(project *types.Project) Queues {
+	x, ok := project.Extensions["x-queues"]
+	if !ok {
+		return nil
+	}
+	return x.(Queues)
+}

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -19,6 +19,8 @@ package compose
 import (
 	"fmt"
 
+	"github.com/docker/compose-cli/api/lambdas"
+
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
@@ -67,6 +69,12 @@ func (o *composeOptions) toProject() (*types.Project, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = lambdas.LoadQueues(project)
+	if err != nil {
+		return nil, err
+	}
+
 	return project, nil
 }
 

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -135,5 +135,6 @@ func setup(ctx context.Context, opts composeOptions, services []string) (*client
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return c, project, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/mapstructure v1.4.0
 	github.com/moby/buildkit v0.8.1-0.20201205083753-0af7b1b9c693
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf
 	github.com/morikuni/aec v1.0.0

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/compose-cli/local/lambdas"
+
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -43,6 +45,8 @@ import (
 )
 
 func (s *composeService) Create(ctx context.Context, project *types.Project, opts compose.CreateOptions) error {
+	lambdas.TransformForLambdas(project)
+
 	err := s.ensureImagesExists(ctx, project)
 	if err != nil {
 		return err

--- a/local/compose/down.go
+++ b/local/compose/down.go
@@ -21,6 +21,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	lambdas2 "github.com/docker/compose-cli/api/lambdas"
+
+	"github.com/docker/compose-cli/local/lambdas"
+
 	"github.com/docker/compose-cli/api/compose"
 
 	"github.com/docker/compose-cli/api/progress"
@@ -33,6 +37,7 @@ import (
 )
 
 func (s *composeService) Down(ctx context.Context, projectName string, options compose.DownOptions) error {
+
 	eg, _ := errgroup.WithContext(ctx)
 	w := progress.ContextWriter(ctx)
 
@@ -148,6 +153,13 @@ func (s *composeService) projectFromContainerLabels(ctx context.Context, project
 	if err != nil {
 		return nil, err
 	}
+
+	err = lambdas2.LoadQueues(project)
+	if err != nil {
+		return nil, err
+	}
+
+	lambdas.TransformForLambdas(project)
 
 	return project, nil
 }

--- a/local/lambdas/transform.go
+++ b/local/lambdas/transform.go
@@ -1,0 +1,50 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lambdas
+
+import (
+	"fmt"
+
+	"github.com/docker/compose-cli/api/lambdas"
+
+	"github.com/compose-spec/compose-go/types"
+)
+
+func TransformForLambdas(project *types.Project) {
+	queues := lambdas.GetQueues(project)
+	if len(queues) == 0 {
+		return
+	}
+
+	project.Networks["internal.events"] = types.NetworkConfig{
+		Name: fmt.Sprintf("%s_internal.events", project.Name),
+	}
+
+	project.Services = append(project.Services, types.ServiceConfig{
+		Name:     "internal.queues",
+		Image:    "nats",
+		Networks: map[string]*types.ServiceNetworkConfig{"internal.events": nil},
+		Ports: []types.ServicePortConfig{
+			{
+				Target: 4222,
+			},
+			{
+				Target: 8222,
+			},
+		},
+	})
+}


### PR DESCRIPTION
**What I did**
introduced `x-queues` to define event queues and implement on local context by a nats.io service and network

**Related issue**
https://github.com/docker/compose-cli/issues/1127

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
