### PR TITLE
Refactor kubernetes context create

### DIFF
--- a/api/context/store/contextmetadata.go
+++ b/api/context/store/contextmetadata.go
@@ -57,7 +57,8 @@ type EcsContext struct {
 
 // KubeContext is the context for a kube backend
 type KubeContext struct {
-	Endpoint        string `json:",omitempty"`
+	ContextName     string `json:",omitempty"`
+	KubeconfigPath  string `json:",omitempty"`
 	FromEnvironment bool
 }
 

--- a/api/context/store/store.go
+++ b/api/context/store/store.go
@@ -57,7 +57,7 @@ const (
 	LocalContextType = "local"
 	// KubeContextType is the endpoint key in the context endpoints for a new
 	// kube backend
-	KubeContextType = "k8s"
+	KubeContextType = "kube"
 )
 
 const (

--- a/api/context/store/store.go
+++ b/api/context/store/store.go
@@ -57,7 +57,7 @@ const (
 	LocalContextType = "local"
 	// KubeContextType is the endpoint key in the context endpoints for a new
 	// kube backend
-	KubeContextType = "kubernetes"
+	KubeContextType = "k8s"
 )
 
 const (

--- a/cli/cmd/context/create_kube.go
+++ b/cli/cmd/context/create_kube.go
@@ -41,7 +41,7 @@ $ docker context create k8s CONTEXT [flags]
 func createKubeCommand() *cobra.Command {
 	var opts kube.ContextParams
 	cmd := &cobra.Command{
-		Use:   "k8s CONTEXT [flags]",
+		Use:   "kubernetes CONTEXT [flags]",
 		Short: "Create context for a Kubernetes Cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/context/create_kube.go
+++ b/cli/cmd/context/create_kube.go
@@ -33,30 +33,25 @@ func init() {
 	extraCommands = append(extraCommands, createKubeCommand)
 	extraHelp = append(extraHelp, `
 Create a Kubernetes context:
-$ docker context create kubernetes CONTEXT [flags]
-(see docker context create kubernetes --help)
+$ docker context create k8s CONTEXT [flags]
+(see docker context create k8s --help)
 `)
 }
 
 func createKubeCommand() *cobra.Command {
 	var opts kube.ContextParams
 	cmd := &cobra.Command{
-		Use:   "kubernetes CONTEXT [flags]",
+		Use:   "k8s CONTEXT [flags]",
 		Short: "Create context for a Kubernetes Cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Name = args[0]
-
-			if opts.Endpoint != "" {
-				opts.FromEnvironment = false
-			}
 			return runCreateKube(cmd.Context(), args[0], opts)
 		},
 	}
 
 	addDescriptionFlag(cmd, &opts.Description)
-	cmd.Flags().StringVar(&opts.Endpoint, "endpoint", "", "The endpoint of the Kubernetes manager")
-	cmd.Flags().BoolVar(&opts.FromEnvironment, "from-env", true, "Get endpoint and creds from env vars")
+	cmd.Flags().StringVar(&opts.KubeconfigPath, "kubeconfig", "", "The endpoint of the Kubernetes manager")
+	cmd.Flags().BoolVar(&opts.FromEnvironment, "from-env", false, "Get endpoint and creds from env vars")
 	return cmd
 }
 
@@ -65,13 +60,9 @@ func runCreateKube(ctx context.Context, contextName string, opts kube.ContextPar
 		return errors.Wrapf(errdefs.ErrAlreadyExists, "context %q", contextName)
 	}
 
-	contextData, description := createContextData(opts)
+	contextData, description, err := opts.CreateContextData()
+	if err != nil {
+		return err
+	}
 	return createDockerContext(ctx, contextName, store.KubeContextType, description, contextData)
-}
-
-func createContextData(opts kube.ContextParams) (interface{}, string) {
-	return store.KubeContext{
-		Endpoint:        opts.Endpoint,
-		FromEnvironment: opts.FromEnvironment,
-	}, opts.Description
 }

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	helm.sh/helm/v3 v3.5.0
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
+	k8s.io/client-go v0.20.1
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 )
 

--- a/kube/charts/kubernetes/context.go
+++ b/kube/charts/kubernetes/context.go
@@ -1,0 +1,50 @@
+// +build kube
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func ListAvailableKubeConfigContexts(kubeconfig string) ([]string, error) {
+	config, err := clientcmd.NewDefaultPathOptions().GetStartingConfig()
+	if err != nil {
+		return nil, err
+	}
+	if kubeconfig != "" {
+		f, err := os.Stat(kubeconfig)
+		if os.IsNotExist(err) {
+			return nil, err
+		}
+		if f.IsDir() {
+			return nil, fmt.Errorf("%s not a config file", kubeconfig)
+		}
+
+		config = clientcmd.GetConfigFromFileOrDie(kubeconfig)
+	}
+
+	contexts := []string{}
+	for k := range config.Contexts {
+		contexts = append(contexts, k)
+	}
+	return contexts, nil
+}


### PR DESCRIPTION
Refactored the context create: 
- renamed `kubernetes` type to `k8s` (conflict with the legacy `kubernetes` endpoint from Docker contexts).
- parse kubeconfigs for the list of contexts
- `.FromEnvironment` option should enable the use of the current context in a kubeconfig passed via `$KUBECONFIG`


```
$ docker context create k8s test
? Create a Docker context using:  [Use arrows to move, type to filter]
> Context from kubeconfig file
  Kubernetes environment variables
```
```
$ docker context create k8s test
? Create a Docker context using: Context from kubeconfig file
? Select kubeconfig context  [Use arrows to move, type to filter]
> kind-kind
  kind-cluster2
```
```
$ docker context create k8s test
? Create a Docker context using: Context from kubeconfig file
? Select kubeconfig context kind-kind
Successfully created k8s context "test"
```
```
$ docker context create k8s test --from-env
Successfully created k8s context "test"
```
```
$ docker context create k8s test --kubeconfig ~/kubeconfig.json
? Select kubeconfig context  [Use arrows to move, type to filter]
> kind-kind
  kind-cluster2

```
Closes https://github.com/docker/dev-tooling-team/issues/271
