### PR TITLE
introduce compose logs --tail and --follow options

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -122,6 +122,8 @@ type ServiceStatus struct {
 // LogOptions defines optional parameters for the `Log` API
 type LogOptions struct {
 	Services []string
+	Tail     string
+	Follow   bool
 }
 
 const (

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -97,7 +97,7 @@ func Command(contextType string) *cobra.Command {
 		stopCommand(&opts),
 		psCommand(&opts),
 		listCommand(),
-		logsCommand(&opts),
+		logsCommand(&opts, contextType),
 		convertCommand(&opts),
 		runCommand(&opts),
 	)

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -46,7 +46,7 @@ func logsCommand(p *projectOptions, contextType string) *cobra.Command {
 			return runLogs(cmd.Context(), opts, args)
 		},
 	}
-	logsCmd.Flags().BoolVarP(&opts.follow, "follow", "f", false, "Follow log output.")
+	logsCmd.Flags().BoolVar(&opts.follow, "follow", false, "Follow log output.")
 	if contextType == store.DefaultContextType {
 		logsCmd.Flags().StringVar(&opts.tail, "tail", "all", "Number of lines to show from the end of the logs for each container.")
 	}

--- a/ecs/aws.go
+++ b/ecs/aws.go
@@ -63,7 +63,7 @@ type API interface {
 	InspectSecret(ctx context.Context, id string) (secrets.Secret, error)
 	ListSecrets(ctx context.Context) ([]secrets.Secret, error)
 	DeleteSecret(ctx context.Context, id string, recover bool) error
-	GetLogs(ctx context.Context, name string, consumer func(service, container, message string)) error
+	GetLogs(ctx context.Context, name string, consumer func(service string, container string, message string), follow bool) error
 	DescribeService(ctx context.Context, cluster string, arn string) (compose.ServiceStatus, error)
 	DescribeServiceTasks(ctx context.Context, cluster string, project string, service string) ([]compose.ContainerSummary, error)
 	getURLWithPortMapping(ctx context.Context, targetGroupArns []string) ([]compose.PortPublisher, error)

--- a/ecs/aws_mock.go
+++ b/ecs/aws_mock.go
@@ -285,17 +285,17 @@ func (mr *MockAPIMockRecorder) GetLoadBalancerURL(arg0, arg1 interface{}) *gomoc
 }
 
 // GetLogs mocks base method
-func (m *MockAPI) GetLogs(arg0 context.Context, arg1 string, arg2 func(string, string, string)) error {
+func (m *MockAPI) GetLogs(arg0 context.Context, arg1 string, arg2 func(string, string, string), arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GetLogs indicates an expected call of GetLogs
-func (mr *MockAPIMockRecorder) GetLogs(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetLogs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockAPI)(nil).GetLogs), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockAPI)(nil).GetLogs), arg0, arg1, arg2, arg3)
 }
 
 // GetParameter mocks base method

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -26,7 +26,7 @@ func (b *ecsAPIService) Logs(ctx context.Context, projectName string, consumer c
 	if len(options.Services) > 0 {
 		consumer = filteredLogConsumer(consumer, options.Services)
 	}
-	err := b.aws.GetLogs(ctx, projectName, consumer.Log)
+	err := b.aws.GetLogs(ctx, projectName, consumer.Log, options.Follow)
 	return err
 }
 

--- a/ecs/sdk.go
+++ b/ecs/sdk.go
@@ -805,7 +805,7 @@ func (s sdk) DeleteSecret(ctx context.Context, id string, recover bool) error {
 	return err
 }
 
-func (s sdk) GetLogs(ctx context.Context, name string, consumer func(service, container, message string)) error {
+func (s sdk) GetLogs(ctx context.Context, name string, consumer func(service string, container string, message string), follow bool) error {
 	logGroup := fmt.Sprintf("/docker-compose/%s", name)
 	var startTime int64
 	for {
@@ -836,6 +836,9 @@ func (s sdk) GetLogs(ctx context.Context, name string, consumer func(service, co
 					startTime = *event.IngestionTime
 				}
 			}
+		}
+		if !follow {
+			return nil
 		}
 		time.Sleep(500 * time.Millisecond)
 	}

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -35,7 +35,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
@@ -77,13 +76,9 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 	orphans := observedState.filter(isNotService(project.ServiceNames()...))
 	if len(orphans) > 0 {
 		if opts.RemoveOrphans {
-			eg, _ := errgroup.WithContext(ctx)
 			w := progress.ContextWriter(ctx)
-			err := s.removeContainers(ctx, w, eg, orphans)
+			err := s.removeContainers(ctx, w, orphans)
 			if err != nil {
-				return err
-			}
-			if eg.Wait() != nil {
 				return err
 			}
 		} else {

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -64,7 +64,8 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 			r, err := s.apiClient.ContainerLogs(ctx, container.ID, types.ContainerLogsOptions{
 				ShowStdout: true,
 				ShowStderr: true,
-				Follow:     true,
+				Follow:     options.Follow,
+				Tail:       options.Tail,
 			})
 			defer r.Close() // nolint errcheck
 

--- a/local/compose/stop.go
+++ b/local/compose/stop.go
@@ -19,17 +19,14 @@ package compose
 import (
 	"context"
 
+	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 
 	"github.com/docker/compose-cli/api/progress"
-
-	"github.com/compose-spec/compose-go/types"
-	"golang.org/x/sync/errgroup"
 )
 
-func (s *composeService) Stop(ctx context.Context, project *types.Project) error {
-	eg, _ := errgroup.WithContext(ctx)
+func (s *composeService) Stop(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
 	w := progress.ContextWriter(ctx)
 
 	var containers Containers
@@ -41,15 +38,10 @@ func (s *composeService) Stop(ctx context.Context, project *types.Project) error
 		return err
 	}
 
-	err = InReverseDependencyOrder(ctx, project, func(c context.Context, service types.ServiceConfig) error {
+	return InReverseDependencyOrder(ctx, project, func(c context.Context, service types.ServiceConfig) error {
 		serviceContainers, others := containers.split(isService(service.Name))
 		err := s.stopContainers(ctx, w, serviceContainers)
 		containers = others
 		return err
 	})
-	if err != nil {
-		return err
-	}
-
-	return eg.Wait()
 }

--- a/local/compose/stop.go
+++ b/local/compose/stop.go
@@ -26,7 +26,7 @@ import (
 	"github.com/docker/compose-cli/api/progress"
 )
 
-func (s *composeService) Stop(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (s *composeService) Stop(ctx context.Context, project *types.Project) error {
 	w := progress.ContextWriter(ctx)
 
 	var containers Containers
@@ -39,9 +39,6 @@ func (s *composeService) Stop(ctx context.Context, project *types.Project, consu
 	}
 
 	return InReverseDependencyOrder(ctx, project, func(c context.Context, service types.ServiceConfig) error {
-		serviceContainers, others := containers.split(isService(service.Name))
-		err := s.stopContainers(ctx, w, serviceContainers)
-		containers = others
-		return err
+		return s.stopContainers(ctx, w, containers.filter(isService(service.Name)))
 	})
 }


### PR DESCRIPTION
**What I did**
introduce compose logs `--tail` and `--follow` options
`--tail` is only supported on local backend

**Related issue**
https://github.com/docker/compose-cli/issues/1059

/test-aci
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
