### PR TITLE
introduce compose create command

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -107,6 +107,7 @@ func Command(contextType string) *cobra.Command {
 			buildCommand(&opts),
 			pushCommand(&opts),
 			pullCommand(&opts),
+			createCommand(&opts),
 		)
 	}
 	command.Flags().SetInterspersed(false)

--- a/cli/cmd/compose/create.go
+++ b/cli/cmd/compose/create.go
@@ -1,0 +1,47 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	*composeOptions
+}
+
+func createCommand(p *projectOptions) *cobra.Command {
+	opts := createOptions{
+		composeOptions: &composeOptions{},
+	}
+	cmd := &cobra.Command{
+		Use:   "create [SERVICE...]",
+		Short: "Creates containers for a service.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreateStart(cmd.Context(), upOptions{
+				composeOptions: &composeOptions{
+					projectOptions: p,
+					Build:          opts.Build,
+				},
+				noStart: true,
+			}, args)
+		},
+	}
+	flags := cmd.Flags()
+	flags.BoolVar(&opts.Build, "build", false, "Build images before starting containers.")
+	return cmd
+}

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -47,6 +47,7 @@ type upOptions struct {
 	removeOrphans bool
 	forceRecreate bool
 	noRecreate    bool
+	noStart       bool
 }
 
 func (o upOptions) recreateStrategy() string {
@@ -92,7 +93,7 @@ func upCommand(p *projectOptions, contextType string) *cobra.Command {
 	case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
 		flags.BoolVar(&opts.forceRecreate, "force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
 		flags.BoolVar(&opts.noRecreate, "no-recreate", false, "If containers already exist, don't recreate them. Incompatible with --force-recreate.")
-
+		flags.BoolVar(&opts.noStart, "no-start", false, "Don't start the services after creating them.")
 	}
 
 	return upCmd
@@ -133,6 +134,10 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 	})
 	if err != nil {
 		return err
+	}
+
+	if opts.noStart {
+		return nil
 	}
 
 	if opts.Detach {


### PR DESCRIPTION
**What I did**
Introduce `docker compose create` command for parity with docker-compose

**Note**
This de-deprecates `create` command (https://github.com/docker/compose/commit/40c05cfc1e33077f7fe35ebabf64af3968ef58c8)
to maintain parity with `docker create` command and avoid ambiguous `--no-xyz=true` flags

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
