### PR TITLE
Kube backend: Target the cluster referenced by the docker context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	helm.sh/helm/v3 v3.5.0
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.1
+	k8s.io/cli-runtime v0.20.1
 	k8s.io/client-go v0.20.1
 	sigs.k8s.io/kustomize/kyaml v0.10.5
 )

--- a/kube/backend.go
+++ b/kube/backend.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/compose-cli/api/cloud"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
-	apicontext "github.com/docker/compose-cli/api/context"
 	"github.com/docker/compose-cli/api/context/store"
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
@@ -35,7 +34,6 @@ import (
 const backendType = store.KubeContextType
 
 type kubeAPIService struct {
-	ctx            store.KubeContext
 	composeService compose.Service
 }
 
@@ -44,20 +42,11 @@ func init() {
 }
 
 func service(ctx context.Context) (backend.Service, error) {
-	contextStore := store.ContextStore(ctx)
-	currentContext := apicontext.CurrentContext(ctx)
-	var kubeContext store.KubeContext
-
-	if err := contextStore.GetEndpoint(currentContext, &kubeContext); err != nil {
-		return nil, err
-	}
-
-	s, err := NewComposeService(kubeContext)
+	s, err := NewComposeService(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &kubeAPIService{
-		ctx:            kubeContext,
 		composeService: s,
 	}, nil
 }

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -23,25 +23,22 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/context/store"
 	"github.com/docker/compose-cli/api/errdefs"
 	"github.com/docker/compose-cli/kube/charts"
 )
 
 // NewComposeService create a kubernetes implementation of the compose.Service API
-func NewComposeService(ctx store.KubeContext) (compose.Service, error) {
+func NewComposeService(ctx context.Context) (compose.Service, error) {
 	chartsAPI, err := charts.NewSDK(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &composeService{
-		ctx: ctx,
 		sdk: chartsAPI,
 	}, nil
 }
 
 type composeService struct {
-	ctx store.KubeContext
 	sdk charts.SDK
 }
 


### PR DESCRIPTION
- Load the kubeconfig 
- Target cluster from the docker context for deployment.

[TODO] - use the progress writer for the output

```
 $ docker context create kubernetes kube1 --description "Kube cluster 1"
? Create a Docker context using: Context from kubeconfig file
? Select kubeconfig context kind-cluster1
Successfully created kube context "kube1"
```
```
 $ docker context create kubernetes kube2 --description "Kube cluster 2"
? Create a Docker context using: Context from kubeconfig file
? Select kubeconfig context kind-cluster2
Successfully created kube context "kube2"
```

```
$ docker --context kube1 compose up
2021/01/28 14:30:03 checking 5 resources for changes
2021/01/28 14:30:03 Created a new Service called "db" in default
2021/01/28 14:30:03 Created a new Service called "wordpress" in default
2021/01/28 14:30:03 Created a new Deployment called "db" in default
2021/01/28 14:30:03 Created a new Deployment called "wordpress" in default
2021/01/28 14:30:03 Release status:  deployed
2021/01/28 14:30:03 Install complete

```

```
$ docker --context kube1 compose ls
NAME                STATUS
compose-cli         deployed

$ docker --context kube2 compose ls
NAME                STATUS

```

```
$ kubectl config use-context kind-cluster1
Switched to context "kind-cluster1".

$ kubectl get svc
NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
db           NodePort    10.106.218.74   <none>        3306:31773/TCP   26s
kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP          9d
wordpress    NodePort    10.98.107.228   <none>        80:32421/TCP     26s


$ kubectl config use-context kind-cluster2
Switched to context "kind-cluster2".

$ kubectl get svc
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP   6d4h
```



