### PR TITLE
Support exposing ports and cross-service communication

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,6 +7,9 @@ ecs:
 local:
   - local/**/*
 
+kube:
+  - kube/**/*
+
 cli:
   - cli/**/*
 

--- a/kube/charts/kubernetes/kube_test.go
+++ b/kube/charts/kubernetes/kube_test.go
@@ -1,0 +1,94 @@
+// +build kube
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestServiceWithExposedPort(t *testing.T) {
+	model, err := loadYAML(`
+services:
+  nginx:
+    image: nginx
+    ports:
+      - "80:80"
+`)
+	assert.NilError(t, err)
+
+	service := mapToService(model, model.Services[0])
+	assert.DeepEqual(t, *service, core.Service{
+		TypeMeta: meta.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name: "nginx",
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{"com.docker.compose.service": "nginx"},
+			Ports: []core.ServicePort{
+				{
+					Name:       "80-tcp",
+					Port:       int32(80),
+					TargetPort: intstr.FromInt(int(80)),
+					Protocol:   core.ProtocolTCP,
+				},
+			},
+			Type: core.ServiceTypeLoadBalancer,
+		}})
+}
+
+func TestServiceWithoutExposedPort(t *testing.T) {
+	model, err := loadYAML(`
+services:
+  nginx:
+    image: nginx
+`)
+	assert.NilError(t, err)
+
+	service := mapToService(model, model.Services[0])
+	assert.DeepEqual(t, *service, core.Service{
+		TypeMeta: meta.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name: "nginx",
+		},
+		Spec: core.ServiceSpec{
+			Selector:  map[string]string{"com.docker.compose.service": "nginx"},
+			ClusterIP: "None",
+			Ports: []core.ServicePort{
+				{
+					Name:       headlessName,
+					Protocol:   core.ProtocolTCP,
+					Port:       headlessPort,
+					TargetPort: intstr.IntOrString{IntVal: 55555},
+				},
+			},
+			Type: core.ServiceTypeClusterIP,
+		}})
+}

--- a/kube/charts/kubernetes/kube_test.go
+++ b/kube/charts/kubernetes/kube_test.go
@@ -48,7 +48,7 @@ services:
 			Name: "nginx",
 		},
 		Spec: core.ServiceSpec{
-			Selector: map[string]string{"com.docker.compose.service": "nginx"},
+			Selector: map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": ""},
 			Ports: []core.ServicePort{
 				{
 					Name:       "80-tcp",
@@ -79,16 +79,9 @@ services:
 			Name: "nginx",
 		},
 		Spec: core.ServiceSpec{
-			Selector:  map[string]string{"com.docker.compose.service": "nginx"},
+			Selector:  map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": ""},
 			ClusterIP: "None",
-			Ports: []core.ServicePort{
-				{
-					Name:       headlessName,
-					Protocol:   core.ProtocolTCP,
-					Port:       headlessPort,
-					TargetPort: intstr.IntOrString{IntVal: 55555},
-				},
-			},
-			Type: core.ServiceTypeClusterIP,
+			Ports:     []core.ServicePort{},
+			Type:      core.ServiceTypeClusterIP,
 		}})
 }

--- a/kube/e2e/kube-simple-demo/demo_sentences.yaml
+++ b/kube/e2e/kube-simple-demo/demo_sentences.yaml
@@ -1,0 +1,13 @@
+services:
+  db:
+    build: aci-demo/db
+    image: gtardif/sentences-db
+
+  words:
+    build: aci-demo/words
+    image: gtardif/sentences-api
+  web:
+    build: aci-demo/web
+    image: gtardif/sentences-web
+    ports:
+      - "80:80"

--- a/local/compose/labels.go
+++ b/local/compose/labels.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"fmt"
 
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/docker/api/types/filters"
 )
 
@@ -26,14 +27,14 @@ const (
 	containerNumberLabel = "com.docker.compose.container-number"
 	oneoffLabel          = "com.docker.compose.oneoff"
 	slugLabel            = "com.docker.compose.slug"
-	projectLabel         = "com.docker.compose.project"
-	volumeLabel          = "com.docker.compose.volume"
+	projectLabel         = compose.ProjectTag
+	volumeLabel          = compose.VolumeTag
 	workingDirLabel      = "com.docker.compose.project.working_dir"
 	configFilesLabel     = "com.docker.compose.project.config_files"
-	serviceLabel         = "com.docker.compose.service"
+	serviceLabel         = compose.ServiceTag
 	versionLabel         = "com.docker.compose.version"
 	configHashLabel      = "com.docker.compose.config-hash"
-	networkLabel         = "com.docker.compose.network"
+	networkLabel         = compose.NetworkTag
 
 	//ComposeVersion Compose version
 	ComposeVersion = "1.0-alpha"


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Add headless service for internal cross-service communication
* Services exposing ports mapped to load-balancer
* add some unit tests
* Added a sample composefile that deploys successfuly on Desktop kube cluster

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1182

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
