### PR TITLE
Fix compose start display

### DIFF
--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/formatter"
 )
 
@@ -59,17 +58,16 @@ func runStart(ctx context.Context, opts startOptions, services []string) error {
 	if !opts.Detach {
 		consumer = formatter.NewLogConsumer(ctx, os.Stdout)
 	}
-	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		project, err := opts.toProject()
-		if err != nil {
-			return "", err
-		}
 
-		err = filter(project, services)
-		if err != nil {
-			return "", err
-		}
-		return "", c.ComposeService().Start(ctx, project, consumer)
-	})
-	return err
+	project, err := opts.toProject()
+	if err != nil {
+		return err
+	}
+
+	err = filter(project, services)
+	if err != nil {
+		return err
+	}
+
+	return c.ComposeService().Start(ctx, project, consumer)
 }


### PR DESCRIPTION
**What I did**
* do not mix progress and attaching to logs in `docker compose start`
* when not attaching to logs, display container start progress in `compose up` and `compose start` 

**Related issue**
Follow up on https://github.com/docker/compose-cli/pull/1180

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
Just to check if there isn't any missed side effect on other backends: 
/test-aci
/test-ecs

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
