### PR TITLE
Add HEALTH column to compose ps

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -106,6 +106,7 @@ type ContainerSummary struct {
 	Project    string
 	Service    string
 	State      string
+	Health     string
 	Publishers []PortPublisher
 }
 

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -88,8 +88,8 @@ func runPs(ctx context.Context, opts psOptions) error {
 						ports = append(ports, fmt.Sprintf("%s->%d/%s", p.URL, p.TargetPort, p.Protocol))
 					}
 				}
-				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", container.Name, container.Service, container.State, strings.Join(ports, ", "))
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", container.Name, container.Service, container.State, container.Health, strings.Join(ports, ", "))
 			}
 		},
-		"NAME", "SERVICE", "STATE", "PORTS")
+		"NAME", "SERVICE", "STATE", "HEALTH", "PORTS")
 }


### PR DESCRIPTION
**What I did**
Inspect containers on `compose ps` to get health status

**Related issue**
closes #1198

**sample output**
```
NAME                SERVICE             STATE               HEALTH              PORTS
nicolas_test_1      test                running             healthy             
nicolas_toto_1      toto                running             healthy             
nicolas_truc_1      truc                running             unhealthy           
```

**Note**
This PR doesn't propose ECS implementation, but AFAIK the `DescribeService` API would also return health status

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/106483053-65352180-64ae-11eb-9324-c503405e621d.png)
