### PR TITLE
First kube e2e. Adapted context create kubernetes command to allow non interactive mode.

### DIFF
--- a/.github/workflows/kube-tests.yml
+++ b/.github/workflows/kube-tests.yml
@@ -1,0 +1,63 @@
+name: Kube integration tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check-optional-tests:
+    name: Check if needs to run Kube tests
+    runs-on: ubuntu-latest
+    outputs:
+      trigger-kube: ${{steps.runkubetest.outputs.triggered}}
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        name: Check if test Kube
+        if: github.event_name == 'pull_request'
+        id: runkubetest
+        with:
+          trigger: '/test-kube'
+
+
+  kube-tests:
+    name: Kube e2e tests
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: "on"
+    needs: check-optional-tests
+    if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-kube == 'true'
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+        id: go
+
+      - name: Setup docker CLI
+        run: |
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.2.tgz | tar xz
+          sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
+
+      - name: Setup Kube tools
+        run: |
+          sudo apt-get install jq && jq --version
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/bin/ && kind version
+          curl -LO "https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl" && sudo mv kubectl /usr/bin/ && kubectl version --client
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ hashFiles('**/go.sum') }}
+
+      - name: Build for Kube e2e tests
+        env:
+          BUILD_TAGS: kube
+        run: make -f builder.Makefile cli
+
+      - name: Kube e2e Test
+        run: make e2e-kube

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ e2e-local: ## Run End to end local tests. Set E2E_TEST=TestName to run a single 
 e2e-win-ci: ## Run end to end local tests on Windows CI, no Docker for Linux containers available ATM. Set E2E_TEST=TestName to run a single test
 	go test -count=1 -v $(TEST_FLAGS) ./local/e2e/cli-only
 
+e2e-kube: ## Run End to end Kube tests. Set E2E_TEST=TestName to run a single test
+	go test -timeout 10m -count=1 -v $(TEST_FLAGS) ./kube/e2e
+
 e2e-aci: ## Run End to end ACI tests. Set E2E_TEST=TestName to run a single test
 	go test -timeout 15m -count=1 -v $(TEST_FLAGS) ./aci/e2e
 

--- a/cli/cmd/context/create_kube.go
+++ b/cli/cmd/context/create_kube.go
@@ -50,7 +50,8 @@ func createKubeCommand() *cobra.Command {
 	}
 
 	addDescriptionFlag(cmd, &opts.Description)
-	cmd.Flags().StringVar(&opts.KubeconfigPath, "kubeconfig", "", "The endpoint of the Kubernetes manager")
+	cmd.Flags().StringVar(&opts.KubeConfigPath, "kubeconfig", "", "The endpoint of the Kubernetes manager")
+	cmd.Flags().StringVar(&opts.KubeContextName, "kubecontext", "", "The name of the context to use in kubeconfig")
 	cmd.Flags().BoolVar(&opts.FromEnvironment, "from-env", false, "Get endpoint and creds from env vars")
 	return cmd
 }

--- a/kube/context.go
+++ b/kube/context.go
@@ -29,9 +29,9 @@ import (
 
 // ContextParams options for creating a Kubernetes context
 type ContextParams struct {
-	ContextName     string
+	KubeContextName string
 	Description     string
-	KubeconfigPath  string
+	KubeConfigPath  string
 	FromEnvironment bool
 }
 
@@ -45,7 +45,7 @@ func (cp ContextParams) CreateContextData() (interface{}, string, error) {
 	}
 	user := prompt.User{}
 	selectContext := func() error {
-		contexts, err := kubernetes.ListAvailableKubeConfigContexts(cp.KubeconfigPath)
+		contexts, err := kubernetes.ListAvailableKubeConfigContexts(cp.KubeConfigPath)
 		if err != nil {
 			return err
 		}
@@ -57,11 +57,18 @@ func (cp ContextParams) CreateContextData() (interface{}, string, error) {
 			}
 			return err
 		}
-		cp.ContextName = contexts[selected]
+		cp.KubeContextName = contexts[selected]
 		return nil
 	}
 
-	if cp.KubeconfigPath != "" {
+	if cp.KubeConfigPath != "" {
+		if cp.KubeContextName != "" {
+			return store.KubeContext{
+				ContextName:     cp.KubeContextName,
+				KubeconfigPath:  cp.KubeConfigPath,
+				FromEnvironment: cp.FromEnvironment,
+			}, cp.Description, nil
+		}
 		err := selectContext()
 		if err != nil {
 			return nil, "", err
@@ -95,8 +102,8 @@ func (cp ContextParams) CreateContextData() (interface{}, string, error) {
 		}
 	}
 	return store.KubeContext{
-		ContextName:     cp.ContextName,
-		KubeconfigPath:  cp.KubeconfigPath,
+		ContextName:     cp.KubeContextName,
+		KubeconfigPath:  cp.KubeConfigPath,
 		FromEnvironment: cp.FromEnvironment,
 	}, cp.Description, nil
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Start kind cluster, wait... 
* deploy compose sample sentence stack. Wait... 
* check all services are wired up and we can get access service exposed on port 80
* Added Kube CI workflow (need to install jq, kubectl, kind)

We should probably check if a specific kube cluster already exists locally and reuse it, for local tests that will make things a lot quicker (but more risks of starting in a non totally clean env locally).

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1192

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
