### PR TITLE
Kube ctx description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,8 @@
 <!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
 
 <!-- optional tests
-You can add a / mention to run tests executed by default only on main branch : 
+You can add a / mention to run tests executed by default only on main branch :
+* `test-kube` to run Kube E2E tests
 * `test-aci` to run ACI E2E tests
 * `test-ecs` to run ECS E2E tests
 * `test-windows` to run tests & E2E tests on windows

--- a/kube/context.go
+++ b/kube/context.go
@@ -19,6 +19,8 @@
 package kube
 
 import (
+	"fmt"
+
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/docker/compose-cli/api/context/store"
 	"github.com/docker/compose-cli/api/errdefs"
@@ -105,5 +107,19 @@ func (cp ContextParams) CreateContextData() (interface{}, string, error) {
 		ContextName:     cp.KubeContextName,
 		KubeconfigPath:  cp.KubeConfigPath,
 		FromEnvironment: cp.FromEnvironment,
-	}, cp.Description, nil
+	}, cp.getDescription(), nil
+}
+
+func (cp ContextParams) getDescription() string {
+	if cp.Description != "" {
+		return cp.Description
+	}
+	if cp.FromEnvironment {
+		return "From environment variables"
+	}
+	configFile := "default kube config"
+	if cp.KubeconfigPath != "" {
+		configFile = cp.KubeconfigPath
+	}
+	return fmt.Sprintf("%s (in %s)", cp.ContextName, configFile)
 }

--- a/kube/context.go
+++ b/kube/context.go
@@ -43,7 +43,7 @@ func (cp ContextParams) CreateContextData() (interface{}, string, error) {
 		// we use the current kubectl context from a $KUBECONFIG path
 		return store.KubeContext{
 			FromEnvironment: cp.FromEnvironment,
-		}, cp.Description, nil
+		}, cp.getDescription(), nil
 	}
 	user := prompt.User{}
 	selectContext := func() error {
@@ -69,7 +69,7 @@ func (cp ContextParams) CreateContextData() (interface{}, string, error) {
 				ContextName:     cp.KubeContextName,
 				KubeconfigPath:  cp.KubeConfigPath,
 				FromEnvironment: cp.FromEnvironment,
-			}, cp.Description, nil
+			}, cp.getDescription(), nil
 		}
 		err := selectContext()
 		if err != nil {
@@ -118,8 +118,8 @@ func (cp ContextParams) getDescription() string {
 		return "From environment variables"
 	}
 	configFile := "default kube config"
-	if cp.KubeconfigPath != "" {
-		configFile = cp.KubeconfigPath
+	if cp.KubeConfigPath != "" {
+		configFile = cp.KubeConfigPath
 	}
-	return fmt.Sprintf("%s (in %s)", cp.ContextName, configFile)
+	return fmt.Sprintf("%s (in %s)", cp.KubeContextName, configFile)
 }

--- a/kube/context_test.go
+++ b/kube/context_test.go
@@ -1,0 +1,58 @@
+// +build kube
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package kube
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestContextDescriptionIfEnvVar(t *testing.T) {
+	cp := ContextParams{
+		FromEnvironment: true,
+	}
+	description := cp.getDescription()
+	assert.Equal(t, description, "From environment variables")
+}
+
+func TestContextDescriptionIfProvided(t *testing.T) {
+	cp := ContextParams{
+		Description:     "custom description",
+		FromEnvironment: true,
+	}
+	description := cp.getDescription()
+	assert.Equal(t, description, "custom description")
+}
+
+func TestContextDescriptionIfConfigFile(t *testing.T) {
+	cp := ContextParams{
+		ContextName:    "my-context",
+		KubeconfigPath: "~/.kube/config",
+	}
+	description := cp.getDescription()
+	assert.Equal(t, description, "my-context (in ~/.kube/config)")
+}
+func TestContextDescriptionIfDefaultConfigFile(t *testing.T) {
+	cp := ContextParams{
+		ContextName: "my-context",
+	}
+	description := cp.getDescription()
+	assert.Equal(t, description, "my-context (in default kube config)")
+}

--- a/kube/context_test.go
+++ b/kube/context_test.go
@@ -43,15 +43,15 @@ func TestContextDescriptionIfProvided(t *testing.T) {
 
 func TestContextDescriptionIfConfigFile(t *testing.T) {
 	cp := ContextParams{
-		ContextName:    "my-context",
-		KubeconfigPath: "~/.kube/config",
+		KubeContextName: "my-context",
+		KubeConfigPath:  "~/.kube/config",
 	}
 	description := cp.getDescription()
 	assert.Equal(t, description, "my-context (in ~/.kube/config)")
 }
 func TestContextDescriptionIfDefaultConfigFile(t *testing.T) {
 	cp := ContextParams{
-		ContextName: "my-context",
+		KubeContextName: "my-context",
 	}
 	description := cp.getDescription()
 	assert.Equal(t, description, "my-context (in default kube config)")

--- a/kube/e2e/compose_test.go
+++ b/kube/e2e/compose_test.go
@@ -65,6 +65,8 @@ func TestComposeUp(t *testing.T) {
 		res := c.RunDockerCmd("context", "create", "kubernetes", "--kubeconfig", kubeconfig, "--kubecontext", kubeContextName, dockerContextName)
 		res.Assert(t, icmd.Expected{Out: fmt.Sprintf("Successfully created kube context %q", dockerContextName)})
 		c.RunDockerCmd("context", "use", dockerContextName)
+		res = c.RunDockerCmd("context", "ls")
+		res.Assert(t, icmd.Expected{Out: fmt.Sprintf("%s *      kube                %s (in %s)", dockerContextName, kubeContextName, kubeconfig)})
 	})
 
 	t.Run("up", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
Set default description if not user-provided in `docker context create kubernetes` command

```
$ ./bin/docker context ls
NAME                TYPE                DESCRIPTION                                                                           DOCKER ENDPOINT               KUBERNETES ENDPOINT   ORCHESTRATOR
default *           moby                Current DOCKER_HOST based configuration                                               unix:///var/run/docker.sock                         swarm
ecscontext          ecs                 us-west-2                                                                                                                                 
kube-e2e-ctx        kube                kind-e2e (in /var/folders/z1/x87jk42x75g33hpbpt5k2rpm0000gn/T/157659045/kubeconfig)                                                       
kube-kind           kube                kind-kind (in default kube config)                                                                                                        
localctx            local                                                    
```


**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1208

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch : 
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
