### PR TITLE
Adding e2e test for local compose healthcheck in compose ps

### DIFF
--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -53,7 +53,7 @@ func TestLocalComposeUp(t *testing.T) {
 		c.RunDockerCmd("compose", "-f", "./fixtures/sentences/compose.yaml", "--project-name", projectName, "up", "-d")
 	})
 
-	t.Run("check running project", func(t *testing.T) {
+	t.Run("check accessing running app", func(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-p", projectName, "ps")
 		res.Assert(t, icmd.Expected{Out: `web`})
 
@@ -87,6 +87,12 @@ func TestLocalComposeUp(t *testing.T) {
 		res := c.RunDockerCmd("inspect", projectName+"_web_1")
 		res.Assert(t, icmd.Expected{Out: `"my-label": "test"`})
 
+	})
+
+	t.Run("check healthcheck display", func(t *testing.T) {
+		c.WaitForCmdResult(c.NewDockerCmd("compose", "-p", projectName, "ps", "--format", "json"),
+			StdoutContains(`"Name":"compose-e2e-demo_web_1","Project":"compose-e2e-demo","Service":"web","State":"running","Health":"healthy"`),
+			5*time.Second, 1*time.Second)
 	})
 
 	t.Run("down", func(t *testing.T) {

--- a/local/e2e/compose/fixtures/sentences/compose.yaml
+++ b/local/e2e/compose/fixtures/sentences/compose.yaml
@@ -11,3 +11,6 @@ services:
       - "90:80"
     labels:
       - "my-label=test"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 5s


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* while preparing a demo, added healthcheck to compose file and then added `compose ps` to local compose e2e tests

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
