### PR TITLE
Avoid negative elapsed the display when only one event is sent.

### DIFF
--- a/api/progress/tty.go
+++ b/api/progress/tty.go
@@ -154,7 +154,10 @@ func (w *ttyWriter) print() {
 func lineText(event Event, pad string, terminalWidth, statusPadding int, color bool) string {
 	endTime := time.Now()
 	if event.Status != Working {
-		endTime = event.endTime
+		endTime = event.startTime
+		if (event.endTime != time.Time{}) {
+			endTime = event.endTime
+		}
 	}
 
 	elapsed := endTime.Sub(event.startTime).Seconds()

--- a/api/progress/tty_test.go
+++ b/api/progress/tty_test.go
@@ -56,6 +56,25 @@ func TestLineText(t *testing.T) {
 	assert.Equal(t, out, "\x1b[31m . id Text Status                            0.0s\n\x1b[0m")
 }
 
+func TestLineTextSingleEvent(t *testing.T) {
+	now := time.Now()
+	ev := Event{
+		ID:         "id",
+		Text:       "Text",
+		Status:     Done,
+		StatusText: "Status",
+		startTime:  now,
+		spinner: &spinner{
+			chars: []string{"."},
+		},
+	}
+
+	lineWidth := len(fmt.Sprintf("%s %s", ev.ID, ev.Text))
+
+	out := lineText(ev, "", 50, lineWidth, true)
+	assert.Equal(t, out, "\x1b[34m . id Text Status                            0.0s\n\x1b[0m")
+}
+
 func TestErrorEvent(t *testing.T) {
 	w := &ttyWriter{
 		events: map[string]Event{},


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* If endTime is not set when displaying elapsed time, init as starTime (=> elapsed = 0)

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1227

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
