### PR TITLE
Expose `—remove-orphans` in compose down command

### DIFF
--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -31,6 +31,7 @@ import (
 
 type downOptions struct {
 	*projectOptions
+	removeOrphans bool
 }
 
 func downCommand(p *projectOptions) *cobra.Command {
@@ -44,6 +45,9 @@ func downCommand(p *projectOptions) *cobra.Command {
 			return runDown(cmd.Context(), opts)
 		},
 	}
+	flags := downCmd.Flags()
+	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")
+
 	return downCmd
 }
 
@@ -66,7 +70,7 @@ func runDown(ctx context.Context, opts downOptions) error {
 		}
 
 		return name, c.ComposeService().Down(ctx, name, compose.DownOptions{
-			RemoveOrphans: false,
+			RemoveOrphans: opts.removeOrphans,
 			Project:       project,
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* just expose the flag, everything was already wired to the backend

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1166

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
