### PR TITLE
Prefix kube resource with compose project name to avoid name clashes between projects.

### DIFF
--- a/kube/resources/kube_test.go
+++ b/kube/resources/kube_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestServiceWithExposedPort(t *testing.T) {
-	model, err := loadYAML(`
+	model, err := loadYAML("myproject", `
 services:
   nginx:
     image: nginx
@@ -45,10 +45,10 @@ services:
 			APIVersion: "v1",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: "nginx",
+			Name: "myproject-nginx",
 		},
 		Spec: core.ServiceSpec{
-			Selector: map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": ""},
+			Selector: map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": "myproject"},
 			Ports: []core.ServicePort{
 				{
 					Name:       "80-tcp",
@@ -62,7 +62,7 @@ services:
 }
 
 func TestServiceWithoutExposedPort(t *testing.T) {
-	model, err := loadYAML(`
+	model, err := loadYAML("myproject", `
 services:
   nginx:
     image: nginx
@@ -76,10 +76,10 @@ services:
 			APIVersion: "v1",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: "nginx",
+			Name: "myproject-nginx",
 		},
 		Spec: core.ServiceSpec{
-			Selector:  map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": ""},
+			Selector:  map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": "myproject"},
 			ClusterIP: "None",
 			Ports:     []core.ServicePort{},
 			Type:      core.ServiceTypeClusterIP,

--- a/kube/resources/pod_test.go
+++ b/kube/resources/pod_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func loadYAML(yaml string) (*types.Project, error) {
+func loadYAML(projectName string, yaml string) (*types.Project, error) {
 	dict, err := loader.ParseYAML([]byte(yaml))
 	if err != nil {
 		return nil, err
@@ -51,7 +51,12 @@ func loadYAML(yaml string) (*types.Project, error) {
 		ConfigFiles: configs,
 		Environment: nil,
 	}
-	return loader.Load(config)
+	project, err := loader.Load(config)
+	if err != nil {
+		return nil, err
+	}
+	project.Name = projectName
+	return project, nil
 }
 
 func podTemplate(t *testing.T, yaml string) apiv1.PodTemplateSpec {
@@ -61,7 +66,7 @@ func podTemplate(t *testing.T, yaml string) apiv1.PodTemplateSpec {
 }
 
 func podTemplateWithError(yaml string) (apiv1.PodTemplateSpec, error) {
-	model, err := loadYAML(yaml)
+	model, err := loadYAML("myproject", yaml)
 	if err != nil {
 		return apiv1.PodTemplateSpec{}, err
 	}


### PR DESCRIPTION
Kube resource name follow the form `<PROJECT>-<SERVICE>`. (“_” are not allowed there, using “-“. Project names can include “-“, so we can’t parse back to retrieve project and service names, we MUST rely on labels.

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Add `myproject-` as a prefix to kube resource names
* * unit tests

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/kube-test

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
