### PR TITLE
Kube compose ps

### DIFF
--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -19,14 +19,24 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/docker/compose-cli/api/compose"
 )
 
+// KubeClient API to access kube objects
 type KubeClient struct {
 	client *kubernetes.Clientset
 }
 
+// NewKubeClient new kubernetes client
 func NewKubeClient(config genericclioptions.RESTClientGetter) (*KubeClient, error) {
 	restConfig, err := config.ToRESTConfig()
 	if err != nil {
@@ -40,4 +50,32 @@ func NewKubeClient(config genericclioptions.RESTClientGetter) (*KubeClient, erro
 	return &KubeClient{
 		client: clientset,
 	}, nil
+}
+
+// GetContainers get containers for a given compose project
+func (kc KubeClient) GetContainers(ctx context.Context, projectName string, all bool) ([]compose.ContainerSummary, error) {
+	pods, err := kc.client.CoreV1().Pods("").List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", compose.ProjectTag, projectName)})
+
+	if err != nil {
+		return nil, err
+	}
+	json, _ := json.MarshalIndent(pods, "", " ")
+	fmt.Println(string(json))
+	fmt.Printf("containers: %d\n", len(pods.Items))
+	result := []compose.ContainerSummary{}
+	for _, pod := range pods.Items {
+		result = append(result, podToContainerSummary(pod))
+	}
+
+	return result, nil
+}
+
+func podToContainerSummary(pod v1.Pod) compose.ContainerSummary {
+	return compose.ContainerSummary{
+		ID:      pod.GetObjectMeta().GetName(),
+		Name:    pod.GetObjectMeta().GetName(),
+		Service: pod.GetObjectMeta().GetLabels()[compose.ServiceTag],
+		State:   string(pod.Status.Phase),
+		Project: pod.GetObjectMeta().GetLabels()[compose.ProjectTag],
+	}
 }

--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -1,0 +1,43 @@
+// +build kube
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+type KubeClient struct {
+	client *kubernetes.Clientset
+}
+
+func NewKubeClient(config genericclioptions.RESTClientGetter) (*KubeClient, error) {
+	restConfig, err := config.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &KubeClient{
+		client: clientset,
+	}, nil
+}

--- a/kube/client/client_test.go
+++ b/kube/client/client_test.go
@@ -1,0 +1,56 @@
+// +build kube
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose-cli/api/compose"
+)
+
+func TestPodToContainerSummary(t *testing.T) {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c1-123",
+			Labels: map[string]string{
+				compose.ProjectTag: "myproject",
+				compose.ServiceTag: "service1",
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: "Running",
+		},
+	}
+
+	container := podToContainerSummary(pod)
+
+	expected := compose.ContainerSummary{
+		ID:      "c1-123",
+		Name:    "c1-123",
+		Project: "myproject",
+		Service: "service1",
+		State:   "Running",
+	}
+	assert.DeepEqual(t, container, expected)
+}

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -54,6 +54,9 @@ func NewComposeService(ctx context.Context) (compose.Service, error) {
 		return nil, err
 	}
 	actions, err := helm.NewActions(config)
+	if err != nil {
+		return nil, err
+	}
 	apiClient, err := client.NewKubeClient(config)
 	if err != nil {
 		return nil, err
@@ -156,7 +159,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 
 // Ps executes the equivalent to a `compose ps`
 func (s *composeService) Ps(ctx context.Context, projectName string, options compose.PsOptions) ([]compose.ContainerSummary, error) {
-	return nil, errdefs.ErrNotImplemented
+	return s.client.GetContainers(ctx, projectName, options.All)
 }
 
 // Convert translate compose model into backend's native format

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -30,12 +30,14 @@ import (
 	"github.com/docker/compose-cli/api/context/store"
 	"github.com/docker/compose-cli/api/errdefs"
 	"github.com/docker/compose-cli/api/progress"
+	"github.com/docker/compose-cli/kube/client"
 	"github.com/docker/compose-cli/kube/helm"
 	"github.com/docker/compose-cli/kube/resources"
 )
 
 type composeService struct {
-	sdk *helm.Actions
+	sdk    *helm.Actions
+	client *client.KubeClient
 }
 
 // NewComposeService create a kubernetes implementation of the compose.Service API
@@ -52,11 +54,14 @@ func NewComposeService(ctx context.Context) (compose.Service, error) {
 		return nil, err
 	}
 	actions, err := helm.NewActions(config)
+	apiClient, err := client.NewKubeClient(config)
 	if err != nil {
 		return nil, err
 	}
+
 	return &composeService{
-		sdk: actions,
+		sdk:    actions,
+		client: apiClient,
 	}, nil
 }
 


### PR DESCRIPTION
**What I did**
* List pods filtering on labels for project name 
* transform pods to compose.ContainerSummary

**Related issue**
https://github.com/docker/compose-cli/issues/1195

This does not yet retrieve containers port data, need to reconcile pod data and kube services to get this

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
