### PR TITLE
Revert "Prefix kube resource with compose project name "

### DIFF
--- a/kube/resources/kube.go
+++ b/kube/resources/kube.go
@@ -45,7 +45,7 @@ func MapToKubernetesObjects(project *types.Project) (map[string]runtime.Object, 
 	for _, service := range project.Services {
 		svcObject := mapToService(project, service)
 		if svcObject != nil {
-			objects[fmt.Sprintf("%s-service.yaml", getProjectServiceName(project, service))] = svcObject
+			objects[fmt.Sprintf("%s-service.yaml", service.Name)] = svcObject
 		} else {
 			log.Println("Missing port mapping from service config.")
 		}
@@ -55,13 +55,13 @@ func MapToKubernetesObjects(project *types.Project) (map[string]runtime.Object, 
 			if err != nil {
 				return nil, err
 			}
-			objects[fmt.Sprintf("%s-daemonset.yaml", getProjectServiceName(project, service))] = daemonset
+			objects[fmt.Sprintf("%s-daemonset.yaml", service.Name)] = daemonset
 		} else {
 			deployment, err := mapToDeployment(project, service)
 			if err != nil {
 				return nil, err
 			}
-			objects[fmt.Sprintf("%s-deployment.yaml", getProjectServiceName(project, service))] = deployment
+			objects[fmt.Sprintf("%s-deployment.yaml", service.Name)] = deployment
 		}
 		for _, vol := range service.Volumes {
 			if vol.Type == "volume" {
@@ -98,7 +98,7 @@ func mapToService(project *types.Project, service types.ServiceConfig) *core.Ser
 			APIVersion: "v1",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: getProjectServiceName(project, service),
+			Name: service.Name,
 		},
 		Spec: core.ServiceSpec{
 			ClusterIP: clusterIP,
@@ -126,7 +126,7 @@ func mapToDeployment(project *types.Project, service types.ServiceConfig) (*apps
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name:   getProjectServiceName(project, service),
+			Name:   service.Name,
 			Labels: labels,
 		},
 		Spec: apps.DeploymentSpec{
@@ -136,10 +136,6 @@ func mapToDeployment(project *types.Project, service types.ServiceConfig) (*apps
 			Template: podTemplate,
 		},
 	}, nil
-}
-
-func getProjectServiceName(project *types.Project, service types.ServiceConfig) string {
-	return fmt.Sprintf("%s-%s", project.Name, service.Name)
 }
 
 func selectorLabels(projectName string, serviceName string) map[string]string {
@@ -158,7 +154,7 @@ func mapToDaemonset(project *types.Project, service types.ServiceConfig) (*apps.
 
 	return &apps.DaemonSet{
 		ObjectMeta: meta.ObjectMeta{
-			Name:   getProjectServiceName(project, service),
+			Name:   service.Name,
 			Labels: labels,
 		},
 		Spec: apps.DaemonSetSpec{

--- a/kube/resources/kube_test.go
+++ b/kube/resources/kube_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestServiceWithExposedPort(t *testing.T) {
-	model, err := loadYAML("myproject", `
+	model, err := loadYAML(`
 services:
   nginx:
     image: nginx
@@ -45,10 +45,10 @@ services:
 			APIVersion: "v1",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: "myproject-nginx",
+			Name: "nginx",
 		},
 		Spec: core.ServiceSpec{
-			Selector: map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": "myproject"},
+			Selector: map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": ""},
 			Ports: []core.ServicePort{
 				{
 					Name:       "80-tcp",
@@ -62,7 +62,7 @@ services:
 }
 
 func TestServiceWithoutExposedPort(t *testing.T) {
-	model, err := loadYAML("myproject", `
+	model, err := loadYAML(`
 services:
   nginx:
     image: nginx
@@ -76,10 +76,10 @@ services:
 			APIVersion: "v1",
 		},
 		ObjectMeta: meta.ObjectMeta{
-			Name: "myproject-nginx",
+			Name: "nginx",
 		},
 		Spec: core.ServiceSpec{
-			Selector:  map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": "myproject"},
+			Selector:  map[string]string{"com.docker.compose.service": "nginx", "com.docker.compose.project": ""},
 			ClusterIP: "None",
 			Ports:     []core.ServicePort{},
 			Type:      core.ServiceTypeClusterIP,

--- a/kube/resources/pod_test.go
+++ b/kube/resources/pod_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func loadYAML(projectName string, yaml string) (*types.Project, error) {
+func loadYAML(yaml string) (*types.Project, error) {
 	dict, err := loader.ParseYAML([]byte(yaml))
 	if err != nil {
 		return nil, err
@@ -51,12 +51,7 @@ func loadYAML(projectName string, yaml string) (*types.Project, error) {
 		ConfigFiles: configs,
 		Environment: nil,
 	}
-	project, err := loader.Load(config)
-	if err != nil {
-		return nil, err
-	}
-	project.Name = projectName
-	return project, nil
+	return loader.Load(config)
 }
 
 func podTemplate(t *testing.T, yaml string) apiv1.PodTemplateSpec {
@@ -66,7 +61,7 @@ func podTemplate(t *testing.T, yaml string) apiv1.PodTemplateSpec {
 }
 
 func podTemplateWithError(yaml string) (apiv1.PodTemplateSpec, error) {
-	model, err := loadYAML("myproject", yaml)
+	model, err := loadYAML(yaml)
 	if err != nil {
 		return apiv1.PodTemplateSpec{}, err
 	}


### PR DESCRIPTION
This breaks networking between containers within a Compose project, since DNS entries are based on service name (and are not scoped to projects)

This reverts commit 6b61902a23763fd51d6a5e864cc568b33058b06e.

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
