### PR TITLE
Kube backend: Add `compose convert`

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -81,6 +81,8 @@ type DownOptions struct {
 type ConvertOptions struct {
 	// Format define the output format used to dump converted application model (json|yaml)
 	Format string
+	// Output defines the path to save the application model
+	Output string
 }
 
 // KillOptions group options of the Kill API

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -30,7 +30,10 @@ import (
 type convertOptions struct {
 	*projectOptions
 	Format string
+	Output string
 }
+
+var addFlagsFuncs []func(cmd *cobra.Command, opts *convertOptions)
 
 func convertCommand(p *projectOptions) *cobra.Command {
 	opts := convertOptions{
@@ -47,6 +50,10 @@ func convertCommand(p *projectOptions) *cobra.Command {
 	flags := convertCmd.Flags()
 	flags.StringVar(&opts.Format, "format", "yaml", "Format the output. Values: [yaml | json]")
 
+	// add flags for hidden backends
+	for _, f := range addFlagsFuncs {
+		f(convertCmd, &opts)
+	}
 	return convertCmd
 }
 
@@ -64,11 +71,14 @@ func runConvert(ctx context.Context, opts convertOptions, services []string) err
 
 	json, err = c.ComposeService().Convert(ctx, project, compose.ConvertOptions{
 		Format: opts.Format,
+		Output: opts.Output,
 	})
 	if err != nil {
 		return err
 	}
-
+	if opts.Output != "" {
+		fmt.Print("model saved to ")
+	}
 	fmt.Println(string(json))
 	return nil
 }

--- a/cli/cmd/compose/convert_kube.go
+++ b/cli/cmd/compose/convert_kube.go
@@ -1,0 +1,31 @@
+// +build kube
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	addFlagsFuncs = append(addFlagsFuncs, func(cmd *cobra.Command, opts *convertOptions) {
+		flags := cmd.Flags()
+		flags.StringVar(&opts.Output, "output", "", "Save to directory")
+	})
+
+}

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -164,10 +164,17 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options com
 
 // Convert translate compose model into backend's native format
 func (s *composeService) Convert(ctx context.Context, project *types.Project, options compose.ConvertOptions) ([]byte, error) {
+
 	chart, err := helm.GetChartInMemory(project)
 	if err != nil {
 		return nil, err
 	}
+
+	if options.Output != "" {
+		fullpath, err := helm.SaveChart(chart, options.Output)
+		return []byte(fullpath), err
+	}
+
 	buff := []byte{}
 	for _, f := range chart.Raw {
 		header := "\n" + f.Name + "\n" + strings.Repeat("-", len(f.Name)) + "\n"

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -164,7 +164,18 @@ func (s *composeService) Ps(ctx context.Context, projectName string, options com
 
 // Convert translate compose model into backend's native format
 func (s *composeService) Convert(ctx context.Context, project *types.Project, options compose.ConvertOptions) ([]byte, error) {
-	return nil, errdefs.ErrNotImplemented
+	chart, err := helm.GetChartInMemory(project)
+	if err != nil {
+		return nil, err
+	}
+	buff := []byte{}
+	for _, f := range chart.Raw {
+		header := "\n" + f.Name + "\n" + strings.Repeat("-", len(f.Name)) + "\n"
+		buff = append(buff, []byte(header)...)
+		buff = append(buff, f.Data...)
+		buff = append(buff, []byte("\n")...)
+	}
+	return buff, nil
 }
 
 func (s *composeService) Kill(ctx context.Context, project *types.Project, options compose.KillOptions) error {


### PR DESCRIPTION
Add `compose convert` command to display the content of the chart files generated from the Compose file.
Closes https://github.com/docker/compose-cli/issues/1207

Save generated chart files to a directory:


```
$ docker compose convert --output-dir /tmp/test
model saved to /tmp/test

$ ls /tmp/test/
Chart.yaml  README.md  templates

```

```
$ docker compose convert --help
Converts the compose file to platform's canonical format

Usage:
  docker compose convert SERVICES [flags]

Aliases:
  convert, config

Flags:
      --format string       Format the output. Values: [yaml | json] (default "yaml")
  -h, --help                help for convert
      --output-dir string   Save to directory

```

Check chart content:

```
$ docker  compose convert

README.md
---------
This chart was created by converting a Compose file

Chart.yaml
----------
name: kube-simple-demo
description: A generated Helm Chart for kube-simple-demo from Skippbox Kompose
version: 0.0.1
apiVersion: v1
keywords:
  - kube-simple-demo
sources:
home:


templates/words-deployment.yaml
-------------------------------
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    com.docker.compose.project: kube-simple-demo
    com.docker.compose.service: words
  name: words
spec:
  replicas: 1
  selector:
    matchLabels:
      com.docker.compose.project: kube-simple-demo
      com.docker.compose.service: words
  strategy:
    type: Recreate
  template:
    metadata:
      creationTimestamp: null
      labels:
        com.docker.compose.project: kube-simple-demo
        com.docker.compose.service: words
    spec:
      containers:
      - image: gtardif/sentences-api
        name: words
        resources: {}
      restartPolicy: Always
status: {}


templates/web-service.yaml
--------------------------
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  name: web
spec:
  ports:
  - name: 80-tcp
    port: 80
    protocol: TCP
    targetPort: 80
  selector:
    com.docker.compose.project: kube-simple-demo
    com.docker.compose.service: web
  type: LoadBalancer
status:
  loadBalancer: {}


templates/web-deployment.yaml
-----------------------------
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    com.docker.compose.project: kube-simple-demo
    com.docker.compose.service: web
  name: web
spec:
  replicas: 1
  selector:
    matchLabels:
      com.docker.compose.project: kube-simple-demo
      com.docker.compose.service: web
  strategy:
    type: Recreate
  template:
    metadata:
      creationTimestamp: null
      labels:
        com.docker.compose.project: kube-simple-demo
        com.docker.compose.service: web
    spec:
      containers:
      - image: gtardif/sentences-web
        name: web
        ports:
        - containerPort: 80
          protocol: TCP
        resources: {}
      restartPolicy: Always
status: {}


templates/db-service.yaml
-------------------------
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  name: db
spec:
  clusterIP: None
  selector:
    com.docker.compose.project: kube-simple-demo
    com.docker.compose.service: db
  type: ClusterIP
status:
  loadBalancer: {}


templates/db-deployment.yaml
----------------------------
apiVersion: apps/v1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    com.docker.compose.project: kube-simple-demo
    com.docker.compose.service: db
  name: db
spec:
  replicas: 1
  selector:
    matchLabels:
      com.docker.compose.project: kube-simple-demo
      com.docker.compose.service: db
  strategy:
    type: Recreate
  template:
    metadata:
      creationTimestamp: null
      labels:
        com.docker.compose.project: kube-simple-demo
        com.docker.compose.service: db
    spec:
      containers:
      - image: gtardif/sentences-db
        name: db
        resources: {}
      restartPolicy: Always
status: {}


templates/words-service.yaml
----------------------------
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  name: words
spec:
  clusterIP: None
  selector:
    com.docker.compose.project: kube-simple-demo
    com.docker.compose.service: words
  type: ClusterIP
status:
  loadBalancer: {}



```




/test-kube