### PR TITLE
Filter out one_off containers on `compose logs`

### DIFF
--- a/local/compose/labels.go
+++ b/local/compose/labels.go
@@ -18,6 +18,8 @@ package compose
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/docker/api/types/filters"
@@ -42,6 +44,10 @@ const (
 
 func projectFilter(projectName string) filters.KeyValuePair {
 	return filters.Arg("label", fmt.Sprintf("%s=%s", projectLabel, projectName))
+}
+
+func oneOffFilter(oneOff bool) filters.KeyValuePair {
+	return filters.Arg("label", fmt.Sprintf("%s=%s", oneoffLabel, strings.Title(strconv.FormatBool(oneOff))))
 }
 
 func serviceFilter(serviceName string) filters.KeyValuePair {

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -33,6 +33,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 	list, err := s.apiClient.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters.NewArgs(
 			projectFilter(projectName),
+			oneOffFilter(false),
 		),
 		All: true,
 	})
@@ -72,7 +73,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 			if err != nil {
 				return err
 			}
-			w := getWriter(service, container.ID, consumer)
+			w := getWriter(service, container.Name[1:], consumer)
 			if container.Config.Tty {
 				_, err = io.Copy(w, r)
 			} else {


### PR DESCRIPTION
**What I did**
Exclude one_off container as we collect project containers for `compose logs`
Ue container name for line prefix, not ID (sha)

**Related issue**
https://github.com/docker/compose-cli/issues/1248

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
