### PR TITLE
Remove the HEALTH column in `docker compose ps` 

### DIFF
--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -93,8 +93,12 @@ func runPs(ctx context.Context, opts psOptions) error {
 						ports = append(ports, fmt.Sprintf("%s->%d/%s", p.URL, p.TargetPort, p.Protocol))
 					}
 				}
-				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", container.Name, container.Service, container.State, container.Health, strings.Join(ports, ", "))
+				status := container.State
+				if container.Health != "" {
+					status = fmt.Sprintf("%s (%s)", container.State, container.Health)
+				}
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", container.Name, container.Service, status, strings.Join(ports, ", "))
 			}
 		},
-		"NAME", "SERVICE", "STATE", "HEALTH", "PORTS")
+		"NAME", "SERVICE", "STATUS", "PORTS")
 }

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -89,10 +89,15 @@ func TestLocalComposeUp(t *testing.T) {
 
 	})
 
-	t.Run("check healthcheck display", func(t *testing.T) {
+	t.Run("check healthcheck output", func(t *testing.T) {
 		c.WaitForCmdResult(c.NewDockerCmd("compose", "-p", projectName, "ps", "--format", "json"),
 			StdoutContains(`"Name":"compose-e2e-demo_web_1","Project":"compose-e2e-demo","Service":"web","State":"running","Health":"healthy"`),
 			5*time.Second, 1*time.Second)
+
+		res := c.RunDockerCmd("compose", "-p", projectName, "ps")
+		res.Assert(t, icmd.Expected{Out: `NAME                       SERVICE             STATUS              PORTS`})
+		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo_web_1     web                 running (healthy)   0.0.0.0:90->80/tcp`})
+		res.Assert(t, icmd.Expected{Out: `compose-e2e-demo_db_1      db                  running             5432/tcp`})
 	})
 
 	t.Run("down", func(t *testing.T) {

--- a/local/e2e/compose/fixtures/sentences/compose.yaml
+++ b/local/e2e/compose/fixtures/sentences/compose.yaml
@@ -13,4 +13,4 @@ services:
       - "my-label=test"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/"]
-      interval: 5s
+      interval: 2s


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Combine values from fields “state” and “health”. 
* Rename column STATE => STATUS.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
