### PR TITLE
Allow compose common fags  (-f, -p, ...) to be used after compose command or after subcommand (as it used to be).

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -105,7 +105,14 @@ func Command(contextType string) *cobra.Command {
 		},
 	}
 
-	command.AddCommand(
+	addComposeCommand := func(cmds ...*cobra.Command) {
+		for _, subCmd := range cmds {
+			opts.addProjectFlags(subCmd.Flags())
+			command.AddCommand(subCmd)
+		}
+	}
+
+	addComposeCommand(
 		upCommand(&opts, contextType),
 		downCommand(&opts),
 		startCommand(&opts),
@@ -119,7 +126,7 @@ func Command(contextType string) *cobra.Command {
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {
-		command.AddCommand(
+		addComposeCommand(
 			buildCommand(&opts),
 			pushCommand(&opts),
 			pullCommand(&opts),

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -96,7 +96,7 @@ func TestLocalComposeUp(t *testing.T) {
 	})
 
 	t.Run("down", func(t *testing.T) {
-		_ = c.RunDockerCmd("compose", "--project-name", projectName, "down")
+		_ = c.RunDockerCmd("compose", "down", "--project-name", projectName)
 	})
 
 	t.Run("check containers after down", func(t *testing.T) {


### PR DESCRIPTION
Needed to set flags on both command and subcommand. 
Used to work setting the flags only on the subcommand but without `TraverseChildren:true` (also set at root level BTW)

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Common flags are set both on parent `compose` command and on sub commands
* changed one local e2e test to fail not only on cloud backend tests if we change this 

**Related issue**
Red tests on main: https://github.com/docker/compose-cli/runs/1839474094#step:8:31 ; same in ECS, ACI

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
