### PR TITLE
Add Azure sovereign cloud support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 dist/
+/.vscode/

--- a/aci/backend.go
+++ b/aci/backend.go
@@ -51,6 +51,7 @@ type LoginParams struct {
 	TenantID     string
 	ClientID     string
 	ClientSecret string
+	CloudName    string
 }
 
 // Validate returns an error if options are not used properly

--- a/aci/cloud.go
+++ b/aci/cloud.go
@@ -25,7 +25,7 @@ import (
 )
 
 type aciCloudService struct {
-	loginService login.AzureLoginServiceAPI
+	loginService login.AzureLoginService
 }
 
 func (cs *aciCloudService) Login(ctx context.Context, params interface{}) error {
@@ -33,10 +33,13 @@ func (cs *aciCloudService) Login(ctx context.Context, params interface{}) error 
 	if !ok {
 		return errors.New("could not read Azure LoginParams struct from generic parameter")
 	}
-	if opts.ClientID != "" {
-		return cs.loginService.LoginServicePrincipal(opts.ClientID, opts.ClientSecret, opts.TenantID)
+	if opts.CloudName == "" {
+		opts.CloudName = login.AzurePublicCloudName
 	}
-	return cs.loginService.Login(ctx, opts.TenantID)
+	if opts.ClientID != "" {
+		return cs.loginService.LoginServicePrincipal(opts.ClientID, opts.ClientSecret, opts.TenantID, opts.CloudName)
+	}
+	return cs.loginService.Login(ctx, opts.TenantID, opts.CloudName)
 }
 
 func (cs *aciCloudService) Logout(ctx context.Context) error {

--- a/aci/convert/registry_credentials_test.go
+++ b/aci/convert/registry_credentials_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/compose-spec/compose-go/types"
 	cliconfigtypes "github.com/docker/cli/cli/config/types"
+	"github.com/docker/compose-cli/aci/login"
 	"github.com/stretchr/testify/mock"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -255,7 +256,7 @@ func (s *MockRegistryHelper) getAllRegistryCredentials() (map[string]cliconfigty
 	return args.Get(0).(map[string]cliconfigtypes.AuthConfig), args.Error(1)
 }
 
-func (s *MockRegistryHelper) autoLoginAcr(registry string) error {
-	args := s.Called(registry)
+func (s *MockRegistryHelper) autoLoginAcr(registry string, loginService login.AzureLoginService) error {
+	args := s.Called(registry, loginService)
 	return args.Error(0)
 }

--- a/aci/login/client_test.go
+++ b/aci/login/client_test.go
@@ -1,0 +1,36 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package login
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestClearErrorMessageIfNotAlreadyLoggedIn(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test_store")
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	_, _, err = getClientSetupDataImpl(filepath.Join(dir, tokenStoreFilename))
+	assert.ErrorContains(t, err, "not logged in to azure, you need to run \"docker login azure\" first")
+}

--- a/aci/login/cloud_environment.go
+++ b/aci/login/cloud_environment.go
@@ -1,0 +1,274 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package login
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// AzurePublicCloudName is the moniker of the Azure public cloud
+	AzurePublicCloudName = "AzureCloud"
+
+	// AcrSuffixKey is the well-known name of the DNS suffix for Azure Container Registries
+	AcrSuffixKey = "acrLoginServer"
+
+	// CloudMetadataURLVar is the name of the environment variable that (if defined), points to a URL that should be used by Docker CLI to retrieve cloud metadata
+	CloudMetadataURLVar = "ARM_CLOUD_METADATA_URL"
+
+	// DefaultCloudMetadataURL is the URL of the cloud metadata service maintained by Azure public cloud
+	DefaultCloudMetadataURL = "https://management.azure.com/metadata/endpoints?api-version=2019-05-01"
+)
+
+// CloudEnvironmentService exposed metadata about Azure cloud environments
+type CloudEnvironmentService interface {
+	Get(name string) (CloudEnvironment, error)
+}
+
+type cloudEnvironmentService struct {
+	cloudEnvironments map[string]CloudEnvironment
+	cloudMetadataURL  string
+	// True if we have queried the cloud metadata endpoint already.
+	// We do it only once per CLI invocation.
+	metadataQueried bool
+}
+
+var (
+	// CloudEnvironments is the default instance of the CloudEnvironmentService
+	CloudEnvironments CloudEnvironmentService
+)
+
+func init() {
+	CloudEnvironments = newCloudEnvironmentService()
+}
+
+// CloudEnvironmentAuthentication data for logging into, and obtaining tokens for, Azure sovereign clouds
+type CloudEnvironmentAuthentication struct {
+	LoginEndpoint string   `json:"loginEndpoint"`
+	Audiences     []string `json:"audiences"`
+	Tenant        string   `json:"tenant"`
+}
+
+// CloudEnvironment describes Azure sovereign cloud instance (e.g. Azure public, Azure US government, Azure China etc.)
+type CloudEnvironment struct {
+	Name               string                         `json:"name"`
+	Authentication     CloudEnvironmentAuthentication `json:"authentication"`
+	ResourceManagerURL string                         `json:"resourceManager"`
+	Suffixes           map[string]string              `json:"suffixes"`
+}
+
+func newCloudEnvironmentService() *cloudEnvironmentService {
+	retval := cloudEnvironmentService{
+		metadataQueried: false,
+	}
+	retval.resetCloudMetadata()
+	return &retval
+}
+
+func (ces *cloudEnvironmentService) Get(name string) (CloudEnvironment, error) {
+	if ce, present := ces.cloudEnvironments[name]; present {
+		return ce, nil
+	}
+
+	if !ces.metadataQueried {
+		ces.metadataQueried = true
+
+		if ces.cloudMetadataURL == "" {
+			ces.cloudMetadataURL = os.Getenv(CloudMetadataURLVar)
+			if _, err := url.ParseRequestURI(ces.cloudMetadataURL); err != nil {
+				ces.cloudMetadataURL = DefaultCloudMetadataURL
+			}
+		}
+
+		res, err := http.Get(ces.cloudMetadataURL)
+		if err != nil {
+			return CloudEnvironment{}, fmt.Errorf("Cloud metadata retrieval from '%s' failed: %w", ces.cloudMetadataURL, err)
+		}
+		if res.StatusCode != 200 {
+			return CloudEnvironment{}, errors.Errorf("Cloud metadata retrieval from '%s' failed: server response was '%s'", ces.cloudMetadataURL, res.Status)
+		}
+
+		bytes, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return CloudEnvironment{}, fmt.Errorf("Cloud metadata retrieval from '%s' failed: %w", ces.cloudMetadataURL, err)
+		}
+
+		if err = ces.applyCloudMetadata(bytes); err != nil {
+			return CloudEnvironment{}, fmt.Errorf("Cloud metadata retrieval from '%s' failed: %w", ces.cloudMetadataURL, err)
+		}
+	}
+
+	if ce, present := ces.cloudEnvironments[name]; present {
+		return ce, nil
+	}
+
+	return CloudEnvironment{}, errors.Errorf("Cloud environment '%s' was not found", name)
+}
+
+func (ces *cloudEnvironmentService) applyCloudMetadata(jsonBytes []byte) error {
+	input := []CloudEnvironment{}
+	if err := json.Unmarshal(jsonBytes, &input); err != nil {
+		return err
+	}
+
+	newEnvironments := make(map[string]CloudEnvironment, len(input))
+	// If _any_ of the submitted data is invalid, we bail out.
+	for _, e := range input {
+		if len(e.Name) == 0 {
+			return errors.New("Azure cloud environment metadata is invalid (an environment with no name has been encountered)")
+		}
+
+		e.normalizeURLs()
+
+		if _, err := url.ParseRequestURI(e.Authentication.LoginEndpoint); err != nil {
+			return errors.Errorf("Metadata of cloud environment '%s' has invalid login endpoint URL: %s", e.Name, e.Authentication.LoginEndpoint)
+		}
+
+		if _, err := url.ParseRequestURI(e.ResourceManagerURL); err != nil {
+			return errors.Errorf("Metadata of cloud environment '%s' has invalid resource manager URL: %s", e.Name, e.ResourceManagerURL)
+		}
+
+		if len(e.Authentication.Audiences) == 0 {
+			return errors.Errorf("Metadata of cloud environment '%s' is invalid (no authentication audiences)", e.Name)
+		}
+
+		newEnvironments[e.Name] = e
+	}
+
+	for name, e := range newEnvironments {
+		ces.cloudEnvironments[name] = e
+	}
+	return nil
+}
+
+func (ces *cloudEnvironmentService) resetCloudMetadata() {
+	azurePublicCloud := CloudEnvironment{
+		Name: AzurePublicCloudName,
+		Authentication: CloudEnvironmentAuthentication{
+			LoginEndpoint: "https://login.microsoftonline.com",
+			Audiences: []string{
+				"https://management.core.windows.net",
+				"https://management.azure.com",
+			},
+			Tenant: "common",
+		},
+		ResourceManagerURL: "https://management.azure.com",
+		Suffixes: map[string]string{
+			AcrSuffixKey: "azurecr.io",
+		},
+	}
+
+	azureChinaCloud := CloudEnvironment{
+		Name: "AzureChinaCloud",
+		Authentication: CloudEnvironmentAuthentication{
+			LoginEndpoint: "https://login.chinacloudapi.cn",
+			Audiences: []string{
+				"https://management.core.chinacloudapi.cn",
+				"https://management.chinacloudapi.cn",
+			},
+			Tenant: "common",
+		},
+		ResourceManagerURL: "https://management.chinacloudapi.cn",
+		Suffixes: map[string]string{
+			AcrSuffixKey: "azurecr.cn",
+		},
+	}
+
+	azureUSGovernment := CloudEnvironment{
+		Name: "AzureUSGovernment",
+		Authentication: CloudEnvironmentAuthentication{
+			LoginEndpoint: "https://login.microsoftonline.us",
+			Audiences: []string{
+				"https://management.core.usgovcloudapi.net",
+				"https://management.usgovcloudapi.net",
+			},
+			Tenant: "common",
+		},
+		ResourceManagerURL: "https://management.usgovcloudapi.net",
+		Suffixes: map[string]string{
+			AcrSuffixKey: "azurecr.us",
+		},
+	}
+
+	azureGermanCloud := CloudEnvironment{
+		Name: "AzureGermanCloud",
+		Authentication: CloudEnvironmentAuthentication{
+			LoginEndpoint: "https://login.microsoftonline.de",
+			Audiences: []string{
+				"https://management.core.cloudapi.de",
+				"https://management.microsoftazure.de",
+			},
+			Tenant: "common",
+		},
+		ResourceManagerURL: "https://management.microsoftazure.de",
+
+		// There is no separate container registry suffix for German cloud
+		Suffixes: map[string]string{},
+	}
+
+	ces.cloudEnvironments = map[string]CloudEnvironment{
+		azurePublicCloud.Name:  azurePublicCloud,
+		azureChinaCloud.Name:   azureChinaCloud,
+		azureUSGovernment.Name: azureUSGovernment,
+		azureGermanCloud.Name:  azureGermanCloud,
+	}
+}
+
+// GetTenantQueryURL returns an URL that can be used to fetch the list of Azure Active Directory tenants from a given cloud environment
+func (ce *CloudEnvironment) GetTenantQueryURL() string {
+	tenantURL := ce.ResourceManagerURL + "/tenants?api-version=2019-11-01"
+	return tenantURL
+}
+
+// GetTokenScope returns a token scope that fits Docker CLI Azure management API usage
+func (ce *CloudEnvironment) GetTokenScope() string {
+	scope := "offline_access " + ce.ResourceManagerURL + "/.default"
+	return scope
+}
+
+// GetAuthorizeRequestFormat returns a string format that can be used to construct authorization code request in an OAuth2 flow.
+// The URL uses login endpoint appropriate for given cloud environment.
+func (ce *CloudEnvironment) GetAuthorizeRequestFormat() string {
+	authorizeFormat := ce.Authentication.LoginEndpoint + "/organizations/oauth2/v2.0/authorize?response_type=code&client_id=%s&redirect_uri=%s&state=%s&prompt=select_account&response_mode=query&scope=%s"
+	return authorizeFormat
+}
+
+// GetTokenRequestFormat returns a string format that can be used to construct a security token request against Azure Active Directory
+func (ce *CloudEnvironment) GetTokenRequestFormat() string {
+	tokenEndpoint := ce.Authentication.LoginEndpoint + "/%s/oauth2/v2.0/token"
+	return tokenEndpoint
+}
+
+func (ce *CloudEnvironment) normalizeURLs() {
+	ce.ResourceManagerURL = removeTrailingSlash(ce.ResourceManagerURL)
+	ce.Authentication.LoginEndpoint = removeTrailingSlash(ce.Authentication.LoginEndpoint)
+	for i, s := range ce.Authentication.Audiences {
+		ce.Authentication.Audiences[i] = removeTrailingSlash(s)
+	}
+}
+
+func removeTrailingSlash(s string) string {
+	return strings.TrimSuffix(s, "/")
+}

--- a/aci/login/cloud_environment_test.go
+++ b/aci/login/cloud_environment_test.go
@@ -1,0 +1,187 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package login
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNormalizeCloudEnvironmentURLs(t *testing.T) {
+	ce := CloudEnvironment{
+		Name: "SecretCloud",
+		Authentication: CloudEnvironmentAuthentication{
+			LoginEndpoint: "https://login.here.com/",
+			Audiences: []string{
+				"https://audience1",
+				"https://audience2/",
+			},
+			Tenant: "common",
+		},
+		ResourceManagerURL: "invalid URL",
+	}
+
+	ce.normalizeURLs()
+
+	assert.Equal(t, ce.Authentication.LoginEndpoint, "https://login.here.com")
+	assert.Equal(t, ce.Authentication.Audiences[0], "https://audience1")
+	assert.Equal(t, ce.Authentication.Audiences[1], "https://audience2")
+}
+
+func TestApplyInvalidCloudMetadataJSON(t *testing.T) {
+	ce := newCloudEnvironmentService()
+	bb := []byte(`This isn't really valid JSON`)
+
+	err := ce.applyCloudMetadata(bb)
+
+	assert.Assert(t, err != nil, "Cloud metadata was invalid, so the application should have failed")
+	ensureWellKnownCloudMetadata(t, ce)
+}
+
+func TestApplyInvalidCloudMetatada(t *testing.T) {
+	ce := newCloudEnvironmentService()
+
+	// No name (moniker) for the cloud
+	bb := []byte(`
+	[{
+		"authentication": {
+			"loginEndpoint": "https://login.docker.com/",
+			"audiences": [
+				"https://management.docker.com/",
+				"https://management.cli.docker.com/"
+			],
+			"tenant": "F5773994-FE88-482E-9E33-6E799D250416"
+		},
+		"suffixes": {
+			"acrLoginServer": "azurecr.docker.io"
+		},
+		"resourceManager": "https://management.docker.com/"
+	}]`)
+
+	err := ce.applyCloudMetadata(bb)
+	assert.ErrorContains(t, err, "no name")
+	ensureWellKnownCloudMetadata(t, ce)
+
+	// Invalid resource manager URL
+	bb = []byte(`
+	[{
+		"authentication": {
+			"loginEndpoint": "https://login.docker.com/",
+			"audiences": [
+				"https://management.docker.com/",
+				"https://management.cli.docker.com/"
+			],
+			"tenant": "F5773994-FE88-482E-9E33-6E799D250416"
+		},
+		"name": "DockerAzureCloud",
+		"suffixes": {
+			"acrLoginServer": "azurecr.docker.io"
+		},
+		"resourceManager": "123"
+	}]`)
+
+	err = ce.applyCloudMetadata(bb)
+	assert.ErrorContains(t, err, "invalid resource manager URL")
+	ensureWellKnownCloudMetadata(t, ce)
+
+	// Invalid login endpoint
+	bb = []byte(`
+	[{
+		"authentication": {
+			"loginEndpoint": "456",
+			"audiences": [
+				"https://management.docker.com/",
+				"https://management.cli.docker.com/"
+			],
+			"tenant": "F5773994-FE88-482E-9E33-6E799D250416"
+		},
+		"name": "DockerAzureCloud",
+		"suffixes": {
+			"acrLoginServer": "azurecr.docker.io"
+		},
+		"resourceManager": "https://management.docker.com/"
+	}]`)
+
+	err = ce.applyCloudMetadata(bb)
+	assert.ErrorContains(t, err, "invalid login endpoint")
+	ensureWellKnownCloudMetadata(t, ce)
+
+	// No audiences
+	bb = []byte(`
+	[{
+		"authentication": {
+			"loginEndpoint": "https://login.docker.com/",
+			"audiences": [ ],
+			"tenant": "F5773994-FE88-482E-9E33-6E799D250416"
+		},
+		"name": "DockerAzureCloud",
+		"suffixes": {
+			"acrLoginServer": "azurecr.docker.io"
+		},
+		"resourceManager": "https://management.docker.com/"
+	}]`)
+
+	err = ce.applyCloudMetadata(bb)
+	assert.ErrorContains(t, err, "no authentication audiences")
+	ensureWellKnownCloudMetadata(t, ce)
+}
+
+func TestApplyCloudMetadata(t *testing.T) {
+	ce := newCloudEnvironmentService()
+
+	bb := []byte(`
+	[{
+		"authentication": {
+			"loginEndpoint": "https://login.docker.com/",
+			"audiences": [
+				"https://management.docker.com/",
+				"https://management.cli.docker.com/"
+			],
+			"tenant": "F5773994-FE88-482E-9E33-6E799D250416"
+		},
+		"name": "DockerAzureCloud",
+		"suffixes": {
+			"acrLoginServer": "azurecr.docker.io"
+		},
+		"resourceManager": "https://management.docker.com/"
+	}]`)
+
+	err := ce.applyCloudMetadata(bb)
+	assert.NilError(t, err)
+
+	env, err := ce.Get("DockerAzureCloud")
+	assert.NilError(t, err)
+	assert.Equal(t, env.Authentication.LoginEndpoint, "https://login.docker.com")
+	ensureWellKnownCloudMetadata(t, ce)
+}
+
+func TestDefaultCloudMetadataPresent(t *testing.T) {
+	ensureWellKnownCloudMetadata(t, CloudEnvironments)
+}
+
+func ensureWellKnownCloudMetadata(t *testing.T, ce CloudEnvironmentService) {
+	// Make sure well-known public cloud information is still available
+	_, err := ce.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	_, err = ce.Get("AzureChinaCloud")
+	assert.NilError(t, err)
+
+	_, err = ce.Get("AzureUSGovernment")
+	assert.NilError(t, err)
+}

--- a/aci/login/login_test.go
+++ b/aci/login/login_test.go
@@ -21,10 +21,12 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,7 +38,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func testLoginService(t *testing.T, m *MockAzureHelper) (*AzureLoginService, error) {
+func testLoginService(t *testing.T, apiHelperMock *MockAzureHelper, cloudEnvironmentSvc CloudEnvironmentService) (*azureLoginService, error) {
 	dir, err := ioutil.TempDir("", "test_store")
 	if err != nil {
 		return nil, err
@@ -44,20 +46,45 @@ func testLoginService(t *testing.T, m *MockAzureHelper) (*AzureLoginService, err
 	t.Cleanup(func() {
 		_ = os.RemoveAll(dir)
 	})
-	return newAzureLoginServiceFromPath(filepath.Join(dir, tokenStoreFilename), m)
+
+	ces := CloudEnvironments
+	if cloudEnvironmentSvc != nil {
+		ces = cloudEnvironmentSvc
+	}
+	return newAzureLoginServiceFromPath(filepath.Join(dir, tokenStoreFilename), apiHelperMock, ces)
 }
 
 func TestRefreshInValidToken(t *testing.T) {
-	data := refreshTokenData("refreshToken")
-	m := &MockAzureHelper{}
-	m.On("queryToken", data, "123456").Return(azureToken{
+	data := url.Values{
+		"grant_type":    []string{"refresh_token"},
+		"client_id":     []string{clientID},
+		"scope":         []string{"offline_access https://management.docker.com/.default"},
+		"refresh_token": []string{"refreshToken"},
+	}
+	helperMock := &MockAzureHelper{}
+	helperMock.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), data, "123456").Return(azureToken{
 		RefreshToken: "newRefreshToken",
 		AccessToken:  "newAccessToken",
 		ExpiresIn:    3600,
 		Foci:         "1",
 	}, nil)
 
-	azureLogin, err := testLoginService(t, m)
+	cloudEnvironmentSvcMock := &MockCloudEnvironmentService{}
+	cloudEnvironmentSvcMock.On("Get", "AzureDockerCloud").Return(CloudEnvironment{
+		Name: "AzureDockerCloud",
+		Authentication: CloudEnvironmentAuthentication{
+			LoginEndpoint: "https://login.docker.com",
+			Audiences: []string{
+				"https://management.docker.com",
+				"https://management-ext.docker.com",
+			},
+			Tenant: "common",
+		},
+		ResourceManagerURL: "https://management.docker.com",
+		Suffixes:           map[string]string{},
+	}, nil)
+
+	azureLogin, err := testLoginService(t, helperMock, cloudEnvironmentSvcMock)
 	assert.NilError(t, err)
 	err = azureLogin.tokenStore.writeLoginInfo(TokenInfo{
 		TenantID: "123456",
@@ -67,33 +94,29 @@ func TestRefreshInValidToken(t *testing.T) {
 			Expiry:       time.Now().Add(-1 * time.Hour),
 			TokenType:    "Bearer",
 		},
+		CloudEnvironment: "AzureDockerCloud",
 	})
 	assert.NilError(t, err)
 
-	token, _ := azureLogin.GetValidToken()
+	token, tenantID, err := azureLogin.GetValidToken()
+	assert.NilError(t, err)
+	assert.Equal(t, tenantID, "123456")
 
 	assert.Equal(t, token.AccessToken, "newAccessToken")
 	assert.Assert(t, time.Now().Add(3500*time.Second).Before(token.Expiry))
 
-	storedToken, _ := azureLogin.tokenStore.readToken()
+	storedToken, err := azureLogin.tokenStore.readToken()
+	assert.NilError(t, err)
 	assert.Equal(t, storedToken.Token.AccessToken, "newAccessToken")
 	assert.Equal(t, storedToken.Token.RefreshToken, "newRefreshToken")
 	assert.Assert(t, time.Now().Add(3500*time.Second).Before(storedToken.Token.Expiry))
-}
 
-func TestClearErrorMessageIfNotAlreadyLoggedIn(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_store")
-	assert.NilError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(dir)
-	})
-	_, err = newAuthorizerFromLoginStorePath(filepath.Join(dir, tokenStoreFilename))
-	assert.ErrorContains(t, err, "not logged in to azure, you need to run \"docker login azure\" first")
+	assert.Equal(t, storedToken.CloudEnvironment, "AzureDockerCloud")
 }
 
 func TestDoesNotRefreshValidToken(t *testing.T) {
 	expiryDate := time.Now().Add(1 * time.Hour)
-	azureLogin, err := testLoginService(t, nil)
+	azureLogin, err := testLoginService(t, nil, nil)
 	assert.NilError(t, err)
 	err = azureLogin.tokenStore.writeLoginInfo(TokenInfo{
 		TenantID: "123456",
@@ -103,25 +126,55 @@ func TestDoesNotRefreshValidToken(t *testing.T) {
 			Expiry:       expiryDate,
 			TokenType:    "Bearer",
 		},
+		CloudEnvironment: AzurePublicCloudName,
 	})
 	assert.NilError(t, err)
 
-	token, _ := azureLogin.GetValidToken()
+	token, tenantID, err := azureLogin.GetValidToken()
+	assert.NilError(t, err)
 	assert.Equal(t, token.AccessToken, "accessToken")
+	assert.Equal(t, tenantID, "123456")
+}
+
+func TestTokenStoreAssumesAzurePublicCloud(t *testing.T) {
+	expiryDate := time.Now().Add(1 * time.Hour)
+	azureLogin, err := testLoginService(t, nil, nil)
+	assert.NilError(t, err)
+	err = azureLogin.tokenStore.writeLoginInfo(TokenInfo{
+		TenantID: "123456",
+		Token: oauth2.Token{
+			AccessToken:  "accessToken",
+			RefreshToken: "refreshToken",
+			Expiry:       expiryDate,
+			TokenType:    "Bearer",
+		},
+		// Simulates upgrade from older version of Docker CLI that did not have cloud environment concept
+		CloudEnvironment: "",
+	})
+	assert.NilError(t, err)
+
+	token, tenantID, err := azureLogin.GetValidToken()
+	assert.NilError(t, err)
+	assert.Equal(t, tenantID, "123456")
+	assert.Equal(t, token.AccessToken, "accessToken")
+
+	ce, err := azureLogin.GetCloudEnvironment()
+	assert.NilError(t, err)
+	assert.Equal(t, ce.Name, AzurePublicCloudName)
 }
 
 func TestInvalidLogin(t *testing.T) {
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
 		redirectURL := args.Get(0).(string)
 		err := queryKeyValue(redirectURL, "error", "access denied: login failed")
 		assert.NilError(t, err)
 	}).Return(nil)
 
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(context.TODO(), "")
+	err = azureLogin.Login(context.TODO(), "", AzurePublicCloudName)
 	assert.Error(t, err, "no login code: login failed")
 }
 
@@ -129,19 +182,22 @@ func TestValidLogin(t *testing.T) {
 	var redirectURL string
 	ctx := context.TODO()
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	ce, err := CloudEnvironments.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
 		redirectURL = args.Get(0).(string)
 		err := queryKeyValue(redirectURL, "code", "123456879")
 		assert.NilError(t, err)
 	}).Return(nil)
 
-	m.On("queryToken", mock.MatchedBy(func(data url.Values) bool {
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), mock.MatchedBy(func(data url.Values) bool {
 		//Need a matcher here because the value of redirectUrl is not known until executing openAzureLoginPage
 		return reflect.DeepEqual(data, url.Values{
 			"grant_type":   []string{"authorization_code"},
 			"client_id":    []string{clientID},
 			"code":         []string{"123456879"},
-			"scope":        []string{scopes},
+			"scope":        []string{ce.GetTokenScope()},
 			"redirect_uri": []string{redirectURL},
 		})
 	}), "organizations").Return(azureToken{
@@ -153,18 +209,18 @@ func TestValidLogin(t *testing.T) {
 
 	authBody := `{"value":[{"id":"/tenants/12345a7c-c56d-43e8-9549-dd230ce8a038","tenantId":"12345a7c-c56d-43e8-9549-dd230ce8a038"}]}`
 
-	m.On("queryAPIWithHeader", ctx, getTenantURL, "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
-	data := refreshTokenData("firstRefreshToken")
-	m.On("queryToken", data, "12345a7c-c56d-43e8-9549-dd230ce8a038").Return(azureToken{
+	m.On("queryAPIWithHeader", ctx, ce.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
+	data := refreshTokenData("firstRefreshToken", ce)
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), data, "12345a7c-c56d-43e8-9549-dd230ce8a038").Return(azureToken{
 		RefreshToken: "newRefreshToken",
 		AccessToken:  "newAccessToken",
 		ExpiresIn:    3600,
 		Foci:         "1",
 	}, nil)
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(ctx, "")
+	err = azureLogin.Login(ctx, "", AzurePublicCloudName)
 	assert.NilError(t, err)
 
 	loginToken, err := azureLogin.tokenStore.readToken()
@@ -174,24 +230,28 @@ func TestValidLogin(t *testing.T) {
 	assert.Assert(t, time.Now().Add(3500*time.Second).Before(loginToken.Token.Expiry))
 	assert.Equal(t, loginToken.TenantID, "12345a7c-c56d-43e8-9549-dd230ce8a038")
 	assert.Equal(t, loginToken.Token.Type(), "Bearer")
+	assert.Equal(t, loginToken.CloudEnvironment, "AzureCloud")
 }
 
 func TestValidLoginRequestedTenant(t *testing.T) {
 	var redirectURL string
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	ce, err := CloudEnvironments.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
 		redirectURL = args.Get(0).(string)
 		err := queryKeyValue(redirectURL, "code", "123456879")
 		assert.NilError(t, err)
 	}).Return(nil)
 
-	m.On("queryToken", mock.MatchedBy(func(data url.Values) bool {
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), mock.MatchedBy(func(data url.Values) bool {
 		//Need a matcher here because the value of redirectUrl is not known until executing openAzureLoginPage
 		return reflect.DeepEqual(data, url.Values{
 			"grant_type":   []string{"authorization_code"},
 			"client_id":    []string{clientID},
 			"code":         []string{"123456879"},
-			"scope":        []string{scopes},
+			"scope":        []string{ce.GetTokenScope()},
 			"redirect_uri": []string{redirectURL},
 		})
 	}), "organizations").Return(azureToken{
@@ -205,18 +265,18 @@ func TestValidLoginRequestedTenant(t *testing.T) {
 						   {"id":"/tenants/12345a7c-c56d-43e8-9549-dd230ce8a038","tenantId":"12345a7c-c56d-43e8-9549-dd230ce8a038"}]}`
 
 	ctx := context.TODO()
-	m.On("queryAPIWithHeader", ctx, getTenantURL, "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
-	data := refreshTokenData("firstRefreshToken")
-	m.On("queryToken", data, "12345a7c-c56d-43e8-9549-dd230ce8a038").Return(azureToken{
+	m.On("queryAPIWithHeader", ctx, ce.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
+	data := refreshTokenData("firstRefreshToken", ce)
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), data, "12345a7c-c56d-43e8-9549-dd230ce8a038").Return(azureToken{
 		RefreshToken: "newRefreshToken",
 		AccessToken:  "newAccessToken",
 		ExpiresIn:    3600,
 		Foci:         "1",
 	}, nil)
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(ctx, "12345a7c-c56d-43e8-9549-dd230ce8a038")
+	err = azureLogin.Login(ctx, "12345a7c-c56d-43e8-9549-dd230ce8a038", AzurePublicCloudName)
 	assert.NilError(t, err)
 
 	loginToken, err := azureLogin.tokenStore.readToken()
@@ -226,24 +286,28 @@ func TestValidLoginRequestedTenant(t *testing.T) {
 	assert.Assert(t, time.Now().Add(3500*time.Second).Before(loginToken.Token.Expiry))
 	assert.Equal(t, loginToken.TenantID, "12345a7c-c56d-43e8-9549-dd230ce8a038")
 	assert.Equal(t, loginToken.Token.Type(), "Bearer")
+	assert.Equal(t, loginToken.CloudEnvironment, "AzureCloud")
 }
 
 func TestLoginNoTenant(t *testing.T) {
 	var redirectURL string
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	ce, err := CloudEnvironments.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
 		redirectURL = args.Get(0).(string)
 		err := queryKeyValue(redirectURL, "code", "123456879")
 		assert.NilError(t, err)
 	}).Return(nil)
 
-	m.On("queryToken", mock.MatchedBy(func(data url.Values) bool {
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), mock.MatchedBy(func(data url.Values) bool {
 		//Need a matcher here because the value of redirectUrl is not known until executing openAzureLoginPage
 		return reflect.DeepEqual(data, url.Values{
 			"grant_type":   []string{"authorization_code"},
 			"client_id":    []string{clientID},
 			"code":         []string{"123456879"},
-			"scope":        []string{scopes},
+			"scope":        []string{ce.GetTokenScope()},
 			"redirect_uri": []string{redirectURL},
 		})
 	}), "organizations").Return(azureToken{
@@ -255,31 +319,34 @@ func TestLoginNoTenant(t *testing.T) {
 
 	ctx := context.TODO()
 	authBody := `{"value":[{"id":"/tenants/12345a7c-c56d-43e8-9549-dd230ce8a038","tenantId":"12345a7c-c56d-43e8-9549-dd230ce8a038"}]}`
-	m.On("queryAPIWithHeader", ctx, getTenantURL, "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
+	m.On("queryAPIWithHeader", ctx, ce.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
 
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(ctx, "00000000-c56d-43e8-9549-dd230ce8a038")
+	err = azureLogin.Login(ctx, "00000000-c56d-43e8-9549-dd230ce8a038", AzurePublicCloudName)
 	assert.Error(t, err, "could not find requested azure tenant 00000000-c56d-43e8-9549-dd230ce8a038: login failed")
 }
 
 func TestLoginRequestedTenantNotFound(t *testing.T) {
 	var redirectURL string
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	ce, err := CloudEnvironments.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
 		redirectURL = args.Get(0).(string)
 		err := queryKeyValue(redirectURL, "code", "123456879")
 		assert.NilError(t, err)
 	}).Return(nil)
 
-	m.On("queryToken", mock.MatchedBy(func(data url.Values) bool {
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), mock.MatchedBy(func(data url.Values) bool {
 		//Need a matcher here because the value of redirectUrl is not known until executing openAzureLoginPage
 		return reflect.DeepEqual(data, url.Values{
 			"grant_type":   []string{"authorization_code"},
 			"client_id":    []string{clientID},
 			"code":         []string{"123456879"},
-			"scope":        []string{scopes},
+			"scope":        []string{ce.GetTokenScope()},
 			"redirect_uri": []string{redirectURL},
 		})
 	}), "organizations").Return(azureToken{
@@ -291,31 +358,34 @@ func TestLoginRequestedTenantNotFound(t *testing.T) {
 
 	ctx := context.TODO()
 	authBody := `{"value":[]}`
-	m.On("queryAPIWithHeader", ctx, getTenantURL, "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
+	m.On("queryAPIWithHeader", ctx, ce.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
 
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(ctx, "")
+	err = azureLogin.Login(ctx, "", AzurePublicCloudName)
 	assert.Error(t, err, "could not find azure tenant: login failed")
 }
 
 func TestLoginAuthorizationFailed(t *testing.T) {
 	var redirectURL string
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+	ce, err := CloudEnvironments.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
 		redirectURL = args.Get(0).(string)
 		err := queryKeyValue(redirectURL, "code", "123456879")
 		assert.NilError(t, err)
 	}).Return(nil)
 
-	m.On("queryToken", mock.MatchedBy(func(data url.Values) bool {
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), mock.MatchedBy(func(data url.Values) bool {
 		//Need a matcher here because the value of redirectUrl is not known until executing openAzureLoginPage
 		return reflect.DeepEqual(data, url.Values{
 			"grant_type":   []string{"authorization_code"},
 			"client_id":    []string{clientID},
 			"code":         []string{"123456879"},
-			"scope":        []string{scopes},
+			"scope":        []string{ce.GetTokenScope()},
 			"redirect_uri": []string{redirectURL},
 		})
 	}), "organizations").Return(azureToken{
@@ -328,35 +398,38 @@ func TestLoginAuthorizationFailed(t *testing.T) {
 	authBody := `[access denied]`
 
 	ctx := context.TODO()
-	m.On("queryAPIWithHeader", ctx, getTenantURL, "Bearer firstAccessToken").Return([]byte(authBody), 400, nil)
+	m.On("queryAPIWithHeader", ctx, ce.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 400, nil)
 
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(ctx, "")
+	err = azureLogin.Login(ctx, "", AzurePublicCloudName)
 	assert.Error(t, err, "unable to login status code 400: [access denied]: login failed")
 }
 
 func TestValidThroughDeviceCodeFlow(t *testing.T) {
 	m := &MockAzureHelper{}
-	m.On("openAzureLoginPage", mock.AnythingOfType("string")).Return(errors.New("Could not open browser"))
-	m.On("getDeviceCodeFlowToken").Return(adal.Token{AccessToken: "firstAccessToken", RefreshToken: "firstRefreshToken"}, nil)
+	ce, err := CloudEnvironments.Get(AzurePublicCloudName)
+	assert.NilError(t, err)
+
+	m.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Return(errors.New("Could not open browser"))
+	m.On("getDeviceCodeFlowToken", mock.AnythingOfType("CloudEnvironment")).Return(adal.Token{AccessToken: "firstAccessToken", RefreshToken: "firstRefreshToken"}, nil)
 
 	authBody := `{"value":[{"id":"/tenants/12345a7c-c56d-43e8-9549-dd230ce8a038","tenantId":"12345a7c-c56d-43e8-9549-dd230ce8a038"}]}`
 
 	ctx := context.TODO()
-	m.On("queryAPIWithHeader", ctx, getTenantURL, "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
-	data := refreshTokenData("firstRefreshToken")
-	m.On("queryToken", data, "12345a7c-c56d-43e8-9549-dd230ce8a038").Return(azureToken{
+	m.On("queryAPIWithHeader", ctx, ce.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
+	data := refreshTokenData("firstRefreshToken", ce)
+	m.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), data, "12345a7c-c56d-43e8-9549-dd230ce8a038").Return(azureToken{
 		RefreshToken: "newRefreshToken",
 		AccessToken:  "newAccessToken",
 		ExpiresIn:    3600,
 		Foci:         "1",
 	}, nil)
-	azureLogin, err := testLoginService(t, m)
+	azureLogin, err := testLoginService(t, m, nil)
 	assert.NilError(t, err)
 
-	err = azureLogin.Login(ctx, "")
+	err = azureLogin.Login(ctx, "", AzurePublicCloudName)
 	assert.NilError(t, err)
 
 	loginToken, err := azureLogin.tokenStore.readToken()
@@ -366,13 +439,110 @@ func TestValidThroughDeviceCodeFlow(t *testing.T) {
 	assert.Assert(t, time.Now().Add(3500*time.Second).Before(loginToken.Token.Expiry))
 	assert.Equal(t, loginToken.TenantID, "12345a7c-c56d-43e8-9549-dd230ce8a038")
 	assert.Equal(t, loginToken.Token.Type(), "Bearer")
+	assert.Equal(t, loginToken.CloudEnvironment, "AzureCloud")
 }
 
-func refreshTokenData(refreshToken string) url.Values {
+func TestNonstandardCloudEnvironment(t *testing.T) {
+	dockerCloudMetadata := []byte(`
+	[{
+		"authentication": {
+			"loginEndpoint": "https://login.docker.com/",
+			"audiences": [
+				"https://management.docker.com/",
+				"https://management.cli.docker.com/"
+			],
+			"tenant": "F5773994-FE88-482E-9E33-6E799D250416"
+		},
+		"name": "AzureDockerCloud",
+		"suffixes": {
+			"acrLoginServer": "azurecr.docker.io"
+		},
+		"resourceManager": "https://management.docker.com/"
+	}]`)
+	var metadataReqCount int32 = 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(dockerCloudMetadata)
+		assert.NilError(t, err)
+		atomic.AddInt32(&metadataReqCount, 1)
+	}))
+	defer srv.Close()
+
+	cloudMetadataURL, cloudMetadataURLSet := os.LookupEnv(CloudMetadataURLVar)
+	if cloudMetadataURLSet {
+		defer func() {
+			err := os.Setenv(CloudMetadataURLVar, cloudMetadataURL)
+			assert.NilError(t, err)
+		}()
+	}
+	err := os.Setenv(CloudMetadataURLVar, srv.URL)
+	assert.NilError(t, err)
+
+	ctx := context.TODO()
+
+	ces := newCloudEnvironmentService()
+	ces.cloudMetadataURL = srv.URL
+	dockerCloudEnv, err := ces.Get("AzureDockerCloud")
+	assert.NilError(t, err)
+
+	helperMock := &MockAzureHelper{}
+	var redirectURL string
+	helperMock.On("openAzureLoginPage", mock.AnythingOfType("string"), mock.AnythingOfType("CloudEnvironment")).Run(func(args mock.Arguments) {
+		redirectURL = args.Get(0).(string)
+		err := queryKeyValue(redirectURL, "code", "123456879")
+		assert.NilError(t, err)
+	}).Return(nil)
+
+	helperMock.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), mock.MatchedBy(func(data url.Values) bool {
+		//Need a matcher here because the value of redirectUrl is not known until executing openAzureLoginPage
+		return reflect.DeepEqual(data, url.Values{
+			"grant_type":   []string{"authorization_code"},
+			"client_id":    []string{clientID},
+			"code":         []string{"123456879"},
+			"scope":        []string{dockerCloudEnv.GetTokenScope()},
+			"redirect_uri": []string{redirectURL},
+		})
+	}), "organizations").Return(azureToken{
+		RefreshToken: "firstRefreshToken",
+		AccessToken:  "firstAccessToken",
+		ExpiresIn:    3600,
+		Foci:         "1",
+	}, nil)
+
+	authBody := `{"value":[{"id":"/tenants/F5773994-FE88-482E-9E33-6E799D250416","tenantId":"F5773994-FE88-482E-9E33-6E799D250416"}]}`
+
+	helperMock.On("queryAPIWithHeader", ctx, dockerCloudEnv.GetTenantQueryURL(), "Bearer firstAccessToken").Return([]byte(authBody), 200, nil)
+	data := refreshTokenData("firstRefreshToken", dockerCloudEnv)
+	helperMock.On("queryToken", mock.AnythingOfType("login.CloudEnvironment"), data, "F5773994-FE88-482E-9E33-6E799D250416").Return(azureToken{
+		RefreshToken: "newRefreshToken",
+		AccessToken:  "newAccessToken",
+		ExpiresIn:    3600,
+		Foci:         "1",
+	}, nil)
+
+	azureLogin, err := testLoginService(t, helperMock, ces)
+	assert.NilError(t, err)
+
+	err = azureLogin.Login(ctx, "", "AzureDockerCloud")
+	assert.NilError(t, err)
+
+	loginToken, err := azureLogin.tokenStore.readToken()
+	assert.NilError(t, err)
+	assert.Equal(t, loginToken.Token.AccessToken, "newAccessToken")
+	assert.Equal(t, loginToken.Token.RefreshToken, "newRefreshToken")
+	assert.Assert(t, time.Now().Add(3500*time.Second).Before(loginToken.Token.Expiry))
+	assert.Equal(t, loginToken.TenantID, "F5773994-FE88-482E-9E33-6E799D250416")
+	assert.Equal(t, loginToken.Token.Type(), "Bearer")
+	assert.Equal(t, loginToken.CloudEnvironment, "AzureDockerCloud")
+	assert.Equal(t, metadataReqCount, int32(1))
+}
+
+// Don't warn about refreshToken parameter taking the same value for all invocations
+// nolint:unparam
+func refreshTokenData(refreshToken string, ce CloudEnvironment) url.Values {
 	return url.Values{
 		"grant_type":    []string{"refresh_token"},
 		"client_id":     []string{clientID},
-		"scope":         []string{scopes},
+		"scope":         []string{ce.GetTokenScope()},
 		"refresh_token": []string{refreshToken},
 	}
 }
@@ -394,13 +564,13 @@ type MockAzureHelper struct {
 	mock.Mock
 }
 
-func (s *MockAzureHelper) getDeviceCodeFlowToken() (adal.Token, error) {
-	args := s.Called()
+func (s *MockAzureHelper) getDeviceCodeFlowToken(ce CloudEnvironment) (adal.Token, error) {
+	args := s.Called(ce)
 	return args.Get(0).(adal.Token), args.Error(1)
 }
 
-func (s *MockAzureHelper) queryToken(data url.Values, tenantID string) (token azureToken, err error) {
-	args := s.Called(data, tenantID)
+func (s *MockAzureHelper) queryToken(ce CloudEnvironment, data url.Values, tenantID string) (token azureToken, err error) {
+	args := s.Called(ce, data, tenantID)
 	return args.Get(0).(azureToken), args.Error(1)
 }
 
@@ -409,7 +579,16 @@ func (s *MockAzureHelper) queryAPIWithHeader(ctx context.Context, authorizationU
 	return args.Get(0).([]byte), args.Int(1), args.Error(2)
 }
 
-func (s *MockAzureHelper) openAzureLoginPage(redirectURL string) error {
-	args := s.Called(redirectURL)
+func (s *MockAzureHelper) openAzureLoginPage(redirectURL string, ce CloudEnvironment) error {
+	args := s.Called(redirectURL, ce)
 	return args.Error(0)
+}
+
+type MockCloudEnvironmentService struct {
+	mock.Mock
+}
+
+func (s *MockCloudEnvironmentService) Get(name string) (CloudEnvironment, error) {
+	args := s.Called(name)
+	return args.Get(0).(CloudEnvironment), args.Error(1)
 }

--- a/aci/login/token_store.go
+++ b/aci/login/token_store.go
@@ -34,8 +34,9 @@ type tokenStore struct {
 
 // TokenInfo data stored in tokenStore
 type TokenInfo struct {
-	Token    oauth2.Token `json:"oauthToken"`
-	TenantID string       `json:"tenantId"`
+	Token            oauth2.Token `json:"oauthToken"`
+	TenantID         string       `json:"tenantId"`
+	CloudEnvironment string       `json:"cloudEnvironment"`
 }
 
 func newTokenStore(path string) (tokenStore, error) {
@@ -81,6 +82,9 @@ func (store tokenStore) readToken() (TokenInfo, error) {
 	loginInfo := TokenInfo{}
 	if err := json.Unmarshal(bytes, &loginInfo); err != nil {
 		return TokenInfo{}, err
+	}
+	if loginInfo.CloudEnvironment == "" {
+		loginInfo.CloudEnvironment = AzurePublicCloudName
 	}
 	return loginInfo, nil
 }

--- a/cli/cmd/login/azurelogin.go
+++ b/cli/cmd/login/azurelogin.go
@@ -40,6 +40,7 @@ func AzureLoginCommand() *cobra.Command {
 	flags.StringVar(&opts.TenantID, "tenant-id", "", "Specify tenant ID to use")
 	flags.StringVar(&opts.ClientID, "client-id", "", "Client ID for Service principal login")
 	flags.StringVar(&opts.ClientSecret, "client-secret", "", "Client secret for Service principal login")
+	flags.StringVar(&opts.CloudName, "cloud-name", "", "Name of a registered Azure cloud")
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Karol Zadora-Przylecki <karolz@microsoft.com>

**What I did**
Added a notion of "cloud environment" for Azure integration. This allows Docker CLI to work with "sovereign" clouds like Azure China, Azure US Government etc.

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/658

This PR does not include documentation changes

This PR does not add new E2E (integration) tests--I was not sure if you want to have any that target non-public Azure clouds. Even for teams inside Microsoft it is not always the case that we have *automated* tests targeting non-public clouds, so I think unit tests are good enough for a start.

