### PR TITLE
Add content based e2e tests for configs and secrets

### DIFF
--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -280,6 +280,16 @@ func TestLocalComposeVolume(t *testing.T) {
 		assert.Assert(t, strings.Contains(output, `"Destination":"/myconfig","Mode":"","RW":false,"Propagation":"rprivate"`), output)
 	})
 
+	t.Run("check config content", func(t *testing.T) {
+		output := c.RunDockerCmd("exec", "compose-e2e-volume_nginx2_1", "cat", "/myconfig").Stdout()
+		assert.Assert(t, strings.Contains(output, `Hello from Nginx container`), output)
+	})
+
+	t.Run("check secrets content", func(t *testing.T) {
+		output := c.RunDockerCmd("exec", "compose-e2e-volume_nginx2_1", "cat", "/run/secrets/mysecret").Stdout()
+		assert.Assert(t, strings.Contains(output, `Hello from Nginx container`), output)
+	})
+
 	t.Run("check container bind-mounts specs", func(t *testing.T) {
 		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx_1", "--format", "{{ json .HostConfig.Mounts }}")
 		output := res.Stdout()

--- a/local/e2e/compose/fixtures/volume-test/compose.yml
+++ b/local/e2e/compose/fixtures/volume-test/compose.yml
@@ -16,6 +16,8 @@ services:
       - 9090:80
     configs:
       - myconfig
+    secrets:
+      - mysecret
 
 volumes:
   staticVol:
@@ -24,4 +26,8 @@ volumes:
 
 configs:
   myconfig:
+    file: ./static/index.html
+
+secrets:
+  mysecret:
     file: ./static/index.html


### PR DESCRIPTION
**What I did**
Add e2e tests on configs and secrets

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/1242