### PR TITLE
Adapt e2e tests to compose flag order

### DIFF
--- a/aci/e2e/e2e-aci_test.go
+++ b/aci/e2e/e2e-aci_test.go
@@ -557,7 +557,7 @@ func TestUpSecretsResources(t *testing.T) {
 	_, _, _ = setupTestResourceGroup(t, c)
 
 	t.Run("compose up", func(t *testing.T) {
-		c.RunDockerCmd("compose", "up", "-f", composefilePath, "--project-name", composeProjectName)
+		c.RunDockerCmd("compose", "-f", composefilePath, "--project-name", composeProjectName, "up")
 		res := c.RunDockerCmd("ps")
 		out := Lines(res.Stdout())
 		// Check 2 containers running
@@ -565,7 +565,7 @@ func TestUpSecretsResources(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		c.RunDockerCmd("compose", "down", "--project-name", composeProjectName)
+		c.RunDockerCmd("compose", "--project-name", composeProjectName, "down")
 		res := c.RunDockerCmd("ps")
 		out := Lines(res.Stdout())
 		assert.Equal(t, len(out), 1)
@@ -696,7 +696,7 @@ func TestUpUpdate(t *testing.T) {
 			Location:       location,
 			ResourceGroup:  groupID,
 		}
-		c.RunDockerCmd("compose", "up", "-f", singlePortVolumesComposefile, "--domainname", dnsLabelName, "--project-name", projectName)
+		c.RunDockerCmd("compose", "-f", singlePortVolumesComposefile, "--project-name", projectName, "up", "--domainname", dnsLabelName)
 
 		// Volume should be autocreated by the "compose up"
 		uploadTestFile(t, aciContext, composeAccountName, fileshareName, testFileName, testFileContent)
@@ -747,11 +747,11 @@ func TestUpUpdate(t *testing.T) {
 	})
 
 	t.Run("compose ps", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ps", "--project-name", composeProjectName, "--quiet")
+		res := c.RunDockerCmd("compose", "--project-name", composeProjectName, "ps", "--quiet")
 		l := Lines(res.Stdout())
 		assert.Assert(t, is.Len(l, 3))
 
-		res = c.RunDockerCmd("compose", "ps", "--project-name", composeProjectName)
+		res = c.RunDockerCmd("compose", "--project-name", composeProjectName, "ps")
 		l = Lines(res.Stdout())
 		assert.Assert(t, is.Len(l, 4))
 		var wordsDisplayed, webDisplayed, dbDisplayed bool
@@ -797,7 +797,7 @@ func TestUpUpdate(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		c.RunDockerCmd("compose", "up", "-f", multiPortComposefile, "--project-name", composeProjectName)
+		c.RunDockerCmd("compose", "-f", multiPortComposefile, "--project-name", composeProjectName, "up")
 		res := c.RunDockerCmd("ps")
 		out := Lines(res.Stdout())
 		// Check three containers are running
@@ -832,7 +832,7 @@ func TestUpUpdate(t *testing.T) {
 	})
 
 	t.Run("down", func(t *testing.T) {
-		c.RunDockerCmd("compose", "down", "--project-name", composeProjectName)
+		c.RunDockerCmd("compose", "--project-name", composeProjectName, "down")
 		res := c.RunDockerCmd("ps")
 		out := Lines(res.Stdout())
 		assert.Equal(t, len(out), 1)

--- a/cli/metrics/metrics_test.go
+++ b/cli/metrics/metrics_test.go
@@ -130,7 +130,7 @@ func TestGetCommand(t *testing.T) {
 		},
 		{
 			name:     "compose up -f xxx",
-			args:     []string{"compose", "up", "-f", "titi.yaml"},
+			args:     []string{"compose", "-f", "up", "titi.yaml"},
 			expected: "compose up",
 		},
 		{

--- a/ecs/e2e/ecs/e2e-ecs_test.go
+++ b/ecs/e2e/ecs/e2e-ecs_test.go
@@ -81,12 +81,12 @@ func TestCompose(t *testing.T) {
 	c, stack := setupTest(t)
 
 	t.Run("compose up", func(t *testing.T) {
-		c.RunDockerCmd("compose", "up", "--project-name", stack, "-f", "./multi_port_secrets.yaml")
+		c.RunDockerCmd("compose", "--project-name", stack, "-f", "./multi_port_secrets.yaml", "up")
 	})
 
 	var webURL, wordsURL, secretsURL string
 	t.Run("compose ps", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ps", "--project-name", stack)
+		res := c.RunDockerCmd("compose", "--project-name", stack, "ps")
 		lines := strings.Split(strings.TrimSpace(res.Stdout()), "\n")
 
 		assert.Equal(t, 5, len(lines))
@@ -152,7 +152,7 @@ func TestCompose(t *testing.T) {
 	})
 
 	t.Run("compose down", func(t *testing.T) {
-		cmd := c.NewDockerCmd("compose", "down", "--project-name", stack)
+		cmd := c.NewDockerCmd("compose", "--project-name", stack, "down")
 		res := icmd.StartCmd(cmd)
 
 		checkUp := func(t poll.LogT) poll.Result {

--- a/kube/e2e/compose_test.go
+++ b/kube/e2e/compose_test.go
@@ -85,7 +85,7 @@ func TestComposeUp(t *testing.T) {
 			// db-698f4dd798-jd9gw      db                  Running
 			return fmt.Sprintf("%s-.*\\s+%s\\s+Pending\\s+", service, service)
 		}
-		res := c.RunDockerCmd("compose", "ps", "-p", projectName, "--all")
+		res := c.RunDockerCmd("compose", "-p", projectName, "ps", "--all")
 		testify.Regexp(t, getServiceRegx("db"), res.Stdout())
 		testify.Regexp(t, getServiceRegx("words"), res.Stdout())
 		testify.Regexp(t, getServiceRegx("web"), res.Stdout())
@@ -94,7 +94,7 @@ func TestComposeUp(t *testing.T) {
 	})
 
 	t.Run("compose ps hides non running containers", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "ps", "-p", projectName)
+		res := c.RunDockerCmd("compose", "-p", projectName, "ps")
 		assert.Equal(t, len(Lines(res.Stdout())), 1, res.Stdout())
 	})
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* move common compose flags before the compose subcommand

**Related issue**
Red tests on https://github.com/docker/compose-cli/commit/a5b148bda11324309ef75e7538254dd27020ef27 and previous commits on main

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows
/test-ecs
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
