### PR TITLE
Capture container exit code and dump on console

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -60,7 +60,7 @@ func (cs *aciComposeService) Create(ctx context.Context, project *types.Project,
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -44,7 +44,7 @@ func (c *composeService) Create(ctx context.Context, project *types.Project, opt
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (c *composeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -68,7 +68,7 @@ type StartOptions struct {
 	// Attach will attach to container and pipe stdout/stderr to LogConsumer
 	Attach LogConsumer
 	// Listener will get notified on container events
-	Listener Listener
+	Listener chan ContainerExited
 }
 
 // UpOptions group options of the Up API
@@ -186,11 +186,8 @@ type LogConsumer interface {
 	Status(service, container, message string)
 }
 
-// Listener get notified on container Events
-type Listener chan Event
-
-// Event let us know a Container exited
-type Event struct {
+// ContainerExited let us know a Container exited
+type ContainerExited struct {
 	Service string
 	Status  int
 }

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -65,10 +65,8 @@ type CreateOptions struct {
 
 // StartOptions group options of the Start API
 type StartOptions struct {
-	// Attach will attach to container and pipe stdout/stderr to LogConsumer
-	Attach LogConsumer
-	// Listener will get notified on container events
-	Listener chan ContainerExited
+	// Attach will attach to service containers and pipe stdout/stderr to channel
+	Attach chan ContainerEvent
 }
 
 // UpOptions group options of the Up API
@@ -183,11 +181,18 @@ type Stack struct {
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
 	Log(service, container, message string)
-	Status(service, container, message string)
+	Status(service, container, msg string)
 }
 
-// ContainerExited let us know a Container exited
-type ContainerExited struct {
-	Service string
-	Status  int
+type ContainerEvent struct {
+	Type     int
+	Source   string
+	Service  string
+	Line     string
+	ExitCode int
 }
+
+const (
+	ContainerEventLog = iota
+	ContainerEventExit
+)

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -34,7 +34,7 @@ type Service interface {
 	// Create executes the equivalent to a `compose create`
 	Create(ctx context.Context, project *types.Project, opts CreateOptions) error
 	// Start executes the equivalent to a `compose start`
-	Start(ctx context.Context, project *types.Project, consumer LogConsumer) error
+	Start(ctx context.Context, project *types.Project, options StartOptions) error
 	// Stop executes the equivalent to a `compose stop`
 	Stop(ctx context.Context, project *types.Project) error
 	// Up executes the equivalent to a `compose up`
@@ -61,6 +61,14 @@ type CreateOptions struct {
 	RemoveOrphans bool
 	// Recreate define the strategy to apply on existing containers
 	Recreate string
+}
+
+// StartOptions group options of the Start API
+type StartOptions struct {
+	// Attach will attach to container and pipe stdout/stderr to LogConsumer
+	Attach LogConsumer
+	// CascadeStop will run `Stop` on any container exit
+	CascadeStop bool
 }
 
 // UpOptions group options of the Up API
@@ -175,4 +183,5 @@ type Stack struct {
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
 	Log(service, container, message string)
+	Exit(service, container string, exitCode int)
 }

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -67,8 +67,8 @@ type CreateOptions struct {
 type StartOptions struct {
 	// Attach will attach to container and pipe stdout/stderr to LogConsumer
 	Attach LogConsumer
-	// CascadeStop will run `Stop` on any container exit
-	CascadeStop bool
+	// Listener will get notified on container events
+	Listener Listener
 }
 
 // UpOptions group options of the Up API
@@ -183,5 +183,14 @@ type Stack struct {
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
 	Log(service, container, message string)
-	Exit(service, container string, exitCode int)
+	Status(service, container, message string)
+}
+
+// Listener get notified on container Events
+type Listener chan Event
+
+// Event let us know a Container exited
+type Event struct {
+	Service string
+	Status  int
 }

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -102,7 +102,7 @@ func startDependencies(ctx context.Context, c *client.Client, project *types.Pro
 	if err := c.ComposeService().Create(ctx, project, compose.CreateOptions{}); err != nil {
 		return err
 	}
-	if err := c.ComposeService().Start(ctx, project, nil); err != nil {
+	if err := c.ComposeService().Start(ctx, project, compose.StartOptions{}); err != nil {
 		return err
 	}
 	return nil

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -18,12 +18,12 @@ package compose
 
 import (
 	"context"
-	"github.com/docker/compose-cli/api/compose"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/formatter"
 )

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"github.com/docker/compose-cli/api/compose"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -61,10 +62,12 @@ func runStart(ctx context.Context, opts startOptions, services []string) error {
 
 	if opts.Detach {
 		_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-			return "", c.ComposeService().Start(ctx, project, nil)
+			return "", c.ComposeService().Start(ctx, project, compose.StartOptions{})
 		})
 		return err
 	}
 
-	return c.ComposeService().Start(ctx, project, formatter.NewLogConsumer(ctx, os.Stdout))
+	return c.ComposeService().Start(ctx, project, compose.StartOptions{
+		Attach: formatter.NewLogConsumer(ctx, os.Stdout),
+	})
 }

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -128,7 +128,7 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 			return "", err
 		}
 		if opts.Detach {
-			err = c.ComposeService().Start(ctx, project, nil)
+			err = c.ComposeService().Start(ctx, project, compose.StartOptions{})
 		}
 		return "", err
 	})
@@ -144,7 +144,9 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 		return nil
 	}
 
-	err = c.ComposeService().Start(ctx, project, formatter.NewLogConsumer(ctx, os.Stdout))
+	err = c.ComposeService().Start(ctx, project, compose.StartOptions{
+		Attach: formatter.NewLogConsumer(ctx, os.Stdout),
+	})
 	if errors.Is(ctx.Err(), context.Canceled) {
 		fmt.Println("Gracefully stopping...")
 		ctx = context.Background()

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -150,7 +150,7 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	listener := make(chan compose.Event)
+	listener := make(chan compose.ContainerExited)
 	go func() {
 		var aborting bool
 		for {

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -48,6 +48,7 @@ type upOptions struct {
 	forceRecreate bool
 	noRecreate    bool
 	noStart       bool
+	cascadeStop   bool
 }
 
 func (o upOptions) recreateStrategy() string {
@@ -72,6 +73,9 @@ func upCommand(p *projectOptions, contextType string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
+				if opts.cascadeStop && opts.Detach {
+					return fmt.Errorf("--abort-on-container-exit and --detach are incompatible")
+				}
 				if opts.forceRecreate && opts.noRecreate {
 					return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
 				}
@@ -94,6 +98,7 @@ func upCommand(p *projectOptions, contextType string) *cobra.Command {
 		flags.BoolVar(&opts.forceRecreate, "force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
 		flags.BoolVar(&opts.noRecreate, "no-recreate", false, "If containers already exist, don't recreate them. Incompatible with --force-recreate.")
 		flags.BoolVar(&opts.noStart, "no-start", false, "Don't start the services after creating them.")
+		flags.BoolVar(&opts.cascadeStop, "abort-on-container-exit", false, "Stops all containers if any container was stopped. Incompatible with -d")
 	}
 
 	return upCmd
@@ -144,9 +149,25 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 		return nil
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	listener := make(chan compose.Event)
+	go func() {
+		var aborting bool
+		for {
+			<-listener
+			if opts.cascadeStop && !aborting {
+				aborting = true
+				fmt.Println("Aborting on container exit...")
+				cancel()
+			}
+		}
+	}()
+
 	err = c.ComposeService().Start(ctx, project, compose.StartOptions{
-		Attach: formatter.NewLogConsumer(ctx, os.Stdout),
+		Attach:   formatter.NewLogConsumer(ctx, os.Stdout),
+		Listener: listener,
 	})
+
 	if errors.Is(ctx.Err(), context.Canceled) {
 		fmt.Println("Gracefully stopping...")
 		ctx = context.Background()

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"os"
 
 	"github.com/docker/compose-cli/api/client"
@@ -151,14 +152,15 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 
 	ctx, cancel := context.WithCancel(ctx)
 	listener := make(chan compose.ContainerExited)
+	exitCode := make(chan int)
 	go func() {
 		var aborting bool
 		for {
-			<-listener
+			exit := <-listener
 			if opts.cascadeStop && !aborting {
 				aborting = true
-				fmt.Println("Aborting on container exit...")
 				cancel()
+				exitCode <- exit.Status
 			}
 		}
 	}()
@@ -169,12 +171,26 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 	})
 
 	if errors.Is(ctx.Err(), context.Canceled) {
-		fmt.Println("Gracefully stopping...")
-		ctx = context.Background()
-		_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-			return "", c.ComposeService().Stop(ctx, project)
-		})
+		select {
+		case exit := <-exitCode:
+			fmt.Println("Aborting on container exit...")
+			err = stop(c, project)
+			logrus.Error(exit)
+			// os.Exit(exit)
+		default:
+			// cancelled by user
+			fmt.Println("Gracefully stopping...")
+			err = stop(c, project)
+		}
 	}
+	return err
+}
+
+func stop(c *client.Client, project *types.Project) error {
+	ctx := context.Background()
+	_, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
+		return "", c.ComposeService().Stop(ctx, project)
+	})
 	return err
 }
 

--- a/cli/formatter/logs.go
+++ b/cli/formatter/logs.go
@@ -53,7 +53,7 @@ func (l *logConsumer) Log(service, container, message string) {
 
 func (l *logConsumer) Status(service, container, msg string) {
 	cf := l.getColorFunc(service)
-	buf := bytes.NewBufferString(fmt.Sprintf("%s %s \n", cf(container), cf(msg)))
+	buf := bytes.NewBufferString(cf(fmt.Sprintf("%s %s\n", container, msg)))
 	l.writer.Write(buf.Bytes()) // nolint:errcheck
 }
 

--- a/cli/formatter/logs.go
+++ b/cli/formatter/logs.go
@@ -51,9 +51,10 @@ func (l *logConsumer) Log(service, container, message string) {
 	}
 }
 
-func (l *logConsumer) Exit(service, container string, exitCode int) {
-	msg := fmt.Sprintf("%s exited with code %d\n", container, exitCode)
-	l.writer.Write([]byte(l.getColorFunc(service)(msg)))
+func (l *logConsumer) Status(service, container, msg string) {
+	cf := l.getColorFunc(service)
+	buf := bytes.NewBufferString(fmt.Sprintf("%s %s \n", cf(container), cf(msg)))
+	l.writer.Write(buf.Bytes()) // nolint:errcheck
 }
 
 func (l *logConsumer) getColorFunc(service string) colorFunc {

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -53,8 +53,8 @@ func (e ecsLocalSimulation) Create(ctx context.Context, project *types.Project, 
 	return e.compose.Create(ctx, enhanced, opts)
 }
 
-func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
-	return e.compose.Start(ctx, project, consumer)
+func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
+	return e.compose.Start(ctx, project, options)
 }
 
 func (e ecsLocalSimulation) Stop(ctx context.Context, project *types.Project) error {

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -54,3 +54,9 @@ func (a *allowListLogConsumer) Log(service, container, message string) {
 		a.delegate.Log(service, container, message)
 	}
 }
+
+func (a *allowListLogConsumer) Exit(service, container string, exitCode int) {
+	if a.allowList[service] {
+		a.delegate.Exit(service, container, exitCode)
+	}
+}

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -55,8 +55,8 @@ func (a *allowListLogConsumer) Log(service, container, message string) {
 	}
 }
 
-func (a *allowListLogConsumer) Exit(service, container string, exitCode int) {
+func (a *allowListLogConsumer) Status(service, container, message string) {
 	if a.allowList[service] {
-		a.delegate.Exit(service, container, exitCode)
+		a.delegate.Status(service, container, message)
 	}
 }

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -47,7 +47,7 @@ func (b *ecsAPIService) Create(ctx context.Context, project *types.Project, opts
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -135,7 +135,7 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 }
 
 // Start executes the equivalent to a `compose start`
-func (s *composeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (s *composeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -43,7 +43,10 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	fmt.Printf("Attaching to %s\n", strings.Join(names, ", "))
 
 	for _, container := range containers {
-		s.attachContainer(ctx, container, consumer, project)
+		err := s.attachContainer(ctx, container, consumer, project)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return containers, nil
 }

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -27,22 +27,14 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/stdcopy"
-	"golang.org/x/sync/errgroup"
 )
 
-func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.LogConsumer) (*errgroup.Group, error) {
-	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(
-			projectFilter(project.Name),
-		),
-		All: true,
-	})
+func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.LogConsumer) (Containers, error) {
+	containers, err := s.getContainers(ctx, project)
 	if err != nil {
 		return nil, err
 	}
-	containers = Containers(containers).filter(isService(project.ServiceNames()...))
 
 	var names []string
 	for _, c := range containers {
@@ -50,19 +42,15 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	}
 	fmt.Printf("Attaching to %s\n", strings.Join(names, ", "))
 
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, c := range containers {
-		container := c
-		eg.Go(func() error {
-			return s.attachContainer(ctx, container, consumer, project)
-		})
+	for _, container := range containers {
+		s.attachContainer(ctx, container, consumer, project)
 	}
-	return eg, nil
+	return containers, nil
 }
 
 func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.LogConsumer, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
-	w := getWriter(serviceName, getCanonicalContainerName(container), consumer)
+	w := getWriter(serviceName, getContainerNameWithoutProject(container), consumer)
 
 	service, err := project.GetService(serviceName)
 	if err != nil {
@@ -93,13 +81,15 @@ func (s *composeService) attachContainerStreams(ctx context.Context, container m
 	}
 
 	if w != nil {
-		if tty {
-			_, err = io.Copy(w, stdout)
-		} else {
-			_, err = stdcopy.StdCopy(w, w, stdout)
-		}
+		go func() {
+			if tty {
+				io.Copy(w, stdout) // nolint:errcheck
+			} else {
+				stdcopy.StdCopy(w, w, stdout) // nolint:errcheck
+			}
+		}()
 	}
-	return err
+	return nil
 }
 
 func (s *composeService) getContainerStreams(ctx context.Context, container moby.Container) (io.WriteCloser, io.ReadCloser, error) {

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -30,7 +30,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.LogConsumer) (Containers, error) {
+func (s *composeService) attach(ctx context.Context, project *types.Project, consumer chan compose.ContainerEvent) (Containers, error) {
 	containers, err := s.getContainers(ctx, project)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	return containers, nil
 }
 
-func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.LogConsumer, project *types.Project) error {
+func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer chan compose.ContainerEvent, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
 	w := getWriter(serviceName, getContainerNameWithoutProject(container), consumer)
 

--- a/local/compose/compose.go
+++ b/local/compose/compose.go
@@ -55,6 +55,16 @@ func getCanonicalContainerName(c moby.Container) string {
 	return c.Names[0][1:]
 }
 
+func getContainerNameWithoutProject(c moby.Container) string {
+	name := getCanonicalContainerName(c)
+	project := c.Labels[projectLabel]
+	prefix := fmt.Sprintf("%s_%s_", project, c.Labels[serviceLabel])
+	if strings.HasPrefix(name, prefix) {
+		return name[len(project)+1:]
+	}
+	return name
+}
+
 func (s *composeService) Convert(ctx context.Context, project *types.Project, options compose.ConvertOptions) ([]byte, error) {
 	switch options.Format {
 	case "json":

--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -16,10 +16,30 @@
 
 package compose
 
-import moby "github.com/docker/docker/api/types"
+import (
+	"context"
+	"github.com/compose-spec/compose-go/types"
+	moby "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Containers is a set of moby Container
 type Containers []moby.Container
+
+func (s *composeService) getContainers(ctx context.Context, project *types.Project) (Containers, error) {
+	var containers Containers
+	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
+		Filters: filters.NewArgs(
+			projectFilter(project.Name),
+		),
+		All: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	containers = containers.filter(isService(project.ServiceNames()...))
+	return containers, nil
+}
 
 // containerPredicate define a predicate we want container to satisfy for filtering operations
 type containerPredicate func(c moby.Container) bool

--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"sort"
 
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
@@ -96,4 +97,11 @@ func (containers Containers) forEach(fn func(moby.Container)) {
 	for _, c := range containers {
 		fn(c)
 	}
+}
+
+func (containers Containers) sortByName() Containers {
+	sort.Slice(containers, func(i, j int) bool {
+		return getCanonicalContainerName(containers[i]) < getCanonicalContainerName(containers[j])
+	})
+	return containers
 }

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -64,7 +64,7 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 				service := c.Labels[serviceLabel]
 				options.Attach.Status(service, getCanonicalContainerName(c), fmt.Sprintf("exited with code %d", status.StatusCode))
 				if options.Listener != nil {
-					options.Listener <- compose.Event{
+					options.Listener <- compose.ContainerExited{
 						Service: service,
 						Status:  int(status.StatusCode),
 					}

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -62,7 +62,7 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 			select {
 			case status := <-statusC:
 				service := c.Labels[serviceLabel]
-				options.Attach.Status(service, getContainerNameWithoutProject(c), fmt.Sprintf("exited with code %d", status.StatusCode))
+				options.Attach.Status(service, getCanonicalContainerName(c), fmt.Sprintf("exited with code %d", status.StatusCode))
 				if options.Listener != nil {
 					options.Listener <- compose.Event{
 						Service: service,

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -18,25 +18,17 @@ package compose
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/docker/compose-cli/api/compose"
+	"github.com/sirupsen/logrus"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/docker/api/types/container"
-	"golang.org/x/sync/errgroup"
 )
 
 func (s *composeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	var containers Containers
 	if options.Attach != nil {
 		c, err := s.attach(ctx, project, options.Attach)
-		if err != nil {
-			return err
-		}
-		containers = c
-	} else {
-		c, err := s.getContainers(ctx, project)
 		if err != nil {
 			return err
 		}
@@ -54,26 +46,21 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 		return nil
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
 		c := c
-		eg.Go(func() error {
-			statusC, errC := s.apiClient.ContainerWait(ctx, c.ID, container.WaitConditionNotRunning)
+		go func() {
+			statusC, errC := s.apiClient.ContainerWait(context.Background(), c.ID, container.WaitConditionNotRunning)
 			select {
 			case status := <-statusC:
-				service := c.Labels[serviceLabel]
-				options.Attach.Status(service, getCanonicalContainerName(c), fmt.Sprintf("exited with code %d", status.StatusCode))
-				if options.Listener != nil {
-					options.Listener <- compose.ContainerExited{
-						Service: service,
-						Status:  int(status.StatusCode),
-					}
+				options.Attach <- compose.ContainerEvent{
+					Type:     compose.ContainerEventExit,
+					Source:   getCanonicalContainerName(c),
+					ExitCode: int(status.StatusCode),
 				}
-				return nil
 			case err := <-errC:
-				return err
+				logrus.Warnf("Unexpected API error for %s : %s\n", getCanonicalContainerName(c), err.Error())
 			}
-		})
+		}()
 	}
-	return eg.Wait()
+	return nil
 }

--- a/local/e2e/compose/cascade_stop_test.go
+++ b/local/e2e/compose/cascade_stop_test.go
@@ -1,0 +1,36 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+
+	. "github.com/docker/compose-cli/utils/e2e"
+)
+
+func TestCascadeStop(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	const projectName = "compose-e2e-logs"
+
+	res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
+	res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
+	res.Assert(t, icmd.Expected{Out: `ping_1 exited with code 0`})
+	res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
+}

--- a/local/e2e/compose/cascade_stop_test.go
+++ b/local/e2e/compose/cascade_stop_test.go
@@ -31,6 +31,8 @@ func TestCascadeStop(t *testing.T) {
 
 	res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
 	res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
-	res.Assert(t, icmd.Expected{Out: `ping_1 exited with code 0`})
+	res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
+	res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
 	res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
+	// FIXME res.Assert(t, icmd.Expected{ExitCode: 1})
 }

--- a/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
+++ b/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  ping:
+    image: busybox:1.27.2
+    command: ping localhost -c 1

--- a/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
+++ b/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
@@ -1,4 +1,7 @@
 services:
+  should_fail:
+    image: busybox:1.27.2
+    command: ls /does_not_exist
   ping:
     image: busybox:1.27.2
-    command: ping localhost -c 1
+    command: ping localhost


### PR DESCRIPTION
Introduce "--abort-on-container-exit"
use `ContainerWait` API to capture container termination and exit code, dump on console and cancel the context, which trigger `Stop` execution.

Note: 
The UX need some eextra improvement to remove duplicated stop-cause being reported
```
test4_1 exited with code 137 
Aborting on container exit...
Gracefully stopping...
[+] Running 4/4
 ⠿ Container truc_test2_1  Stopping                                                                                                                                    0.6s
 ⠿ Container truc_test4_1  Stopped                                                                                                                                      0.0s
 ⠿ Container truc_test3_1  Stopping                                                                                                                                     0.6s
 ⠿ Container truc_test1_1  Stopping      
```

**Related issue**
required to later implement https://github.com/docker/compose-cli/issues/1209

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
