### PR TITLE
Down warning when nothing to remove

### DIFF
--- a/api/progress/tty.go
+++ b/api/progress/tty.go
@@ -84,6 +84,9 @@ func (w *ttyWriter) Event(e Event) {
 	} else {
 		e.startTime = time.Now()
 		e.spinner = newSpinner()
+		if e.Status == Done || e.Status == Error {
+			e.stop()
+		}
 		w.events[e.ID] = e
 	}
 }


### PR DESCRIPTION
**What I did**
* Display a warning from local backend if `docker compose down` finds nothing to remove (no containers nor network)
```
[+] Running 1/0
 ⠿ sentences  Warning: No resource found to remove      
```

**Related issue**
`docker-compose` displays a warning on no network to remove in the same case (still exits with zero)

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
