### PR TITLE
Exit code from

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -60,7 +60,7 @@ func (cs *aciComposeService) Create(ctx context.Context, project *types.Project,
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (cs *aciComposeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -44,7 +44,7 @@ func (c *composeService) Create(ctx context.Context, project *types.Project, opt
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (c *composeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -65,10 +65,8 @@ type CreateOptions struct {
 
 // StartOptions group options of the Start API
 type StartOptions struct {
-	// Attach will attach to container and pipe stdout/stderr to LogConsumer
-	Attach LogConsumer
-	// Listener will get notified on container events
-	Listener chan ContainerExited
+	// Attach will attach to service containers and pipe stdout/stderr to channel
+	Attach chan ContainerEvent
 }
 
 // UpOptions group options of the Up API
@@ -185,11 +183,21 @@ type Stack struct {
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
 	Log(service, container, message string)
-	Status(service, container, message string)
+	Status(service, container, msg string)
 }
 
-// ContainerExited let us know a Container exited
-type ContainerExited struct {
-	Service string
-	Status  int
+// ContainerEvent notify an event has been collected on Source container implementing Service
+type ContainerEvent struct {
+	Type     int
+	Source   string
+	Service  string
+	Line     string
+	ExitCode int
 }
+
+const (
+	// ContainerEventLog is a ContainerEvent of type log. Line is set
+	ContainerEventLog = iota
+	// ContainerEventExit is a ContainerEvent of type exit. ExitCode is set
+	ContainerEventExit
+)

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -68,7 +68,7 @@ type StartOptions struct {
 	// Attach will attach to container and pipe stdout/stderr to LogConsumer
 	Attach LogConsumer
 	// Listener will get notified on container events
-	Listener Listener
+	Listener chan ContainerExited
 }
 
 // UpOptions group options of the Up API
@@ -188,11 +188,8 @@ type LogConsumer interface {
 	Status(service, container, message string)
 }
 
-// Listener get notified on container Events
-type Listener chan Event
-
-// Event let us know a Container exited
-type Event struct {
+// ContainerExited let us know a Container exited
+type ContainerExited struct {
 	Service string
 	Status  int
 }

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -67,8 +67,8 @@ type CreateOptions struct {
 type StartOptions struct {
 	// Attach will attach to container and pipe stdout/stderr to LogConsumer
 	Attach LogConsumer
-	// CascadeStop will run `Stop` on any container exit
-	CascadeStop bool
+	// Listener will get notified on container events
+	Listener Listener
 }
 
 // UpOptions group options of the Up API
@@ -185,5 +185,14 @@ type Stack struct {
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
 	Log(service, container, message string)
-	Exit(service, container string, exitCode int)
+	Status(service, container, message string)
+}
+
+// Listener get notified on container Events
+type Listener chan Event
+
+// Event let us know a Container exited
+type Event struct {
+	Service string
+	Status  int
 }

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -65,7 +65,7 @@ type CreateOptions struct {
 
 // StartOptions group options of the Start API
 type StartOptions struct {
-	// Attach will attach to service containers and pipe stdout/stderr to channel
+	// Attach will attach to service containers and send container logs and events
 	Attach ContainerEventListener
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -34,7 +34,7 @@ type Service interface {
 	// Create executes the equivalent to a `compose create`
 	Create(ctx context.Context, project *types.Project, opts CreateOptions) error
 	// Start executes the equivalent to a `compose start`
-	Start(ctx context.Context, project *types.Project, consumer LogConsumer) error
+	Start(ctx context.Context, project *types.Project, options StartOptions) error
 	// Stop executes the equivalent to a `compose stop`
 	Stop(ctx context.Context, project *types.Project) error
 	// Up executes the equivalent to a `compose up`
@@ -61,6 +61,14 @@ type CreateOptions struct {
 	RemoveOrphans bool
 	// Recreate define the strategy to apply on existing containers
 	Recreate string
+}
+
+// StartOptions group options of the Start API
+type StartOptions struct {
+	// Attach will attach to container and pipe stdout/stderr to LogConsumer
+	Attach LogConsumer
+	// CascadeStop will run `Stop` on any container exit
+	CascadeStop bool
 }
 
 // UpOptions group options of the Up API
@@ -177,4 +185,5 @@ type Stack struct {
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
 	Log(service, container, message string)
+	Exit(service, container string, exitCode int)
 }

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -66,7 +66,7 @@ type CreateOptions struct {
 // StartOptions group options of the Start API
 type StartOptions struct {
 	// Attach will attach to service containers and pipe stdout/stderr to channel
-	Attach chan ContainerEvent
+	Attach ContainerEventListener
 }
 
 // UpOptions group options of the Up API
@@ -185,6 +185,9 @@ type LogConsumer interface {
 	Log(service, container, message string)
 	Status(service, container, msg string)
 }
+
+// ContainerEventListener is a callback to process ContainerEvent from services
+type ContainerEventListener func(event ContainerEvent)
 
 // ContainerEvent notify an event has been collected on Source container implementing Service
 type ContainerEvent struct {

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -102,7 +102,7 @@ func startDependencies(ctx context.Context, c *client.Client, project *types.Pro
 	if err := c.ComposeService().Create(ctx, project, compose.CreateOptions{}); err != nil {
 		return err
 	}
-	if err := c.ComposeService().Start(ctx, project, nil); err != nil {
+	if err := c.ComposeService().Start(ctx, project, compose.StartOptions{}); err != nil {
 		return err
 	}
 	return nil

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -70,7 +70,9 @@ func runStart(ctx context.Context, opts startOptions, services []string) error {
 		queue: queue,
 	}
 	err = c.ComposeService().Start(ctx, project, compose.StartOptions{
-		Attach: queue,
+		Attach: func(event compose.ContainerEvent) {
+			queue <- event
+		},
 	})
 	if err != nil {
 		return err

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -18,14 +18,12 @@ package compose
 
 import (
 	"context"
-	"os"
-
-	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
-	"github.com/docker/compose-cli/cli/formatter"
+
+	"github.com/spf13/cobra"
 )
 
 type startOptions struct {
@@ -67,7 +65,23 @@ func runStart(ctx context.Context, opts startOptions, services []string) error {
 		return err
 	}
 
-	return c.ComposeService().Start(ctx, project, compose.StartOptions{
-		Attach: formatter.NewLogConsumer(ctx, os.Stdout),
+	queue := make(chan compose.ContainerEvent)
+	printer := printer{
+		queue: queue,
+	}
+	err = c.ComposeService().Start(ctx, project, compose.StartOptions{
+		Attach: queue,
 	})
+	if err != nil {
+		return err
+	}
+
+	_, err = printer.run(ctx, false, func() error {
+		ctx := context.Background()
+		_, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
+			return "", c.ComposeService().Stop(ctx, project)
+		})
+		return err
+	})
+	return err
 }

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -18,12 +18,12 @@ package compose
 
 import (
 	"context"
-	"github.com/docker/compose-cli/api/compose"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/formatter"
 )

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"github.com/docker/compose-cli/api/compose"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -61,10 +62,12 @@ func runStart(ctx context.Context, opts startOptions, services []string) error {
 
 	if opts.Detach {
 		_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-			return "", c.ComposeService().Start(ctx, project, nil)
+			return "", c.ComposeService().Start(ctx, project, compose.StartOptions{})
 		})
 		return err
 	}
 
-	return c.ComposeService().Start(ctx, project, formatter.NewLogConsumer(ctx, os.Stdout))
+	return c.ComposeService().Start(ctx, project, compose.StartOptions{
+		Attach: formatter.NewLogConsumer(ctx, os.Stdout),
+	})
 }

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -76,7 +76,7 @@ func runStart(ctx context.Context, opts startOptions, services []string) error {
 		return err
 	}
 
-	_, err = printer.run(ctx, false, func() error {
+	_, err = printer.run(ctx, false, "", func() error {
 		ctx := context.Background()
 		_, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
 			return "", c.ComposeService().Stop(ctx, project)

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -151,7 +151,7 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	listener := make(chan compose.Event)
+	listener := make(chan compose.ContainerExited)
 	go func() {
 		var aborting bool
 		for {

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -18,11 +18,11 @@ package compose
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/compose-cli/cli/formatter"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -151,47 +152,35 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	listener := make(chan compose.ContainerExited)
-	exitCode := make(chan int)
+	queue := make(chan compose.ContainerEvent)
+	printer := printer{
+		queue: queue,
+	}
+
+	stopFunc := func() error {
+		ctx := context.Background()
+		_, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
+			return "", c.ComposeService().Stop(ctx, project)
+		})
+		return err
+	}
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		var aborting bool
-		for {
-			exit := <-listener
-			if opts.cascadeStop && !aborting {
-				aborting = true
-				cancel()
-				exitCode <- exit.Status
-			}
-		}
+		<-signalChan
+		fmt.Println("Gracefully stopping...")
+		stopFunc() // nolint:errcheck
 	}()
 
 	err = c.ComposeService().Start(ctx, project, compose.StartOptions{
-		Attach:   formatter.NewLogConsumer(ctx, os.Stdout),
-		Listener: listener,
+		Attach: queue,
 	})
-
-	if errors.Is(ctx.Err(), context.Canceled) {
-		select {
-		case exit := <-exitCode:
-			fmt.Println("Aborting on container exit...")
-			err = stop(c, project)
-			logrus.Error(exit)
-			// os.Exit(exit)
-		default:
-			// cancelled by user
-			fmt.Println("Gracefully stopping...")
-			err = stop(c, project)
-		}
+	if err != nil {
+		return err
 	}
-	return err
-}
 
-func stop(c *client.Client, project *types.Project) error {
-	ctx := context.Background()
-	_, err := progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().Stop(ctx, project)
-	})
+	_, err = printer.run(ctx, opts.cascadeStop, stopFunc)
+	// FIXME os.Exit
 	return err
 }
 
@@ -234,4 +223,27 @@ func setup(ctx context.Context, opts composeOptions, services []string) (*client
 	}
 
 	return c, project, nil
+}
+
+type printer struct {
+	queue chan compose.ContainerEvent
+}
+
+func (p printer) run(ctx context.Context, cascadeStop bool, stopFn func() error) (int, error) { //nolint:unparam
+	consumer := formatter.NewLogConsumer(ctx, os.Stdout)
+	for {
+		event := <-p.queue
+		switch event.Type {
+		case compose.ContainerEventExit:
+			consumer.Status(event.Service, event.Source, fmt.Sprintf("exited with code %d", event.ExitCode))
+			if cascadeStop {
+				fmt.Println("Aborting on container exit...")
+				err := stopFn()
+				logrus.Error(event.ExitCode)
+				return event.ExitCode, err
+			}
+		case compose.ContainerEventLog:
+			consumer.Log(event.Service, event.Source, event.Line)
+		}
+	}
 }

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -129,7 +129,7 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 			return "", err
 		}
 		if opts.Detach {
-			err = c.ComposeService().Start(ctx, project, nil)
+			err = c.ComposeService().Start(ctx, project, compose.StartOptions{})
 		}
 		return "", err
 	})
@@ -145,7 +145,9 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 		return nil
 	}
 
-	err = c.ComposeService().Start(ctx, project, formatter.NewLogConsumer(ctx, os.Stdout))
+	err = c.ComposeService().Start(ctx, project, compose.StartOptions{
+		Attach: formatter.NewLogConsumer(ctx, os.Stdout),
+	})
 	if errors.Is(ctx.Err(), context.Canceled) {
 		fmt.Println("Gracefully stopping...")
 		ctx = context.Background()

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -133,6 +133,13 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 		return err
 	}
 
+	if opts.exitCodeFrom != "" {
+		_, err := project.GetService(opts.exitCodeFrom)
+		if err != nil {
+			return err
+		}
+	}
+
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
 		err := c.ComposeService().Create(ctx, project, compose.CreateOptions{
 			RemoveOrphans: opts.removeOrphans,

--- a/cli/cmd/exit.go
+++ b/cli/cmd/exit.go
@@ -1,0 +1,28 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cmd
+
+import "strconv"
+
+// ExitCodeError reports an exit code set by command.
+type ExitCodeError struct {
+	ExitCode int
+}
+
+func (e ExitCodeError) Error() string {
+	return strconv.Itoa(e.ExitCode)
+}

--- a/cli/formatter/logs.go
+++ b/cli/formatter/logs.go
@@ -53,7 +53,7 @@ func (l *logConsumer) Log(service, container, message string) {
 
 func (l *logConsumer) Status(service, container, msg string) {
 	cf := l.getColorFunc(service)
-	buf := bytes.NewBufferString(fmt.Sprintf("%s %s \n", cf(container), cf(msg)))
+	buf := bytes.NewBufferString(cf(fmt.Sprintf("%s %s\n", container, msg)))
 	l.writer.Write(buf.Bytes()) // nolint:errcheck
 }
 

--- a/cli/formatter/logs.go
+++ b/cli/formatter/logs.go
@@ -51,9 +51,10 @@ func (l *logConsumer) Log(service, container, message string) {
 	}
 }
 
-func (l *logConsumer) Exit(service, container string, exitCode int) {
-	msg := fmt.Sprintf("%s exited with code %d\n", container, exitCode)
-	l.writer.Write([]byte(l.getColorFunc(service)(msg)))
+func (l *logConsumer) Status(service, container, msg string) {
+	cf := l.getColorFunc(service)
+	buf := bytes.NewBufferString(fmt.Sprintf("%s %s \n", cf(container), cf(msg)))
+	l.writer.Write(buf.Bytes()) // nolint:errcheck
 }
 
 func (l *logConsumer) getColorFunc(service string) colorFunc {

--- a/cli/main.go
+++ b/cli/main.go
@@ -170,6 +170,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Unable to parse logging level: %s\n", opts.LogLevel)
 		os.Exit(1)
 	}
+	logrus.SetFormatter(&logrus.TextFormatter{
+		DisableTimestamp:       true,
+		DisableLevelTruncation: true,
+	})
 	logrus.SetLevel(level)
 	if opts.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
@@ -241,6 +245,11 @@ $ docker context create %s <name>`, cc.Type(), store.EcsContextType), ctype)
 }
 
 func exit(ctx string, err error, ctype string) {
+	if exit, ok := err.(cmd.ExitCodeError); ok {
+		metrics.Track(ctype, os.Args[1:], metrics.SuccessStatus)
+		os.Exit(exit.ExitCode)
+	}
+
 	metrics.Track(ctype, os.Args[1:], metrics.FailureStatus)
 
 	if errors.Is(err, errdefs.ErrLoginRequired) {

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -53,8 +53,8 @@ func (e ecsLocalSimulation) Create(ctx context.Context, project *types.Project, 
 	return e.compose.Create(ctx, enhanced, opts)
 }
 
-func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
-	return e.compose.Start(ctx, project, consumer)
+func (e ecsLocalSimulation) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
+	return e.compose.Start(ctx, project, options)
 }
 
 func (e ecsLocalSimulation) Stop(ctx context.Context, project *types.Project) error {

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -54,3 +54,9 @@ func (a *allowListLogConsumer) Log(service, container, message string) {
 		a.delegate.Log(service, container, message)
 	}
 }
+
+func (a *allowListLogConsumer) Exit(service, container string, exitCode int) {
+	if a.allowList[service] {
+		a.delegate.Exit(service, container, exitCode)
+	}
+}

--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -55,8 +55,8 @@ func (a *allowListLogConsumer) Log(service, container, message string) {
 	}
 }
 
-func (a *allowListLogConsumer) Exit(service, container string, exitCode int) {
+func (a *allowListLogConsumer) Status(service, container, message string) {
 	if a.allowList[service] {
-		a.delegate.Exit(service, container, exitCode)
+		a.delegate.Status(service, container, message)
 	}
 }

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -47,7 +47,7 @@ func (b *ecsAPIService) Create(ctx context.Context, project *types.Project, opts
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (b *ecsAPIService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,7 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -144,7 +144,7 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 }
 
 // Start executes the equivalent to a `compose start`
-func (s *composeService) Start(ctx context.Context, project *types.Project, consumer compose.LogConsumer) error {
+func (s *composeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -28,22 +28,14 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/stdcopy"
-	"golang.org/x/sync/errgroup"
 )
 
-func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.LogConsumer) (*errgroup.Group, error) {
-	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(
-			projectFilter(project.Name),
-		),
-		All: true,
-	})
+func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.LogConsumer) (Containers, error) {
+	containers, err := s.getContainers(ctx, project)
 	if err != nil {
 		return nil, err
 	}
-	containers = Containers(containers).filter(isService(project.ServiceNames()...))
 
 	var names []string
 	for _, c := range containers {
@@ -51,19 +43,15 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	}
 	fmt.Printf("Attaching to %s\n", strings.Join(names, ", "))
 
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, c := range containers {
-		container := c
-		eg.Go(func() error {
-			return s.attachContainer(ctx, container, consumer, project)
-		})
+	for _, container := range containers {
+		s.attachContainer(ctx, container, consumer, project)
 	}
-	return eg, nil
+	return containers, nil
 }
 
 func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.LogConsumer, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
-	w := utils.GetWriter(serviceName, getCanonicalContainerName(container), consumer)
+	w := getWriter(serviceName, getContainerNameWithoutProject(container), consumer)
 
 	service, err := project.GetService(serviceName)
 	if err != nil {
@@ -94,13 +82,15 @@ func (s *composeService) attachContainerStreams(ctx context.Context, container m
 	}
 
 	if w != nil {
-		if tty {
-			_, err = io.Copy(w, stdout)
-		} else {
-			_, err = stdcopy.StdCopy(w, w, stdout)
-		}
+		go func() {
+			if tty {
+				io.Copy(w, stdout) // nolint:errcheck
+			} else {
+				stdcopy.StdCopy(w, w, stdout) // nolint:errcheck
+			}
+		}()
 	}
-	return err
+	return nil
 }
 
 func (s *composeService) getContainerStreams(ctx context.Context, container moby.Container) (io.WriteCloser, io.ReadCloser, error) {

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -44,7 +44,10 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	fmt.Printf("Attaching to %s\n", strings.Join(names, ", "))
 
 	for _, container := range containers {
-		s.attachContainer(ctx, container, consumer, project)
+		err := s.attachContainer(ctx, container, consumer, project)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return containers, nil
 }

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -24,14 +24,13 @@ import (
 
 	"github.com/docker/compose-cli/api/compose"
 	convert "github.com/docker/compose-cli/local/moby"
-	"github.com/docker/compose-cli/utils"
 
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.LogConsumer) (Containers, error) {
+func (s *composeService) attach(ctx context.Context, project *types.Project, consumer chan compose.ContainerEvent) (Containers, error) {
 	containers, err := s.getContainers(ctx, project)
 	if err != nil {
 		return nil, err
@@ -52,7 +51,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	return containers, nil
 }
 
-func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.LogConsumer, project *types.Project) error {
+func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer chan compose.ContainerEvent, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
 	w := getWriter(serviceName, getContainerNameWithoutProject(container), consumer)
 

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -30,7 +30,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
-func (s *composeService) attach(ctx context.Context, project *types.Project, consumer chan compose.ContainerEvent) (Containers, error) {
+func (s *composeService) attach(ctx context.Context, project *types.Project, consumer compose.ContainerEventListener) (Containers, error) {
 	containers, err := s.getContainers(ctx, project)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	return containers, nil
 }
 
-func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer chan compose.ContainerEvent, project *types.Project) error {
+func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.ContainerEventListener, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
 	w := getWriter(serviceName, getContainerNameWithoutProject(container), consumer)
 

--- a/local/compose/compose.go
+++ b/local/compose/compose.go
@@ -55,6 +55,16 @@ func getCanonicalContainerName(c moby.Container) string {
 	return c.Names[0][1:]
 }
 
+func getContainerNameWithoutProject(c moby.Container) string {
+	name := getCanonicalContainerName(c)
+	project := c.Labels[projectLabel]
+	prefix := fmt.Sprintf("%s_%s_", project, c.Labels[serviceLabel])
+	if strings.HasPrefix(name, prefix) {
+		return name[len(project)+1:]
+	}
+	return name
+}
+
 func (s *composeService) Convert(ctx context.Context, project *types.Project, options compose.ConvertOptions) ([]byte, error) {
 	switch options.Format {
 	case "json":

--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"

--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -16,10 +16,30 @@
 
 package compose
 
-import moby "github.com/docker/docker/api/types"
+import (
+	"context"
+	"github.com/compose-spec/compose-go/types"
+	moby "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Containers is a set of moby Container
 type Containers []moby.Container
+
+func (s *composeService) getContainers(ctx context.Context, project *types.Project) (Containers, error) {
+	var containers Containers
+	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
+		Filters: filters.NewArgs(
+			projectFilter(project.Name),
+		),
+		All: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	containers = containers.filter(isService(project.ServiceNames()...))
+	return containers, nil
+}
 
 // containerPredicate define a predicate we want container to satisfy for filtering operations
 type containerPredicate func(c moby.Container) bool

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -90,11 +90,11 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 type splitBuffer struct {
 	service   string
 	container string
-	consumer  chan compose.ContainerEvent
+	consumer  compose.ContainerEventListener
 }
 
 // getWriter creates a io.Writer that will actually split by line and format by LogConsumer
-func getWriter(service, container string, events chan compose.ContainerEvent) io.Writer {
+func getWriter(service, container string, events compose.ContainerEventListener) io.Writer {
 	return splitBuffer{
 		service:   service,
 		container: container,
@@ -106,12 +106,12 @@ func (s splitBuffer) Write(b []byte) (n int, err error) {
 	split := bytes.Split(b, []byte{'\n'})
 	for _, line := range split {
 		if len(line) != 0 {
-			s.consumer <- compose.ContainerEvent{
+			s.consumer(compose.ContainerEvent{
 				Type:    compose.ContainerEventLog,
 				Service: s.service,
 				Source:  s.container,
 				Line:    string(line),
-			}
+			})
 		}
 	}
 	return len(b), nil

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -64,7 +64,7 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 				service := c.Labels[serviceLabel]
 				options.Attach.Status(service, getCanonicalContainerName(c), fmt.Sprintf("exited with code %d", status.StatusCode))
 				if options.Listener != nil {
-					options.Listener <- compose.Event{
+					options.Listener <- compose.ContainerExited{
 						Service: service,
 						Status:  int(status.StatusCode),
 					}

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -56,6 +56,7 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 				options.Attach <- compose.ContainerEvent{
 					Type:     compose.ContainerEventExit,
 					Source:   getCanonicalContainerName(c),
+					Service:  c.Labels[serviceLabel],
 					ExitCode: int(status.StatusCode),
 				}
 			case err := <-errC:

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -62,7 +62,7 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 			select {
 			case status := <-statusC:
 				service := c.Labels[serviceLabel]
-				options.Attach.Status(service, getContainerNameWithoutProject(c), fmt.Sprintf("exited with code %d", status.StatusCode))
+				options.Attach.Status(service, getCanonicalContainerName(c), fmt.Sprintf("exited with code %d", status.StatusCode))
 				if options.Listener != nil {
 					options.Listener <- compose.Event{
 						Service: service,

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -53,12 +53,12 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 			statusC, errC := s.apiClient.ContainerWait(context.Background(), c.ID, container.WaitConditionNotRunning)
 			select {
 			case status := <-statusC:
-				options.Attach <- compose.ContainerEvent{
+				options.Attach(compose.ContainerEvent{
 					Type:     compose.ContainerEventExit,
 					Source:   getCanonicalContainerName(c),
 					Service:  c.Labels[serviceLabel],
 					ExitCode: int(status.StatusCode),
-				}
+				})
 			case err := <-errC:
 				logrus.Warnf("Unexpected API error for %s : %s\n", getCanonicalContainerName(c), err.Error())
 			}

--- a/local/e2e/compose/cascade_stop_test.go
+++ b/local/e2e/compose/cascade_stop_test.go
@@ -1,0 +1,36 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+
+	. "github.com/docker/compose-cli/utils/e2e"
+)
+
+func TestCascadeStop(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	const projectName = "compose-e2e-logs"
+
+	res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
+	res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
+	res.Assert(t, icmd.Expected{Out: `ping_1 exited with code 0`})
+	res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
+}

--- a/local/e2e/compose/cascade_stop_test.go
+++ b/local/e2e/compose/cascade_stop_test.go
@@ -31,6 +31,8 @@ func TestCascadeStop(t *testing.T) {
 
 	res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
 	res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
-	res.Assert(t, icmd.Expected{Out: `ping_1 exited with code 0`})
+	res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
+	res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
 	res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
+	// FIXME res.Assert(t, icmd.Expected{ExitCode: 1})
 }

--- a/local/e2e/compose/cascade_stop_test.go
+++ b/local/e2e/compose/cascade_stop_test.go
@@ -30,20 +30,19 @@ func TestCascadeStop(t *testing.T) {
 	const projectName = "compose-e2e-logs"
 
 	t.Run("abort-on-container-exit", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
-		res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
-		res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
-		res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
-		res.Assert(t, icmd.Expected{Out: `ERROR 1`})
-		res.Assert(t, icmd.Expected{ExitCode: 1})
+		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
+		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `should_fail_1 exited with code 1`})
+		res.Assert(t, icmd.Expected{ExitCode: 1, Out: `Aborting on container exit...`})
 	})
 
 	t.Run("exit-code-from", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
-		res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
-		res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
-		res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
-		res.Assert(t, icmd.Expected{Out: `ERROR 143`})
-		res.Assert(t, icmd.Expected{ExitCode: 143})
+		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
+		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `should_fail_1 exited with code 1`})
+		res.Assert(t, icmd.Expected{ExitCode: 137, Out: `Aborting on container exit...`})
+	})
+
+	t.Run("exit-code-from unknown", func(t *testing.T) {
+		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=unknown")
+		res.Assert(t, icmd.Expected{ExitCode: 1, Err: `no such service: unknown`})
 	})
 }

--- a/local/e2e/compose/cascade_stop_test.go
+++ b/local/e2e/compose/cascade_stop_test.go
@@ -29,10 +29,21 @@ func TestCascadeStop(t *testing.T) {
 
 	const projectName = "compose-e2e-logs"
 
-	res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
-	res.Assert(t, icmd.Expected{Out: `PING localhost (127.0.0.1)`})
-	res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
-	res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
-	res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
-	// FIXME res.Assert(t, icmd.Expected{ExitCode: 1})
+	t.Run("abort-on-container-exit", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--abort-on-container-exit")
+		res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
+		res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
+		res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
+		res.Assert(t, icmd.Expected{Out: `ERROR 1`})
+		res.Assert(t, icmd.Expected{ExitCode: 1})
+	})
+
+	t.Run("exit-code-from", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/cascade-stop-test/compose.yaml", "--project-name", projectName, "up", "--exit-code-from=sleep")
+		res.Assert(t, icmd.Expected{Out: `/does_not_exist: No such file or directory`})
+		res.Assert(t, icmd.Expected{Out: `should_fail_1 exited with code 1`})
+		res.Assert(t, icmd.Expected{Out: `Aborting on container exit...`})
+		res.Assert(t, icmd.Expected{Out: `ERROR 143`})
+		res.Assert(t, icmd.Expected{ExitCode: 143})
+	})
 }

--- a/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
+++ b/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
@@ -2,6 +2,6 @@ services:
   should_fail:
     image: busybox:1.27.2
     command: ls /does_not_exist
-  ping:
+  sleep: # will be killed
     image: busybox:1.27.2
-    command: ping localhost
+    command: sleep 10

--- a/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
+++ b/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  ping:
+    image: busybox:1.27.2
+    command: ping localhost -c 1

--- a/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
+++ b/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
@@ -1,4 +1,7 @@
 services:
+  should_fail:
+    image: busybox:1.27.2
+    command: ls /does_not_exist
   ping:
     image: busybox:1.27.2
-    command: ping localhost -c 1
+    command: ping localhost

--- a/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
+++ b/local/e2e/compose/fixtures/cascade-stop-test/compose.yaml
@@ -4,4 +4,4 @@ services:
     command: ls /does_not_exist
   sleep: # will be killed
     image: busybox:1.27.2
-    command: sleep 10
+    command: ping localhost

--- a/utils/logconsumer.go
+++ b/utils/logconsumer.go
@@ -58,6 +58,12 @@ func (a *allowListLogConsumer) Log(service, container, message string) {
 	}
 }
 
+func (a *allowListLogConsumer) Status(service, container, message string) {
+	if a.allowList[service] {
+		a.delegate.Status(service, container, message)
+	}
+}
+
 type splitBuffer struct {
 	service   string
 	container string


### PR DESCRIPTION
**What I did**

Introduce "--abort-on-container-exit" and "--exit-code-from"
use ContainerWait API to capture container termination and exit code
changed architecture to pull logs and events from cli, so that we can easily react to "container exit" event

**Related issue**
replace https://github.com/docker/compose-cli/pull/1259
fix https://github.com/docker/compose-cli/issues/1209

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
