### PR TITLE
Compose orphans warning

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -73,7 +73,12 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 		return err
 	}
 
-	orphans := observedState.filter(isNotService(project.ServiceNames()...))
+	allServices := project.AllServices()
+	allServiceNames := []string{}
+	for _, service := range allServices {
+		allServiceNames = append(allServiceNames, service.Name)
+	}
+	orphans := observedState.filter(isNotService(allServiceNames...))
 	if len(orphans) > 0 {
 		if opts.RemoveOrphans {
 			w := progress.ContextWriter(ctx)

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -122,6 +122,12 @@ func TestLocalComposeRun(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/run-test/compose.yml", "run", "back")
 		lines := Lines(res.Stdout())
 		assert.Equal(t, lines[len(lines)-1], "Hello there!!", res.Stdout())
+		assert.Assert(t, !strings.Contains(res.Combined(), "orphan"))
+
+		res = c.RunDockerCmd("compose", "-f", "./fixtures/run-test/compose.yml", "run", "back", "echo", "Hello one more time")
+		lines = Lines(res.Stdout())
+		assert.Equal(t, lines[len(lines)-1], "Hello one more time", res.Stdout())
+		assert.Assert(t, !strings.Contains(res.Combined(), "orphan"))
 	})
 
 	t.Run("check run container exited", func(t *testing.T) {
@@ -156,10 +162,8 @@ func TestLocalComposeRun(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-f", "./fixtures/run-test/compose.yml", "run", "--rm", "back", "/bin/sh", "-c", "echo Hello again")
 		lines := Lines(res.Stdout())
 		assert.Equal(t, lines[len(lines)-1], "Hello again", res.Stdout())
-	})
 
-	t.Run("check run container removed", func(t *testing.T) {
-		res := c.RunDockerCmd("ps", "--all")
+		res = c.RunDockerCmd("ps", "--all")
 		assert.Assert(t, strings.Contains(res.Stdout(), "run-test_back"), res.Stdout())
 	})
 


### PR DESCRIPTION
**What I did**
* Fix orphans warning displayed when running `docker compose up SERVICE`
* Fix orphans warning displayed when running `docker compose run ...`

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1199

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
