### PR TITLE
detect stopped containers as "Created"

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -207,6 +207,6 @@ func (cs *aciComposeService) Kill(ctx context.Context, project *types.Project, o
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
-	return errdefs.ErrNotImplemented
+func (cs *aciComposeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {
+	return 0, errdefs.ErrNotImplemented
 }

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -80,6 +80,6 @@ func (c *composeService) Kill(ctx context.Context, project *types.Project, optio
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
-	return errdefs.ErrNotImplemented
+func (c *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {
+	return 0, errdefs.ErrNotImplemented
 }

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -52,7 +52,7 @@ type Service interface {
 	// Kill executes the equivalent to a `compose kill`
 	Kill(ctx context.Context, project *types.Project, options KillOptions) error
 	// RunOneOffContainer creates a service oneoff container and starts its dependencies
-	RunOneOffContainer(ctx context.Context, project *types.Project, opts RunOptions) error
+	RunOneOffContainer(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 }
 
 // CreateOptions group options of the Create API

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
+	"github.com/docker/compose-cli/cli/cmd"
 )
 
 type runOptions struct {
@@ -85,7 +86,11 @@ func runRun(ctx context.Context, opts runOptions) error {
 		Writer:     os.Stdout,
 		Reader:     os.Stdin,
 	}
-	return c.ComposeService().RunOneOffContainer(ctx, project, runOpts)
+	exitCode, err := c.ComposeService().RunOneOffContainer(ctx, project, runOpts)
+	if exitCode != 0 {
+		return cmd.ExitCodeError{ExitCode: exitCode}
+	}
+	return err
 }
 
 func startDependencies(ctx context.Context, c *client.Client, project types.Project, requestedServiceName string) error {

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -172,6 +172,6 @@ func (e ecsLocalSimulation) Ps(ctx context.Context, projectName string, options 
 func (e ecsLocalSimulation) List(ctx context.Context) ([]compose.Stack, error) {
 	return e.compose.List(ctx)
 }
-func (e ecsLocalSimulation) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
-	return errors.Wrap(errdefs.ErrNotImplemented, "use docker-compose run")
+func (e ecsLocalSimulation) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {
+	return 0, errors.Wrap(errdefs.ErrNotImplemented, "use docker-compose run")
 }

--- a/ecs/run.go
+++ b/ecs/run.go
@@ -25,6 +25,6 @@ import (
 	"github.com/docker/compose-cli/api/errdefs"
 )
 
-func (b *ecsAPIService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
-	return errdefs.ErrNotImplemented
+func (b *ecsAPIService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {
+	return 0, errdefs.ErrNotImplemented
 }

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -194,6 +194,6 @@ func (s *composeService) Kill(ctx context.Context, project *types.Project, optio
 }
 
 // RunOneOffContainer creates a service oneoff container and starts its dependencies
-func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
-	return errdefs.ErrNotImplemented
+func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {
+	return 0, errdefs.ErrNotImplemented
 }

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -114,7 +114,7 @@ func (s *composeService) getContainerStreams(ctx context.Context, container moby
 			Stdin:  true,
 			Stdout: true,
 			Stderr: true,
-			Logs:   true,
+			Logs:   false,
 		})
 		if err != nil {
 			return nil, nil, err

--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -114,6 +114,7 @@ func (s *composeService) ensureService(ctx context.Context, observedState Contai
 			w.Event(progress.RunningEvent(name))
 		case status.ContainerCreated:
 		case status.ContainerRestarting:
+		case status.ContainerExited:
 			w.Event(progress.CreatedEvent(name))
 		default:
 			eg.Go(func() error {


### PR DESCRIPTION
**What I did**
consider "exited" container from a previous run as "Created" so we just need to invoke _start_ 

**Related issue**
https://github.com/docker/compose-cli/issues/1289

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
