### PR TITLE
921 fix public subnet retrieval

### DIFF
--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -421,7 +421,7 @@ func (b *ecsAPIService) ensureVolumes(r *awsResources, project *types.Project, t
 	return nil
 }
 
-func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Project, template *cloudformation.Template) {
+func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Project, template *cloudformation.Template) error {
 	if r.loadBalancer != nil {
 		return
 	}
@@ -452,7 +452,7 @@ func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Proje
 
 	var publicSubNetIDs []string
 	for _, subNetID := range r.subnetsIDs() {
-        isPublic, err := b.aws.IsPublicSubnet(b.ctx, subNetID)
+        isPublic, err := b.aws.IsPublicSubnet(context.Background(), subNetID)
         if err != nil {
             return err
         }
@@ -474,6 +474,7 @@ func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Proje
 		nameProperty: "LoadBalancerName",
 	}
 	r.loadBalancerType = balancerType
+	return nil
 }
 
 func (r *awsResources) getLoadBalancerSecurityGroups(project *types.Project) []string {

--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -450,10 +450,21 @@ func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Proje
 			})
 	}
 
+	var publicSubNetIDs []string
+	for _, subNetID := range r.subnetsIDs() {
+        isPublic, err := b.aws.IsPublicSubnet(b.ctx, subNetID)
+        if err != nil {
+            return err
+        }
+        if isPublic {
+            publicSubNetIDs = append(publicSubNetIDs, subNetID)
+        }
+    }
+
 	template.Resources["LoadBalancer"] = &elasticloadbalancingv2.LoadBalancer{
 		Scheme:                 elbv2.LoadBalancerSchemeEnumInternetFacing,
 		SecurityGroups:         securityGroups,
-		Subnets:                r.subnetsIDs(),
+		Subnets:                publicSubNetIDs,
 		Tags:                   projectTags(project),
 		Type:                   balancerType,
 		LoadBalancerAttributes: loadBalancerAttributes,

--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -423,13 +423,13 @@ func (b *ecsAPIService) ensureVolumes(r *awsResources, project *types.Project, t
 
 func (b *ecsAPIService) ensureLoadBalancer(r *awsResources, project *types.Project, template *cloudformation.Template) error {
 	if r.loadBalancer != nil {
-		return
+		return nil
 	}
 	if allServices(project.Services, func(it types.ServiceConfig) bool {
 		return len(it.Ports) == 0
 	}) {
 		logrus.Debug("Application does not expose any public port, so no need for a LoadBalancer")
-		return
+		return nil
 	}
 
 	balancerType := getRequiredLoadBalancerType(project)

--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -222,7 +222,7 @@ func (b *ecsAPIService) parseVPCExtension(ctx context.Context, project *types.Pr
 	}
 
 	r.vpc = vpc
-	r.subnets = publicSubNets
+	r.subnets = subNets
 	return nil
 }
 


### PR DESCRIPTION
**What I did**
Ensure Loadbalancer is created in public subnets only

**Related issue**
fixes #921 and improves #1064 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
test-ecs 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
