### PR TITLE
introduce create --force-recreate and --no-recreate

### DIFF
--- a/cli/cmd/compose/create.go
+++ b/cli/cmd/compose/create.go
@@ -22,6 +22,8 @@ import (
 
 type createOptions struct {
 	*composeOptions
+	forceRecreate bool
+	noRecreate    bool
 }
 
 func createCommand(p *projectOptions) *cobra.Command {
@@ -37,11 +39,15 @@ func createCommand(p *projectOptions) *cobra.Command {
 					projectOptions: p,
 					Build:          opts.Build,
 				},
-				noStart: true,
+				noStart:       true,
+				forceRecreate: opts.forceRecreate,
+				noRecreate:    opts.noRecreate,
 			}, args)
 		},
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.Build, "build", false, "Build images before starting containers.")
+	flags.BoolVar(&opts.forceRecreate, "force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
+	flags.BoolVar(&opts.noRecreate, "no-recreate", false, "If containers already exist, don't recreate them. Incompatible with --force-recreate.")
 	return cmd
 }


### PR DESCRIPTION
**What I did**

added --force-recreate and --no-recreate flags to create command
implementation code already exists on up

**Related issue**
https://github.com/docker/compose-cli/issues/1277

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/107926004-77669380-6f75-11eb-9e54-ad8a9a495715.png)
