### PR TITLE
fix color assignment on status messages

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -182,9 +182,9 @@ type Stack struct {
 
 // LogConsumer is a callback to process log messages from services
 type LogConsumer interface {
-	Log(service, container, message string)
-	Status(service, container, msg string)
-	Register(service string, source string)
+	Log(name, container, message string)
+	Status(name, container, msg string)
+	Register(name string, source string)
 }
 
 // ContainerEventListener is a callback to process ContainerEvent from services
@@ -195,6 +195,7 @@ type ContainerEvent struct {
 	Type     int
 	Source   string
 	Service  string
+	Name     string
 	Line     string
 	ExitCode int
 }

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -320,11 +320,11 @@ func (p printer) run(ctx context.Context, cascadeStop bool, exitCodeFrom string,
 		event := <-p.queue
 		switch event.Type {
 		case compose.ContainerEventAttach:
-			consumer.Register(event.Service, event.Source)
+			consumer.Register(event.Name, event.Source)
 			count++
 		case compose.ContainerEventExit:
 			if !aborting {
-				consumer.Status(event.Service, event.Source, fmt.Sprintf("exited with code %d", event.ExitCode))
+				consumer.Status(event.Name, event.Source, fmt.Sprintf("exited with code %d", event.ExitCode))
 			}
 			if cascadeStop {
 				if !aborting {
@@ -347,7 +347,7 @@ func (p printer) run(ctx context.Context, cascadeStop bool, exitCodeFrom string,
 			}
 		case compose.ContainerEventLog:
 			if !aborting {
-				consumer.Log(event.Service, event.Source, event.Line)
+				consumer.Log(event.Name, event.Source, event.Line)
 			}
 		}
 	}

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -48,7 +48,8 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 	for _, container := range containers {
 		consumer(compose.ContainerEvent{
 			Type:    compose.ContainerEventAttach,
-			Source:  getContainerNameWithoutProject(container),
+			Source:  container.ID,
+			Name:    getContainerNameWithoutProject(container),
 			Service: container.Labels[serviceLabel],
 		})
 		err := s.attachContainer(ctx, container, consumer, project)
@@ -61,7 +62,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, con
 
 func (s *composeService) attachContainer(ctx context.Context, container moby.Container, consumer compose.ContainerEventListener, project *types.Project) error {
 	serviceName := container.Labels[serviceLabel]
-	w := getWriter(serviceName, getContainerNameWithoutProject(container), consumer)
+	w := getWriter(getContainerNameWithoutProject(container), serviceName, container.ID, consumer)
 
 	service, err := project.GetService(serviceName)
 	if err != nil {

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -88,14 +88,16 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 }
 
 type splitBuffer struct {
-	service   string
+	name      string
 	container string
 	consumer  compose.ContainerEventListener
+	service   string
 }
 
 // getWriter creates a io.Writer that will actually split by line and format by LogConsumer
-func getWriter(service, container string, events compose.ContainerEventListener) io.Writer {
+func getWriter(name, service, container string, events compose.ContainerEventListener) io.Writer {
 	return splitBuffer{
+		name:      name,
 		service:   service,
 		container: container,
 		consumer:  events,
@@ -108,6 +110,7 @@ func (s splitBuffer) Write(b []byte) (n int, err error) {
 		if len(line) != 0 {
 			s.consumer(compose.ContainerEvent{
 				Type:    compose.ContainerEventLog,
+				Name:    s.name,
 				Service: s.service,
 				Source:  s.container,
 				Line:    string(line),

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -55,7 +55,8 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 			case status := <-statusC:
 				options.Attach(compose.ContainerEvent{
 					Type:     compose.ContainerEventExit,
-					Source:   getCanonicalContainerName(c),
+					Source:   c.ID,
+					Name:     getCanonicalContainerName(c),
 					Service:  c.Labels[serviceLabel],
 					ExitCode: int(status.StatusCode),
 				})


### PR DESCRIPTION
**What I did**
fix color assignment for status message.
container status `xxx exited with code 123` use full container name, while logs use container name without project.
As a side effect, a distinct color is assigned to status message.

This PR changes the container -> color map to rely on container ID, and pass the resource name as part of the event to distinguish both usages

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/107933672-599e2c00-6f7f-11eb-8f45-b2ee86f97440.png)
