### PR TITLE
introduce logs --timestamp

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -178,9 +178,10 @@ type ServiceStatus struct {
 
 // LogOptions defines optional parameters for the `Log` API
 type LogOptions struct {
-	Services []string
-	Tail     string
-	Follow   bool
+	Services   []string
+	Tail       string
+	Follow     bool
+	Timestamps bool
 }
 
 const (

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -31,10 +31,11 @@ import (
 type logsOptions struct {
 	*projectOptions
 	composeOptions
-	follow   bool
-	tail     string
-	noColor  bool
-	noPrefix bool
+	follow     bool
+	tail       string
+	noColor    bool
+	noPrefix   bool
+	timestamps bool
 }
 
 func logsCommand(p *projectOptions, contextType string) *cobra.Command {
@@ -52,6 +53,7 @@ func logsCommand(p *projectOptions, contextType string) *cobra.Command {
 	flags.BoolVar(&opts.follow, "follow", false, "Follow log output.")
 	flags.BoolVar(&opts.noColor, "no-color", false, "Produce monochrome output.")
 	flags.BoolVar(&opts.noPrefix, "no-log-prefix", false, "Don't print prefix in logs.")
+	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps.")
 
 	if contextType == store.DefaultContextType {
 		flags.StringVar(&opts.tail, "tail", "all", "Number of lines to show from the end of the logs for each container.")
@@ -74,5 +76,6 @@ func runLogs(ctx context.Context, opts logsOptions, services []string) error {
 		Services: services,
 		Follow:   opts.follow,
 		Tail:     opts.tail,
+		Timestamps: opts.timestamps,
 	})
 }

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -68,6 +68,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 				ShowStderr: true,
 				Follow:     options.Follow,
 				Tail:       options.Tail,
+				Timestamps: options.Timestamps,
 			})
 			defer r.Close() // nolint errcheck
 
@@ -76,7 +77,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 			}
 			name := getContainerNameWithoutProject(c)
 			w := utils.GetWriter(name, service, c.ID, func(event compose.ContainerEvent) {
-				consumer.Log(event.Service, event.Name, event.Line)
+				consumer.Log(name, event.Name, event.Line)
 			})
 			if container.Config.Tty {
 				_, err = io.Copy(w, r)


### PR DESCRIPTION
**What I did**
Introduced `--timestamps` option on `compose logs`

**Related issue**
https://github.com/docker/compose-cli/issues/1272

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
