### PR TITLE
os ENV has precedence over env file

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -83,9 +83,9 @@ func (o *projectOptions) toProject(services []string) (*types.Project, error) {
 
 func (o *projectOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 	return cli.NewProjectOptions(o.ConfigPaths,
-		cli.WithOsEnv,
 		cli.WithEnvFile(o.EnvFile),
 		cli.WithDotEnv,
+		cli.WithOsEnv,
 		cli.WithWorkingDirectory(o.WorkingDir),
 		cli.WithName(o.ProjectName))
 }


### PR DESCRIPTION
**What I did**
fixed os.ENV precendence over env file

**Related issue**
https://github.com/docker/compose-cli/issues/1327

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
