### PR TITLE
introduce pause and unpause commands

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -68,6 +68,14 @@ func (cs *aciComposeService) Stop(ctx context.Context, project *types.Project, o
 	return errdefs.ErrNotImplemented
 }
 
+func (cs *aciComposeService) Pause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (cs *aciComposeService) UnPause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
 func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
 	logrus.Debugf("Up on project with name %q", project.Name)
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -91,3 +91,11 @@ func (c *composeService) Remove(ctx context.Context, project *types.Project, opt
 func (c *composeService) Exec(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
 	return errdefs.ErrNotImplemented
 }
+
+func (c *composeService) Pause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (c *composeService) UnPause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -58,6 +58,10 @@ type Service interface {
 	Remove(ctx context.Context, project *types.Project, options RemoveOptions) ([]string, error)
 	// Exec executes a command in a running service container
 	Exec(ctx context.Context, project *types.Project, opts RunOptions) error
+	// Pause executes the equivalent to a `compose pause`
+	Pause(ctx context.Context, project *types.Project) error
+	// UnPause executes the equivalent to a `compose unpause`
+	UnPause(ctx context.Context, project *types.Project) error
 }
 
 // CreateOptions group options of the Create API

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -118,6 +118,8 @@ func Command(contextType string) *cobra.Command {
 		runCommand(&opts),
 		removeCommand(&opts),
 		execCommand(&opts),
+		pauseCommand(&opts),
+		unpauseCommand(&opts),
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {

--- a/cli/cmd/compose/pause.go
+++ b/cli/cmd/compose/pause.go
@@ -1,0 +1,96 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/progress"
+)
+
+type pauseOptions struct {
+	*projectOptions
+}
+
+func pauseCommand(p *projectOptions) *cobra.Command {
+	opts := pauseOptions{
+		projectOptions: p,
+	}
+	cmd := &cobra.Command{
+		Use:   "pause [SERVICE...]",
+		Short: "pause services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPause(cmd.Context(), opts, args)
+		},
+	}
+	return cmd
+}
+
+func runPause(ctx context.Context, opts pauseOptions, services []string) error {
+	c, err := client.NewWithDefaultLocalBackend(ctx)
+	if err != nil {
+		return err
+	}
+
+	project, err := opts.toProject(services)
+	if err != nil {
+		return err
+	}
+
+	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
+		return "", c.ComposeService().Pause(ctx, project)
+	})
+	return err
+}
+
+type unpauseOptions struct {
+	*projectOptions
+}
+
+func unpauseCommand(p *projectOptions) *cobra.Command {
+	opts := unpauseOptions{
+		projectOptions: p,
+	}
+	cmd := &cobra.Command{
+		Use:   "unpause [SERVICE...]",
+		Short: "unpause services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUnPause(cmd.Context(), opts, args)
+		},
+	}
+	return cmd
+}
+
+func runUnPause(ctx context.Context, opts unpauseOptions, services []string) error {
+	c, err := client.NewWithDefaultLocalBackend(ctx)
+	if err != nil {
+		return err
+	}
+
+	project, err := opts.toProject(services)
+	if err != nil {
+		return err
+	}
+
+	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
+		return "", c.ComposeService().UnPause(ctx, project)
+	})
+	return err
+}

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -183,3 +183,11 @@ func (e ecsLocalSimulation) Remove(ctx context.Context, project *types.Project, 
 func (e ecsLocalSimulation) Exec(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
 	return errdefs.ErrNotImplemented
 }
+
+func (e ecsLocalSimulation) Pause(ctx context.Context, project *types.Project) error {
+	return e.compose.Pause(ctx, project)
+}
+
+func (e ecsLocalSimulation) UnPause(ctx context.Context, project *types.Project) error {
+	return e.compose.UnPause(ctx, project)
+}

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -55,6 +55,14 @@ func (b *ecsAPIService) Stop(ctx context.Context, project *types.Project, option
 	return errdefs.ErrNotImplemented
 }
 
+func (b *ecsAPIService) Pause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (b *ecsAPIService) UnPause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
 func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
 	logrus.Debugf("deploying on AWS with region=%q", b.Region)
 	err := b.aws.CheckRequirements(ctx, b.Region)

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -206,3 +206,11 @@ func (s *composeService) Remove(ctx context.Context, project *types.Project, opt
 func (s *composeService) Exec(ctx context.Context, project *types.Project, opts compose.RunOptions) error {
 	return errdefs.ErrNotImplemented
 }
+
+func (s *composeService) Pause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}
+
+func (s *composeService) UnPause(ctx context.Context, project *types.Project) error {
+	return errdefs.ErrNotImplemented
+}

--- a/local/compose/pause.go
+++ b/local/compose/pause.go
@@ -1,0 +1,71 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+
+	"github.com/compose-spec/compose-go/types"
+	moby "github.com/docker/docker/api/types"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose-cli/api/progress"
+)
+
+func (s *composeService) Pause(ctx context.Context, project *types.Project) error {
+	containers, err := s.getContainers(ctx, project, oneOffExclude)
+	if err != nil {
+		return err
+	}
+
+	w := progress.ContextWriter(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
+	containers.forEach(func(container moby.Container) {
+		eg.Go(func() error {
+			err := s.apiClient.ContainerPause(ctx, container.ID)
+			if err == nil {
+				eventName := getContainerProgressName(container)
+				w.Event(progress.NewEvent(eventName, progress.Done, "Paused"))
+			}
+			return err
+		})
+
+	})
+	return eg.Wait()
+}
+
+func (s *composeService) UnPause(ctx context.Context, project *types.Project) error {
+	containers, err := s.getContainers(ctx, project, oneOffExclude)
+	if err != nil {
+		return err
+	}
+
+	w := progress.ContextWriter(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
+	containers.forEach(func(container moby.Container) {
+		eg.Go(func() error {
+			err = s.apiClient.ContainerUnpause(ctx, container.ID)
+			if err == nil {
+				eventName := getContainerProgressName(container)
+				w.Event(progress.NewEvent(eventName, progress.Done, "Unpaused"))
+			}
+			return err
+		})
+
+	})
+	return eg.Wait()
+}


### PR DESCRIPTION
**What I did**
Introduced `compose pause` and `compose unpause` commands for parity with docker-compose

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
