### PR TITLE
Fixes GH Action config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           go-version: 1.16
         id: go
+
+      - name: Set up gosum
         run: |
           go get -u gotest.tools/gotestsum
 


### PR DESCRIPTION


**What I did**

**Related issue**
https://github.com/docker/compose-cli/actions/runs/588864117

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
