### PR TITLE
Fix linter

### DIFF
--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -73,9 +73,9 @@ func runLogs(ctx context.Context, opts logsOptions, services []string) error {
 	}
 	consumer := formatter.NewLogConsumer(ctx, os.Stdout, !opts.noColor, !opts.noPrefix)
 	return c.ComposeService().Logs(ctx, projectName, consumer, compose.LogOptions{
-		Services: services,
-		Follow:   opts.follow,
-		Tail:     opts.tail,
+		Services:   services,
+		Follow:     opts.follow,
+		Tail:       opts.tail,
 		Timestamps: opts.timestamps,
 	})
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
is in the title

**Related issue**
https://github.com/docker/compose-cli/runs/1952730636

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
