### PR TITLE
Add make install to symlink cli from `make cli`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ifeq ($(UNAME_S),Darwin)
 	MOBY_DOCKER=/Applications/Docker.app/Contents/Resources/bin/docker
 endif
 
+BINARY_FOLDER=$(shell pwd)/bin
 GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
 TEST_FLAGS?=
 E2E_TEST?=
@@ -91,6 +92,9 @@ serve: cli ## start server
 
 moby-cli-link: ## Create com.docker.cli symlink if does not already exist
 	ln -s $(MOBY_DOCKER) /usr/local/bin/com.docker.cli
+
+install: ## Link /usr/local/bin/ to current binary
+	ln -fs $(BINARY_FOLDER)/docker /usr/local/bin/docker
 
 validate-headers: ## Check license header for all files
 	@docker build . --target check-license-headers


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
