### PR TITLE
Allow `docker compose logs -f` for compatibility

### DIFF
--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -50,7 +50,7 @@ func logsCommand(p *projectOptions, contextType string) *cobra.Command {
 		},
 	}
 	flags := logsCmd.Flags()
-	flags.BoolVar(&opts.follow, "follow", false, "Follow log output.")
+	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output.")
 	flags.BoolVar(&opts.noColor, "no-color", false, "Produce monochrome output.")
 	flags.BoolVar(&opts.noPrefix, "no-log-prefix", false, "Don't print prefix in logs.")
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps.")


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
add `f` shorthand for `docker compose --follow`

**Related issue**
Fixes #1060 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
