### PR TITLE
Fix sidecar Dockerfiles : Go 1.16 uses go modules by default

### DIFF
--- a/aci/etchosts/Dockerfile
+++ b/aci/etchosts/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.16 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/aci/etchosts
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/hosts main/main.go
+RUN GO111MODULE=auto CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/hosts main/main.go
 
 FROM scratch
 COPY --from=builder /go/bin/hosts /hosts

--- a/ecs/resolv/Dockerfile
+++ b/ecs/resolv/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.16 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/resolv
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/resolv main/main.go
+RUN GO111MODULE=auto CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/resolv main/main.go
 
 FROM scratch
 COPY --from=builder /go/bin/resolv /resolv

--- a/ecs/secrets/Dockerfile
+++ b/ecs/secrets/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.16 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/secrets
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/secrets main/main.go
+RUN GO111MODULE=auto CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/secrets main/main.go
 
 FROM scratch
 COPY --from=builder /go/bin/secrets /secrets


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
setting GO111MODULE=auto to let it detect, and run as before
(cf https://blog.golang.org/go116-module-changes)

**Related issue**
red CI on main

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
