### PR TITLE
only display experimental warning on command error

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -17,8 +17,6 @@
 package compose
 
 import (
-	"fmt"
-
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
@@ -26,6 +24,9 @@ import (
 
 	"github.com/docker/compose-cli/api/context/store"
 )
+
+// Warning is a global warning to be displayed to user on command failure
+var Warning string
 
 type projectOptions struct {
 	ProjectName string
@@ -99,7 +100,8 @@ func Command(contextType string) *cobra.Command {
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if contextType == store.DefaultContextType || contextType == store.LocalContextType {
-				fmt.Println("The new 'docker compose' command is currently experimental. To provide feedback or request new features please open issues at https://github.com/docker/compose-cli")
+				Warning = "The new 'docker compose' command is currently experimental. " +
+					"To provide feedback or request new features please open issues at https://github.com/docker/compose-cli"
 			}
 			return nil
 		},

--- a/cli/main.go
+++ b/cli/main.go
@@ -258,6 +258,11 @@ func exit(ctx string, err error, ctype string) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(errdefs.ExitCodeLoginRequired)
 	}
+
+	if compose.Warning != "" {
+		fmt.Fprintln(os.Stderr, compose.Warning)
+	}
+
 	if errors.Is(err, errdefs.ErrNotImplemented) {
 		name := metrics.GetCommand(os.Args[1:])
 		fmt.Fprintf(os.Stderr, "Command %q not available in current context (%s)\n", name, ctx)


### PR DESCRIPTION
**What I did**
only display experimental warning when compose command fails

note: cobra directly return on error, PersistentPostRun is not executed, so I eventually used a global variable :'(

**Related issue**
https://github.com/docker/compose-cli/issues/1108
