### PR TITLE
introduce a few more `compose run` options

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/compose-spec/compose-go/types"
@@ -130,20 +131,38 @@ type RemoveOptions struct {
 
 // RunOptions options to execute compose run
 type RunOptions struct {
-	Service    string
-	Command    []string
-	Detach     bool
-	AutoRemove bool
-	Writer     io.Writer
-	Reader     io.Reader
-
-	// used by exec
+	Name        string
+	Service     string
+	Command     []string
+	Entrypoint  []string
+	Detach      bool
+	AutoRemove  bool
+	Writer      io.Writer
+	Reader      io.Reader
 	Tty         bool
 	WorkingDir  string
 	User        string
 	Environment []string
+	Labels      types.Labels
 	Privileged  bool
-	Index       int
+	// used by exec
+	Index int
+}
+
+// EnvironmentMap return RunOptions.Environment as a MappingWithEquals
+func (opts *RunOptions) EnvironmentMap() types.MappingWithEquals {
+	environment := types.MappingWithEquals{}
+	for _, s := range opts.Environment {
+		parts := strings.SplitN(s, "=", 2)
+		key := parts[0]
+		switch {
+		case len(parts) == 1:
+			environment[key] = nil
+		default:
+			environment[key] = &parts[1]
+		}
+	}
+	return environment
 }
 
 // PsOptions group options of the Ps API

--- a/api/compose/api_test.go
+++ b/api/compose/api_test.go
@@ -1,0 +1,37 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRunOptionsEnvironmentMap(t *testing.T) {
+	opts := RunOptions{
+		Environment: []string{
+			"FOO=BAR",
+			"ZOT=",
+			"QIX",
+		},
+	}
+	env := opts.EnvironmentMap()
+	assert.Equal(t, *env["FOO"], "BAR")
+	assert.Equal(t, *env["ZOT"], "")
+	assert.Check(t, env["QIX"] == nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/mattn/go-shellwords v1.0.11
 	github.com/moby/buildkit v0.8.1-0.20201205083753-0af7b1b9c693
 	github.com/moby/term v0.0.0-20201110203204-bea5bbe245bf
 	github.com/morikuni/aec v1.0.0


### PR DESCRIPTION
**What I did**
extended compose run with a few more options

*  --name NAME Assign a name to the container
* --entrypoint CMD Override the entrypoint of the image.
* -e KEY=VAL Set an environment variable (can be used multiple times)
* -l, --label KEY=VAL Add or override a label (can be used multiple times)
* -u, --user="" Run as specified username or uid
* -T Disable pseudo-tty allocation. By default docker-compose run allocates a TTY.
* -w, --workdir="" Working directory inside the container

