### PR TITLE
Stop displaying logs when user cancels compose up, to not mix with stop progress display

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -266,4 +266,6 @@ const (
 	ContainerEventAttach
 	// ContainerEventExit is a ContainerEvent of type exit. ExitCode is set
 	ContainerEventExit
+	// UserCancel user cancelled compose up, we are stopping containers
+	UserCancel
 )

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -205,6 +205,9 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-signalChan
+		queue <- compose.ContainerEvent{
+			Type: compose.UserCancel,
+		}
 		fmt.Println("Gracefully stopping...")
 		stopFunc() // nolint:errcheck
 	}()
@@ -332,6 +335,8 @@ func (p printer) run(ctx context.Context, cascadeStop bool, exitCodeFrom string,
 	for {
 		event := <-p.queue
 		switch event.Type {
+		case compose.UserCancel:
+			aborting = true
 		case compose.ContainerEventAttach:
 			consumer.Register(event.Name, event.Source)
 			count++


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
sync stop on user cancel with container logs display

**Related issue**
Fixes #1342 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
