### PR TITLE
Fix CI

### DIFF
--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -160,7 +160,7 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 	}
 
 	if opts.noDeps {
-		enabled, err := project.GetServices(services)
+		enabled, err := project.GetServices(services...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
...

**Related issue**
https://github.com/docker/compose-cli/runs/1962755914#step:7:14

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
