### PR TITLE
trying to better work around ACI flaky weird states

### DIFF
--- a/aci/e2e/e2e-aci_test.go
+++ b/aci/e2e/e2e-aci_test.go
@@ -486,7 +486,7 @@ func TestContainerRunAttached(t *testing.T) {
 				c.RunDockerCmd("rm", "-f", container)
 			}
 			c.RunDockerCmd("run",
-				"--name", container,
+				"--name", "fallback", // don't reuse the container name, this container is in a weird state and blocks everything
 				"--memory", "0.1G", "--cpus", "0.1",
 				"nginx")
 		} else {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
do not reuse ACI container name when trying to workaround flaky ACI issue

**Related issue**
https://github.com/docker/compose-cli/runs/1963218029#step:9:256

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-windows
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
