### PR TITLE
ACI workaround invocation does not return, but container is actually running OK, trying to not block on this.

### DIFF
--- a/aci/e2e/e2e-aci_test.go
+++ b/aci/e2e/e2e-aci_test.go
@@ -485,10 +485,14 @@ func TestContainerRunAttached(t *testing.T) {
 				time.Sleep(1 * time.Second)
 				c.RunDockerCmd("rm", "-f", container)
 			}
-			c.RunDockerCmd("run",
-				"--name", "fallback", // don't reuse the container name, this container is in a weird state and blocks everything
-				"--memory", "0.1G", "--cpus", "0.1",
-				"nginx")
+			go func() { // this specific call to run sometimes does not come back when in this weird state, but the container is actually running fine
+				c.RunDockerCmd("run",
+					"--name", container, // don't reuse the container name, this container is in a weird state and blocks everything
+					"--memory", "0.1G", "--cpus", "0.1",
+					"nginx")
+				fmt.Printf("	[%s] Finished docker run %s\n", t.Name(), container)
+			}()
+			waitForStatus(t, c, container, convert.StatusRunning)
 		} else {
 			res.Assert(t, icmd.Expected{Out: container})
 			waitForStatus(t, c, container, convert.StatusRunning)

--- a/aci/e2e/e2e-aci_test.go
+++ b/aci/e2e/e2e-aci_test.go
@@ -977,7 +977,10 @@ func getContainerName(stdout string) string {
 
 func waitForStatus(t *testing.T, c *E2eCLI, containerID string, statuses ...string) {
 	checkStopped := func(logt poll.LogT) poll.Result {
-		res := c.RunDockerCmd("inspect", containerID)
+		res := c.RunDockerOrExitError("inspect", containerID)
+		if res.Error != nil {
+			return poll.Continue("Error while inspecting container %s: %s", containerID, res.Combined())
+		}
 		containerInspect, err := parseContainerInspect(res.Stdout())
 		assert.NilError(t, err)
 		for _, status := range statuses {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* invoke ACI `docker run` workaround async and wait for the container to be running, as the run call is not returning in this crappy state

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-windows

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
