### PR TITLE
Fix --project-directory mix with --workdir

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -32,7 +32,7 @@ type projectOptions struct {
 	ProjectName string
 	Profiles    []string
 	ConfigPaths []string
-	WorkingDir  string
+	ProjectDir  string
 	EnvFile     string
 }
 
@@ -41,8 +41,7 @@ func (o *projectOptions) addProjectFlags(f *pflag.FlagSet) {
 	f.StringVarP(&o.ProjectName, "project-name", "p", "", "Project name")
 	f.StringArrayVarP(&o.ConfigPaths, "file", "f", []string{}, "Compose configuration files")
 	f.StringVar(&o.EnvFile, "env-file", "", "Specify an alternate environment file.")
-	f.StringVar(&o.WorkingDir, "workdir", "", "Specify an alternate working directory")
-	// TODO make --project-directory an alias
+	f.StringVar(&o.ProjectDir, "project-directory", "", "Specify an alternate working directory\n(default: the path of the Compose file)")
 }
 
 func (o *projectOptions) toProjectName() (string, error) {
@@ -87,7 +86,7 @@ func (o *projectOptions) toProjectOptions() (*cli.ProjectOptions, error) {
 		cli.WithEnvFile(o.EnvFile),
 		cli.WithDotEnv,
 		cli.WithOsEnv,
-		cli.WithWorkingDirectory(o.WorkingDir),
+		cli.WithWorkingDirectory(o.ProjectDir),
 		cli.WithName(o.ProjectName))
 }
 

--- a/local/e2e/compose/compose_build_test.go
+++ b/local/e2e/compose/compose_build_test.go
@@ -36,7 +36,7 @@ func TestLocalComposeBuild(t *testing.T) {
 		c.RunDockerOrExitError("rmi", "build-test_nginx")
 		c.RunDockerOrExitError("rmi", "custom-nginx")
 
-		res := c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "build")
+		res := c.RunDockerCmd("compose", "--project-directory", "fixtures/build-test", "build")
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
 		c.RunDockerCmd("image", "inspect", "build-test_nginx")
@@ -47,9 +47,9 @@ func TestLocalComposeBuild(t *testing.T) {
 		c.RunDockerOrExitError("rmi", "build-test_nginx")
 		c.RunDockerOrExitError("rmi", "custom-nginx")
 
-		res := c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "up", "-d")
+		res := c.RunDockerCmd("compose", "--project-directory", "fixtures/build-test", "up", "-d")
 		t.Cleanup(func() {
-			c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "down")
+			c.RunDockerCmd("compose", "--project-directory", "fixtures/build-test", "down")
 		})
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
@@ -62,13 +62,13 @@ func TestLocalComposeBuild(t *testing.T) {
 	})
 
 	t.Run("no rebuild when up again", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "up", "-d")
+		res := c.RunDockerCmd("compose", "--project-directory", "fixtures/build-test", "up", "-d")
 
 		assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static /usr/share/nginx/html"), res.Stdout())
 	})
 
 	t.Run("cleanup build project", func(t *testing.T) {
-		c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "down")
+		c.RunDockerCmd("compose", "--project-directory", "fixtures/build-test", "down")
 		c.RunDockerCmd("rmi", "build-test_nginx")
 		c.RunDockerCmd("rmi", "custom-nginx")
 	})

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -118,7 +118,7 @@ func TestLocalComposeUp(t *testing.T) {
 func TestComposePull(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 
-	res := c.RunDockerOrExitError("compose", "--workdir", "fixtures/simple-composefile", "pull")
+	res := c.RunDockerOrExitError("compose", "--project-directory", "fixtures/simple-composefile", "pull")
 	output := res.Combined()
 
 	assert.Assert(t, strings.Contains(output, "simple Pulled"))

--- a/local/e2e/compose/volumes_test.go
+++ b/local/e2e/compose/volumes_test.go
@@ -37,7 +37,7 @@ func TestLocalComposeVolume(t *testing.T) {
 		c.RunDockerOrExitError("rmi", "compose-e2e-volume_nginx")
 		c.RunDockerOrExitError("volume", "rm", projectName+"_staticVol")
 		c.RunDockerOrExitError("volume", "rm", "myvolume")
-		c.RunDockerCmd("compose", "--workdir", "fixtures/volume-test", "--project-name", projectName, "up", "-d")
+		c.RunDockerCmd("compose", "--project-directory", "fixtures/volume-test", "--project-name", projectName, "up", "-d")
 	})
 
 	t.Run("access bind mount data", func(t *testing.T) {


### PR DESCRIPTION
This fixes the ambiguity between `--project-directory` and `--workdir`

`--project-directory` is the one passed to `compose-go` to resolve compose files
`--workdir` is passed to commands `run` and `exec` to provide $PWD to the container before running the command.

Resolves https://github.com/docker/compose-cli/issues/1279