### PR TITLE
introduce --always-recreate-deps

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -67,10 +67,14 @@ type Service interface {
 
 // CreateOptions group options of the Create API
 type CreateOptions struct {
+	// Services defines the services user interacts with
+	Services []string
 	// Remove legacy containers for services that are not defined in the project
 	RemoveOrphans bool
 	// Recreate define the strategy to apply on existing containers
 	Recreate string
+	// RecreateDependencies define the strategy to apply on dependencies services
+	RecreateDependencies string
 	// Inherit reuse anonymous volumes from previous container
 	Inherit bool
 }


### PR DESCRIPTION
**What I did**
Introduced option  `--always-recreate-deps` 
also introduce Up API option to pass a set of "primary" services user interact with. Will be required to implement --attach-dependencies 

**Related issue**
https://github.com/docker/compose-cli/issues/1370

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
