### PR TITLE
introduce --renew-anon-volumes

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -71,6 +71,8 @@ type CreateOptions struct {
 	RemoveOrphans bool
 	// Recreate define the strategy to apply on existing containers
 	Recreate string
+	// Inherit reuse anonymous volumes from previous container
+	Inherit bool
 }
 
 // StartOptions group options of the Start API

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -65,6 +65,7 @@ type upOptions struct {
 	timeChanged   bool
 	timeout       int
 	noDeps        bool
+	noInherit     bool
 }
 
 func (o upOptions) recreateStrategy() string {
@@ -129,6 +130,7 @@ func upCommand(p *projectOptions, contextType string) *cobra.Command {
 		flags.StringVar(&opts.exitCodeFrom, "exit-code-from", "", "Return the exit code of the selected service container. Implies --abort-on-container-exit")
 		flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Use this timeout in seconds for container shutdown when attached or when containers are already running.")
 		flags.BoolVar(&opts.noDeps, "no-deps", false, "Don't start linked services.")
+		flags.BoolVarP(&opts.noInherit, "renew-anon-volumes", "V", false, "Recreate anonymous volumes instead of retrieving data from the previous containers.")
 	}
 
 	return upCmd
@@ -192,6 +194,7 @@ func runCreateStart(ctx context.Context, opts upOptions, services []string) erro
 		err := c.ComposeService().Create(ctx, project, compose.CreateOptions{
 			RemoveOrphans: opts.removeOrphans,
 			Recreate:      opts.recreateStrategy(),
+			Inherit:       !opts.noInherit,
 		})
 		if err != nil {
 			return "", err

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -97,7 +97,7 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 	prepareNetworkMode(project)
 
 	return InDependencyOrder(ctx, project, func(c context.Context, service types.ServiceConfig) error {
-		return s.ensureService(c, project, service, opts.Recreate)
+		return s.ensureService(c, project, service, opts.Recreate, opts.Inherit)
 	})
 }
 


### PR DESCRIPTION
**What I did**
introduced --renew-anon-volumes so that recreated container **don't** inherit volumes from previous container

**Related issue**
https://github.com/docker/compose-cli/issues/1373

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
