### PR TITLE
Fix compose up --build not forcing rebuild of present image

### DIFF
--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -65,11 +65,6 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			return err
 		}
 
-		if service.Image != "" {
-			if localImagePresent {
-				continue
-			}
-		}
 		if service.Build != nil {
 			if localImagePresent && service.PullPolicy != types.PullPolicyBuild {
 				continue
@@ -77,6 +72,11 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 			imagesToBuild = append(imagesToBuild, imageName)
 			opts[imageName] = s.toBuildOptions(service, project.WorkingDir, imageName)
 			continue
+		}
+		if service.Image != "" {
+			if localImagePresent {
+				continue
+			}
 		}
 
 		// Buildx has no command to "just pull", see

--- a/local/e2e/compose/compose_build_test.go
+++ b/local/e2e/compose/compose_build_test.go
@@ -53,6 +53,7 @@ func TestLocalComposeBuild(t *testing.T) {
 		})
 
 		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
+		res.Assert(t, icmd.Expected{Out: "COPY static2 /usr/share/nginx/html"})
 
 		output := HTTPGetWithRetry(t, "http://localhost:8070", http.StatusOK, 2*time.Second, 20*time.Second)
 		assert.Assert(t, strings.Contains(output, "Hello from Nginx container"))
@@ -64,7 +65,14 @@ func TestLocalComposeBuild(t *testing.T) {
 	t.Run("no rebuild when up again", func(t *testing.T) {
 		res := c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "up", "-d")
 
-		assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static /usr/share/nginx/html"), res.Stdout())
+		assert.Assert(t, !strings.Contains(res.Stdout(), "COPY static"), res.Stdout())
+	})
+
+	t.Run("rebuild when up --build", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "--workdir", "fixtures/build-test", "up", "-d", "--build")
+
+		res.Assert(t, icmd.Expected{Out: "COPY static /usr/share/nginx/html"})
+		res.Assert(t, icmd.Expected{Out: "COPY static2 /usr/share/nginx/html"})
 	})
 
 	t.Run("cleanup build project", func(t *testing.T) {

--- a/local/e2e/compose/fixtures/build-test/compose.yml
+++ b/local/e2e/compose/fixtures/build-test/compose.yml
@@ -5,5 +5,5 @@ services:
       - 8070:80
 
   nginx2:
-    build: nginx-build
+    build: nginx-build2
     image: custom-nginx

--- a/local/e2e/compose/fixtures/build-test/nginx-build2/Dockerfile
+++ b/local/e2e/compose/fixtures/build-test/nginx-build2/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM nginx
+
+COPY static2 /usr/share/nginx/html

--- a/local/e2e/compose/fixtures/build-test/nginx-build2/static2/index.html
+++ b/local/e2e/compose/fixtures/build-test/nginx-build2/static2/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Docker Nginx</title>
+</head>
+<body>
+  <h2>Hello from Nginx container</h2>
+</body>
+</html>


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* check if need to force-build image before ignoring present images

**Related issue**
came across this when deploying local dos.docker.com with compose

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
