### PR TITLE
Display available azure cloud names in azure login help

### DIFF
--- a/cli/cmd/login/azurelogin.go
+++ b/cli/cmd/login/azurelogin.go
@@ -40,7 +40,7 @@ func AzureLoginCommand() *cobra.Command {
 	flags.StringVar(&opts.TenantID, "tenant-id", "", "Specify tenant ID to use")
 	flags.StringVar(&opts.ClientID, "client-id", "", "Client ID for Service principal login")
 	flags.StringVar(&opts.ClientSecret, "client-secret", "", "Client secret for Service principal login")
-	flags.StringVar(&opts.CloudName, "cloud-name", "", "Name of a registered Azure cloud")
+	flags.StringVar(&opts.CloudName, "cloud-name", "", "Name of a registered Azure cloud [AzureCloud | AzureChinaCloud | AzureGermanCloud | AzureUSGovernment] (AzureCloud by default)")
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Add list of hardcoded known azure clouds in help message

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
