### PR TITLE
implement -v, -p, --service-ports and --use-aliases on compose run

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -151,20 +151,21 @@ type RemoveOptions struct {
 
 // RunOptions options to execute compose run
 type RunOptions struct {
-	Name        string
-	Service     string
-	Command     []string
-	Entrypoint  []string
-	Detach      bool
-	AutoRemove  bool
-	Writer      io.Writer
-	Reader      io.Reader
-	Tty         bool
-	WorkingDir  string
-	User        string
-	Environment []string
-	Labels      types.Labels
-	Privileged  bool
+	Name              string
+	Service           string
+	Command           []string
+	Entrypoint        []string
+	Detach            bool
+	AutoRemove        bool
+	Writer            io.Writer
+	Reader            io.Reader
+	Tty               bool
+	WorkingDir        string
+	User              string
+	Environment       []string
+	Labels            types.Labels
+	Privileged        bool
+	UseNetworkAliases bool
 	// used by exec
 	Index int
 }

--- a/local/compose/run.go
+++ b/local/compose/run.go
@@ -62,7 +62,7 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 	if err := s.waitDependencies(ctx, project, service); err != nil {
 		return 0, err
 	}
-	if err := s.createContainer(ctx, project, service, service.ContainerName, 1, opts.AutoRemove); err != nil {
+	if err := s.createContainer(ctx, project, service, service.ContainerName, 1, opts.AutoRemove, opts.UseNetworkAliases); err != nil {
 		return 0, err
 	}
 	containerID := service.ContainerName


### PR DESCRIPTION
**What I did**

**Related issue**
fix https://github.com/docker/compose-cli/issues/1363
fix https://github.com/docker/compose-cli/issues/1364
fix https://github.com/docker/compose-cli/issues/1365


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
