### PR TITLE
Don’t use context for scan suggest message, use cliconfig.Dir() as in scan plugin for consistency

### DIFF
--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -50,7 +50,7 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 
 	err := s.build(ctx, project, opts, options.Progress)
 	if err == nil {
-		displayScanSuggestMsg(ctx, imagesToBuild)
+		displayScanSuggestMsg(imagesToBuild)
 	}
 
 	return err
@@ -100,7 +100,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 
 	err := s.build(ctx, project, opts, "auto")
 	if err == nil {
-		displayScanSuggestMsg(ctx, imagesToBuild)
+		displayScanSuggestMsg(imagesToBuild)
 	}
 	return err
 }

--- a/local/compose/scan_suggest.go
+++ b/local/compose/scan_suggest.go
@@ -17,7 +17,6 @@
 package compose
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -26,25 +25,24 @@ import (
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/compose-cli/api/config"
+	cliConfig "github.com/docker/cli/cli/config"
 )
 
-func displayScanSuggestMsg(ctx context.Context, builtImages []string) {
+func displayScanSuggestMsg(builtImages []string) {
 	if len(builtImages) <= 0 {
 		return
 	}
 	if os.Getenv("DOCKER_SCAN_SUGGEST") == "false" {
 		return
 	}
-	if !scanAvailable() || scanAlreadyInvoked(ctx) {
+	if !scanAvailable() || scanAlreadyInvoked() {
 		return
 	}
 	fmt.Println("Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them")
 }
 
-func scanAlreadyInvoked(ctx context.Context) bool {
-	configDir := config.Dir(ctx)
-	filename := filepath.Join(configDir, "scan", "config.json")
+func scanAlreadyInvoked() bool {
+	filename := filepath.Join(cliConfig.Dir(), "scan", "config.json")
 	f, err := os.Stat(filename)
 	if os.IsNotExist(err) {
 		return false


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
See in https://github.com/docker/scan-cli-plugin/blob/main/config/config.go#L40

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
