### PR TITLE
[WIP] compose local as a cli plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
   # only on main branch, costs too much for the gain on every PR
   validate-cross-build:
-    name: Validate cros build
+    name: Validate cross build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN --mount=target=. \
     GOARCH=${TARGETARCH} \
     BUILD_TAGS=${BUILD_TAGS} \
     GIT_TAG=${GIT_TAG} \
-    make BINARY=/out/docker -f builder.Makefile cli
+    make BINARY=/out/docker COMPOSE_BINARY=/out/docker-compose -f builder.Makefile cli
 
 FROM base AS make-cross
 ARG BUILD_TAGS
@@ -84,7 +84,7 @@ RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     BUILD_TAGS=${BUILD_TAGS} \
     GIT_TAG=${GIT_TAG} \
-    make BINARY=/out/docker  -f builder.Makefile cross
+    make BINARY=/out/docker COMPOSE_BINARY=/out/docker-compose -f builder.Makefile cross
 
 FROM scratch AS protos
 COPY --from=make-protos /compose-cli/cli/server/protos .

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ moby-cli-link: ## Create com.docker.cli symlink if does not already exist
 
 install: ## Link /usr/local/bin/ to current binary
 	ln -fs $(BINARY_FOLDER)/docker /usr/local/bin/docker
+	cp ./bin/docker-compose ~/.docker/cli-plugins/
 
 validate-headers: ## Check license header for all files
 	@docker build . --target check-license-headers

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ cli: ## Compile the cli
 	--output ./bin
 
 e2e-local: ## Run End to end local tests. Set E2E_TEST=TestName to run a single test
-	gotestsum $(TEST_FLAGS) ./local/e2e/compose ./local/e2e/container ./local/e2e/cli-only -- -count=1
+	go test $(TEST_FLAGS) ./local/e2e/compose ./local/e2e/container ./local/e2e/cli-only -- -count=1
 
 e2e-win-ci: ## Run end to end local tests on Windows CI, no Docker for Linux containers available ATM. Set E2E_TEST=TestName to run a single test
 	go test -count=1 -v $(TEST_FLAGS) ./local/e2e/cli-only

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -57,6 +57,10 @@ protos:
 cli:
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
+.PHONY: cli
+compose-plugin:
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o ./bin/docker-compose ./compose_plugin
+
 .PHONY: cross
 cross:
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-amd64 ./cli

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -34,6 +34,9 @@ GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 BINARY?=bin/docker
 BINARY_WITH_EXTENSION=$(BINARY)$(EXTENSION)
 
+COMPOSE_BINARY?=bin/docker-compose
+COMPOSE_BINARY_WITH_EXTENSION=$(COMPOSE_BINARY)$(EXTENSION)
+
 WORK_DIR:=$(shell mktemp -d)
 
 TAGS:=
@@ -54,12 +57,12 @@ protos:
 	protoc -I. --go_out=plugins=grpc,paths=source_relative:. ${PROTOS}
 
 .PHONY: cli
-cli:
+cli: compose-plugin
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
 .PHONY: cli
 compose-plugin:
-	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o ./bin/docker-compose ./compose_plugin
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) ./compose_plugin
 
 .PHONY: cross
 cross:

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -45,9 +45,22 @@ ifdef BUILD_TAGS
   LINT_TAGS=--build-tags $(BUILD_TAGS)
 endif
 
-TAR_TRANSFORM:=--transform s/packaging/docker/ --transform s/bin/docker/ --transform s/docker-linux-amd64/docker/ --transform s/docker-darwin-amd64/docker/ --transform s/docker-linux-arm64/docker/ --transform s/docker-linux-armv6/docker/ --transform s/docker-linux-armv7/docker/ --transform s/docker-darwin-arm64/docker/
+TAR_TRANSFORM:=--transform s/packaging/docker/ --transform s/bin/docker/ \
+				--transform s/docker-linux-amd64/docker/ --transform s/docker-linux-arm64/docker/ \
+				--transform s/docker-linux-armv6/docker/ --transform s/docker-linux-armv7/docker/ \
+				--transform s/docker-darwin-amd64/docker/ --transform s/docker-darwin-arm64/docker/ \
+				--transform s/docker-compose-linux-amd64/docker-compose/ --transform s/docker-compose-linux-arm64/docker-compose/ \
+				--transform s/docker-compose-linux-armv6/docker-compose/ --transform s/docker-compose-linux-armv7/docker-compose/ \
+				--transform s/docker-compose-darwin-amd64/docker-compose/ --transform s/docker-compose-darwin-arm64/docker-compose/
+
 ifneq ($(findstring bsd,$(shell tar --version)),)
-  TAR_TRANSFORM=-s /packaging/docker/ -s /bin/docker/ -s /docker-linux-amd64/docker/ -s /docker-darwin-amd64/docker/ -s /docker-linux-arm64/docker/ -s /docker-linux-armv6/docker/ -s /docker-linux-armv7/docker/ -s /docker-darwin-arm64/docker/
+  TAR_TRANSFORM=-s /packaging/docker/ -s /bin/docker/ \
+  				-s /docker-linux-amd64/docker/  -s /docker-linux-arm64/docker/ \
+  				-s /docker-linux-armv6/docker/  -s /docker-linux-armv7/docker/ \
+				-s /docker-darwin-amd64/docker/	 -s /docker-darwin-arm64/docker/ \
+  				-s /docker-compose-linux-amd64/docker-compose/  -s /docker-compose-linux-arm64/docker-compose/ \
+  				-s /docker-compose-linux-armv6/docker-compose/  -s /docker-compose-linux-armv7/docker-compose/ \
+				-s /docker-compose-darwin-amd64/docker-compose/	 -s /docker-compose-darwin-arm64/docker-compose/
 endif
 
 all: cli
@@ -60,12 +73,12 @@ protos:
 cli: compose-plugin
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
-.PHONY: cli
+.PHONY: compose-plugin
 compose-plugin:
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) ./compose_plugin
 
 .PHONY: cross
-cross:
+cross: cross-compose-plugin
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-amd64 ./cli
 	GOOS=linux   GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-arm64 ./cli
 	GOOS=linux   GOARM=6 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-armv6 ./cli
@@ -73,6 +86,16 @@ cross:
 	GOOS=darwin  GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-darwin-amd64 ./cli
 	GOOS=darwin  GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(BINARY)-darwin-arm64 ./cli
 	GOOS=windows GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-windows-amd64.exe ./cli
+
+.PHONY: cross-compose-plugin
+cross-compose-plugin:
+	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-amd64 ./compose_plugin
+	GOOS=linux   GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-arm64 ./compose_plugin
+	GOOS=linux   GOARM=6 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-armv6 ./compose_plugin
+	GOOS=linux   GOARM=7 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-armv7 ./compose_plugin
+	GOOS=darwin  GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-darwin-amd64 ./compose_plugin
+	GOOS=darwin  GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-darwin-arm64 ./compose_plugin
+	GOOS=windows GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-windows-amd64.exe ./compose_plugin
 
 .PHONY: test
 test:
@@ -97,14 +120,15 @@ check-go-mod:
 .PHONY: package
 package: cross
 	mkdir -p dist
-	tar -czf dist/docker-linux-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-amd64
-	tar -czf dist/docker-linux-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-arm64
-	tar -czf dist/docker-linux-armv6.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv6
-	tar -czf dist/docker-linux-armv7.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv7
-	tar -czf dist/docker-darwin-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-amd64
-	tar -czf dist/docker-darwin-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-arm64
+	tar -czf dist/docker-linux-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-amd64 $(COMPOSE_BINARY)-linux-amd64
+	tar -czf dist/docker-linux-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-arm64 $(COMPOSE_BINARY)-linux-arm64
+	tar -czf dist/docker-linux-armv6.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv6 $(COMPOSE_BINARY)-linux-armv6
+	tar -czf dist/docker-linux-armv7.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv7 $(COMPOSE_BINARY)-linux-armv7
+	tar -czf dist/docker-darwin-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-amd64 $(COMPOSE_BINARY)-darwin-amd64
+	tar -czf dist/docker-darwin-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-arm64 $(COMPOSE_BINARY)-darwin-arm64
 	cp $(BINARY)-windows-amd64.exe $(WORK_DIR)/docker.exe
-	rm -f dist/docker-windows-amd64.zip && zip dist/docker-windows-amd64.zip -j packaging/LICENSE $(WORK_DIR)/docker.exe
+	cp $(COMPOSE_BINARY)-windows-amd64.exe $(WORK_DIR)/docker-compose.exe
+	rm -f dist/docker-windows-amd64.zip && zip dist/docker-windows-amd64.zip -j packaging/LICENSE $(WORK_DIR)/docker.exe $(WORK_DIR)/docker-compose.exe
 	rm -r $(WORK_DIR)
 
 .PHONY: yamldocs

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -115,6 +115,14 @@ func Command(contextType string) *cobra.Command {
 		Use:              "compose",
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			parent := cmd.Root()
+			parentPrerun := parent.PersistentPreRunE
+			if parentPrerun != nil {
+				err := parentPrerun(cmd, args)
+				if err != nil {
+					return err
+				}
+			}
 			if noAnsi {
 				if ansi != "auto" {
 					return errors.New(`cannot specify DEPRECATED "--no-ansi" and "--ansi". Please use only "--ansi"`)

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -166,6 +166,7 @@ func Command(contextType string) *cobra.Command {
 		eventsCommand(&opts),
 		portCommand(&opts),
 		imagesCommand(&opts),
+		versionCommand(),
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -29,14 +29,15 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/docker/cli/cli"
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/context/store"
+	"github.com/docker/compose-cli/api/errdefs"
 	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/utils"
@@ -141,6 +142,7 @@ func (opts upOptions) apply(project *types.Project, services []string) error {
 	return nil
 }
 
+//nolint
 func upCommand(p *projectOptions, contextType string) *cobra.Command {
 	opts := upOptions{
 		composeOptions: &composeOptions{
@@ -151,6 +153,7 @@ func upCommand(p *projectOptions, contextType string) *cobra.Command {
 		Use:   "up [SERVICE...]",
 		Short: "Create and start containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
 			opts.timeChanged = cmd.Flags().Changed("timeout")
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
@@ -169,10 +172,18 @@ func upCommand(p *projectOptions, contextType string) *cobra.Command {
 				if opts.recreateDeps && opts.noRecreate {
 					return fmt.Errorf("--always-recreate-deps and --no-recreate are incompatible")
 				}
-				return runCreateStart(cmd.Context(), opts, args)
+				err = runCreateStart(cmd.Context(), opts, args)
 			default:
-				return runUp(cmd.Context(), opts, args)
+				err = runUp(cmd.Context(), opts, args)
 			}
+
+			if err != nil {
+				if errdefs.IsErrCanceled(err) || errors.Is(cmd.Context().Err(), context.Canceled) {
+					return cli.StatusError{StatusCode: 130}
+				}
+				return err
+			}
+			return nil
 		},
 	}
 	flags := upCmd.Flags()

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/docker/cli/cli"
 	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/context/store"

--- a/cli/cmd/compose/version.go
+++ b/cli/cmd/compose/version.go
@@ -1,0 +1,64 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/compose-cli/cli/formatter"
+	"github.com/docker/compose-cli/internal"
+)
+
+type versionOptions struct {
+	format string
+	short  bool
+}
+
+func versionCommand() *cobra.Command {
+	opts := versionOptions{}
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show the Docker Compose version information",
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runVersion(opts)
+			return nil
+		},
+	}
+	// define flags for backward compatibility with com.docker.cli
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.format, "format", "f", "", "Format the output. Values: [pretty | json]. (Default: pretty)")
+	flags.BoolVar(&opts.short, "short", false, "Shows only Compose's version number.")
+
+	return cmd
+}
+
+func runVersion(opts versionOptions) {
+	displayedVersion := strings.TrimPrefix(internal.Version, "v")
+	if opts.short {
+		fmt.Println(displayedVersion)
+		return
+	}
+	if opts.format == formatter.JSON {
+		fmt.Printf(`{"version":"%s"}\n`, displayedVersion)
+		return
+	}
+	fmt.Printf(`Docker Compose version %s`, displayedVersion)
+}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -40,7 +40,11 @@ func VersionCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			err := runVersion(cmd)
 			if err != nil {
-				return cli.StatusError{StatusCode: 1, Status: err.Error()}
+				errMsg := ""
+				if err != nil {
+					errMsg = err.Error()
+				}
+				return cli.StatusError{StatusCode: 1, Status: errMsg}
 			}
 			return nil
 		},

--- a/cli/config/flags_test.go
+++ b/cli/config/flags_test.go
@@ -1,0 +1,61 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose-cli/api/config"
+)
+
+var contextSetConfig = []byte(`{
+	"currentContext": "some-context"
+}`)
+
+func TestDetermineCurrentContext(t *testing.T) {
+	d, err := ioutil.TempDir("", "")
+	// nolint errcheck
+	defer os.RemoveAll(d)
+	assert.NilError(t, err)
+	err = ioutil.WriteFile(filepath.Join(d, config.ConfigFileName), contextSetConfig, 0644)
+	assert.NilError(t, err)
+
+	// If nothing set, fallback to default
+	c := GetCurrentContext("", "", []string{})
+	assert.Equal(t, c, "default")
+
+	// If context flag set, use that
+	c = GetCurrentContext("other-context", "", []string{})
+	assert.Equal(t, c, "other-context")
+
+	// If no context flag, use config
+	c = GetCurrentContext("", d, []string{})
+	assert.Equal(t, c, "some-context")
+
+	// Ensure context flag overrides config
+	c = GetCurrentContext("other-context", d, []string{})
+	assert.Equal(t, "other-context", c)
+
+	// Ensure host flag overrides context
+	c = GetCurrentContext("other-context", d, []string{"hostname"})
+	assert.Equal(t, "default", c)
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -29,9 +29,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli"
-	"github.com/docker/cli/cli/command"
 	cliconfig "github.com/docker/cli/cli/config"
-	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,6 +46,7 @@ import (
 	"github.com/docker/compose-cli/cli/cmd/logout"
 	"github.com/docker/compose-cli/cli/cmd/run"
 	"github.com/docker/compose-cli/cli/cmd/volume"
+	cliconfig "github.com/docker/compose-cli/cli/config"
 	"github.com/docker/compose-cli/cli/metrics"
 	"github.com/docker/compose-cli/cli/mobycli"
 	cliopts "github.com/docker/compose-cli/cli/options"
@@ -62,7 +61,6 @@ import (
 
 var (
 	contextAgnosticCommands = map[string]struct{}{
-		"compose":          {},
 		"context":          {},
 		"login":            {},
 		"logout":           {},
@@ -198,7 +196,7 @@ func main() {
 	configDir := opts.Config
 	config.WithDir(configDir)
 
-	currentContext := determineCurrentContext(opts.Context, configDir, opts.Hosts)
+	currentContext := cliconfig.GetCurrentContext(opts.Context, configDir, opts.Hosts)
 	apicontext.WithCurrentContext(currentContext)
 
 	s, err := store.New(configDir)
@@ -234,27 +232,7 @@ func main() {
 func getBackend(ctype string, configDir string, opts cliopts.GlobalOpts) (backend.Service, error) {
 	switch ctype {
 	case store.DefaultContextType, store.LocalContextType:
-		configFile, err := cliconfig.Load(configDir)
-		if err != nil {
-			return nil, err
-		}
-		options := cliflags.CommonOptions{
-			Context:  opts.Context,
-			Debug:    opts.Debug,
-			Hosts:    opts.Hosts,
-			LogLevel: opts.LogLevel,
-		}
-
-		if opts.TLSVerify {
-			options.TLS = opts.TLS
-			options.TLSVerify = opts.TLSVerify
-			options.TLSOptions = opts.TLSOptions
-		}
-		apiClient, err := command.NewAPIClientFromFlags(&options, configFile)
-		if err != nil {
-			return nil, err
-		}
-		return local.NewService(apiClient), nil
+		return local.GetLocalBackend(configDir, opts)
 	}
 	service, err := backend.Get(ctype)
 	if errdefs.IsNotFoundError(err) {
@@ -300,6 +278,7 @@ func exit(ctx string, err error, ctype string) {
 	}
 
 	if compose.Warning != "" {
+		logrus.Warn(err)
 		fmt.Fprintln(os.Stderr, compose.Warning)
 	}
 
@@ -340,38 +319,6 @@ func newSigContext() (context.Context, func()) {
 		cancel()
 	}()
 	return ctx, cancel
-}
-
-func determineCurrentContext(flag string, configDir string, hosts []string) string {
-	// host and context flags cannot be both set at the same time -- the local backend enforces this when resolving hostname
-	// -H flag disables context --> set default as current
-	if len(hosts) > 0 {
-		return "default"
-	}
-	// DOCKER_HOST disables context --> set default as current
-	if _, present := os.LookupEnv("DOCKER_HOST"); present {
-		return "default"
-	}
-	res := flag
-	if res == "" {
-		// check if DOCKER_CONTEXT env variable was set
-		if _, present := os.LookupEnv("DOCKER_CONTEXT"); present {
-			res = os.Getenv("DOCKER_CONTEXT")
-		}
-
-		if res == "" {
-			config, err := config.LoadFile(configDir)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, errors.Wrap(err, "WARNING"))
-				return "default"
-			}
-			res = config.CurrentContext
-		}
-	}
-	if res == "" {
-		res = "default"
-	}
-	return res
 }
 
 func walk(c *cobra.Command, f func(*cobra.Command)) {

--- a/cli/main.go
+++ b/cli/main.go
@@ -29,12 +29,10 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli"
-	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/cli/cli"
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/config"
 	apicontext "github.com/docker/compose-cli/api/context"

--- a/cli/main.go
+++ b/cli/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/cli/cli"
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/config"
 	apicontext "github.com/docker/compose-cli/api/context"

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -17,52 +17,16 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
-	"github.com/docker/compose-cli/api/config"
 	"github.com/docker/compose-cli/cli/cmd"
 	"github.com/docker/compose-cli/cli/cmd/context"
 	"github.com/docker/compose-cli/cli/cmd/login"
 	"github.com/docker/compose-cli/cli/cmd/run"
 )
-
-var contextSetConfig = []byte(`{
-	"currentContext": "some-context"
-}`)
-
-func TestDetermineCurrentContext(t *testing.T) {
-	d, err := ioutil.TempDir("", "")
-	// nolint errcheck
-	defer os.RemoveAll(d)
-	assert.NilError(t, err)
-	err = ioutil.WriteFile(filepath.Join(d, config.ConfigFileName), contextSetConfig, 0644)
-	assert.NilError(t, err)
-
-	// If nothing set, fallback to default
-	c := determineCurrentContext("", "", []string{})
-	assert.Equal(t, c, "default")
-
-	// If context flag set, use that
-	c = determineCurrentContext("other-context", "", []string{})
-	assert.Equal(t, c, "other-context")
-
-	// If no context flag, use config
-	c = determineCurrentContext("", d, []string{})
-	assert.Equal(t, c, "some-context")
-
-	// Ensure context flag overrides config
-	c = determineCurrentContext("other-context", d, []string{})
-	assert.Equal(t, "other-context", c)
-
-	// Ensure host flag overrides context
-	c = determineCurrentContext("other-context", d, []string{"hostname"})
-	assert.Equal(t, "default", c)
-}
 
 func TestCheckOwnCommand(t *testing.T) {
 	assert.Assert(t, isContextAgnosticCommand(login.Command()))

--- a/compose_plugin/main.go
+++ b/compose_plugin/main.go
@@ -1,0 +1,86 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli-plugins/manager"
+	"github.com/docker/cli/cli-plugins/plugin"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/compose-cli/api/backend"
+	"github.com/docker/compose-cli/api/config"
+	apicontext "github.com/docker/compose-cli/api/context"
+	"github.com/docker/compose-cli/api/context/store"
+	"github.com/docker/compose-cli/cli/cmd/compose"
+	cliconfig "github.com/docker/compose-cli/cli/config"
+	cliopts "github.com/docker/compose-cli/cli/options"
+	"github.com/docker/compose-cli/internal"
+	"github.com/docker/compose-cli/local"
+)
+
+func main() {
+	var opts cliopts.GlobalOpts
+	root := &cobra.Command{
+		Use: "docker",
+	}
+	flags := root.Flags()
+	opts.InstallFlags(flags)
+	opts.AddConfigFlags(flags)
+	flags.SetInterspersed(false)
+	// populate the opts with the global flags
+	err := flags.Parse(os.Args[1:]) //nolint: errcheck
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	service, err := local.GetLocalBackend(opts.Config, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if opts.Config == "" {
+		log.Fatal(fmt.Errorf("config path cannot be empty"))
+	}
+	configDir := opts.Config
+	config.WithDir(configDir)
+
+	currentContext := cliconfig.GetCurrentContext(opts.Context, opts.Config, opts.Hosts)
+	apicontext.WithCurrentContext(currentContext)
+
+	s, err := store.New(configDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	store.WithContextStore(s)
+
+	backend.WithBackend(service)
+
+	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
+		return compose.Command(store.DefaultContextType)
+	},
+		manager.Metadata{
+			SchemaVersion: "0.1.0",
+			Vendor:        "Docker Inc.",
+			Version:       strings.TrimPrefix(internal.Version, "v"),
+		})
+}

--- a/compose_plugin/main.go
+++ b/compose_plugin/main.go
@@ -76,6 +76,8 @@ func main() {
 	backend.WithBackend(service)
 
 	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
+		cmd := compose.Command(store.DefaultContextType)
+		cmd.Context()
 		return compose.Command(store.DefaultContextType)
 	},
 		manager.Metadata{

--- a/local/backend.go
+++ b/local/backend.go
@@ -19,12 +19,16 @@ package local
 import (
 	"github.com/docker/docker/client"
 
+	"github.com/docker/cli/cli/command"
+	cliconfig "github.com/docker/cli/cli/config"
+	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
+	cliopts "github.com/docker/compose-cli/cli/options"
 	local_compose "github.com/docker/compose-cli/local/compose"
 )
 
@@ -41,6 +45,31 @@ func NewService(apiClient client.APIClient) backend.Service {
 		volumeService:    &volumeService{apiClient},
 		composeService:   local_compose.NewComposeService(apiClient),
 	}
+}
+
+// GetLocalBackend initialize local backend
+func GetLocalBackend(configDir string, opts cliopts.GlobalOpts) (backend.Service, error) {
+	configFile, err := cliconfig.Load(configDir)
+	if err != nil {
+		return nil, err
+	}
+	options := cliflags.CommonOptions{
+		Context:  opts.Context,
+		Debug:    opts.Debug,
+		Hosts:    opts.Hosts,
+		LogLevel: opts.LogLevel,
+	}
+
+	if opts.TLSVerify {
+		options.TLS = opts.TLS
+		options.TLSVerify = opts.TLSVerify
+		options.TLSOptions = opts.TLSOptions
+	}
+	apiClient, err := command.NewAPIClientFromFlags(&options, configFile)
+	if err != nil {
+		return nil, err
+	}
+	return NewService(apiClient), nil
 }
 
 func (s *local) ContainerService() containers.Service {

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -129,6 +130,15 @@ func TestLocalComposeUp(t *testing.T) {
 		res := c.RunDockerCmd("network", "ls")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
+}
+
+func TestComposeUsingCliPlugin(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	err := os.Remove(filepath.Join(c.ConfigDir, "cli-plugins", "docker-compose"))
+	assert.NilError(t, err)
+	res := c.RunDockerOrExitError("compose", "ls")
+	res.Assert(t, icmd.Expected{Err: "'compose' is not a docker command", ExitCode: 1})
 }
 
 func TestComposePull(t *testing.T) {

--- a/local/e2e/compose/fixtures/build-infinite/compose.yml
+++ b/local/e2e/compose/fixtures/build-infinite/compose.yml
@@ -1,0 +1,3 @@
+services:
+  service1:
+    build: service1

--- a/local/e2e/compose/fixtures/build-infinite/service1/Dockerfile
+++ b/local/e2e/compose/fixtures/build-infinite/service1/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM busybox
+
+RUN sleep infinity

--- a/local/e2e/compose/metrics_test.go
+++ b/local/e2e/compose/metrics_test.go
@@ -1,0 +1,95 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	"gotest.tools/v3/icmd"
+
+	. "github.com/docker/compose-cli/utils/e2e"
+)
+
+func TestComposeMetrics(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+	s := NewMetricsServer(c.MetricsSocket())
+	s.Start()
+	defer s.Stop()
+
+	started := false
+	for i := 0; i < 30; i++ {
+		c.RunDockerCmd("help", "ps")
+		if len(s.GetUsage()) > 0 {
+			started = true
+			fmt.Printf("	[%s] Server up in %d ms\n", t.Name(), i*100)
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Assert(t, started, "Metrics mock server not available after 3 secs")
+
+	t.Run("metrics on Compose commands", func(t *testing.T) {
+		s.ResetUsage()
+
+		c.RunDockerCmd("compose", "ls")
+
+		upProjectPath := "../compose/fixtures/simple-composefile/compose.yml"
+		cmd := c.NewDockerCmd("compose", "-f", upProjectPath, "up")
+		defer c.RunDockerCmd("compose", "-f", upProjectPath, "down")
+		upProcess := icmd.StartCmd(cmd)
+		c.WaitForOutputResult(upProcess, StdoutContains("CPU:"), 10*time.Second, 1*time.Second)
+
+		res := c.RunDockerOrExitError("compose", "-f", upProjectPath, "ps", "--all")
+		res.Assert(t, icmd.Expected{Out: "running"})
+
+		err := upProcess.Cmd.Process.Signal(syscall.SIGINT)
+		assert.NilError(t, err, upProcess.Combined())
+		c.WaitForOutputResult(upProcess, StdoutContains("Gracefully stopping..."), 10*time.Second, 1*time.Second)
+
+		c.RunDockerOrExitError("compose", "ps")
+
+		usage := s.GetUsage()
+		assert.DeepEqual(t, []string{
+			`{"command":"compose ls","context":"moby","source":"cli","status":"success"}`,
+			`{"command":"compose ps","context":"moby","source":"cli","status":"success"}`,
+			`{"command":"compose up","context":"moby","source":"cli","status":"success"}`,
+			`{"command":"compose ps","context":"moby","source":"cli","status":"failure"}`,
+		}, usage)
+	})
+
+	t.Run("metrics on cancel Compose build", func(t *testing.T) {
+		s.ResetUsage()
+
+		buildProjectPath := "../compose/fixtures/build-infinite/compose.yml"
+		cmd := c.NewDockerCmd("compose", "-f", buildProjectPath, "build")
+		buildProcess := icmd.StartCmd(cmd)
+		c.WaitForOutputResult(buildProcess, StdoutContains("RUN sleep infinity"), 10*time.Second, 1*time.Second)
+
+		err := buildProcess.Cmd.Process.Signal(syscall.SIGINT)
+		assert.NilError(t, err, buildProcess.Combined())
+		c.WaitForOutputResult(buildProcess, StdoutContains("CANCELED"), 10*time.Second, 1*time.Second)
+
+		usage := s.GetUsage()
+		assert.DeepEqual(t, []string{
+			`{"command":"compose build","context":"moby","source":"cli","status":"canceled"}`,
+		}, usage)
+	})
+}

--- a/scripts/install/install_linux.sh
+++ b/scripts/install/install_linux.sh
@@ -120,6 +120,7 @@ if [ $(is_new_cli "docker") -eq 1 ]; then
 		$sh_c "${download_cmd} ${download_dir}/docker-compose-cli.tar.gz ${DOWNLOAD_URL}"
 		$sh_c "tar xzf ${download_dir}/docker-compose-cli.tar.gz -C ${download_dir} --strip-components 1"
 		$sudo_sh_c "install -m 775 ${download_dir}/docker /usr/local/bin/docker"
+		$sh_c "mkdir -p ~/.docker/cli-plugins && cp ${download_dir}/docker-compose ~/.docker/cli-plugins/docker-compose"
 		exit 0
 	fi
 	echo "You already have the Docker Compose CLI installed, in a different location."
@@ -185,6 +186,8 @@ $sudo_sh_c "ln -s ${existing_cli_path} ${link_path}"
 
 # Install downloaded CLI
 $sudo_sh_c "install -m 775 ${download_dir}/docker /usr/local/bin/docker"
+# Install Compose CLI plugin
+$sh_c "mkdir -p ~/.docker/cli-plugins && cp ${download_dir}/docker-compose ~/.docker/cli-plugins/docker-compose"
 
 # Clear cache
 cleared_cache=1

--- a/scripts/install/test.Dockerfile
+++ b/scripts/install/test.Dockerfile
@@ -37,6 +37,7 @@ RUN sudo chmod +x /scripts/install_linux.sh
 ARG DOWNLOAD_URL=
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
+RUN sh -c "docker info || true" | grep "compose: Docker Compose (Docker Inc.,"
 
 FROM install AS upgrade
 
@@ -45,6 +46,7 @@ WORKDIR /home/newuser
 
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
+RUN sh -c "docker info || true" | grep "compose: Docker Compose (Docker Inc.,"
 
 # To run this test locally, start an HTTP server that serves the dist/ folder
 # then run a docker build passing the DOWNLOAD_URL as a build arg:

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -85,6 +85,13 @@ func newE2eCLI(t *testing.T, binDir string) *E2eCLI {
 		_ = os.RemoveAll(d)
 	})
 
+	_ = os.MkdirAll(filepath.Join(d, "cli-plugins"), 0755)
+	composePlugin, _ := findExecutable("docker-compose", []string{"../../bin", "../../../bin"})
+	err = CopyFile(composePlugin, filepath.Join(d, "cli-plugins", "docker-compose"))
+	if err != nil {
+		panic(err)
+	}
+
 	return &E2eCLI{binDir, d, t}
 }
 
@@ -117,7 +124,7 @@ func SetupExistingCLI() (string, func(), error) {
 		return "", nil, err
 	}
 
-	bin, err := findExecutable([]string{"../../bin", "../../../bin"})
+	bin, err := findExecutable(DockerExecutableName, []string{"../../bin", "../../../bin"})
 	if err != nil {
 		return "", nil, err
 	}
@@ -133,9 +140,9 @@ func SetupExistingCLI() (string, func(), error) {
 	return d, cleanup, nil
 }
 
-func findExecutable(paths []string) (string, error) {
+func findExecutable(executableName string, paths []string) (string, error) {
 	for _, p := range paths {
-		bin, err := filepath.Abs(path.Join(p, DockerExecutableName))
+		bin, err := filepath.Abs(path.Join(p, executableName))
 		if err != nil {
 			return "", err
 		}

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -86,8 +86,12 @@ func newE2eCLI(t *testing.T, binDir string) *E2eCLI {
 	})
 
 	_ = os.MkdirAll(filepath.Join(d, "cli-plugins"), 0755)
-	composePlugin, _ := findExecutable("docker-compose", []string{"../../bin", "../../../bin"})
-	err = CopyFile(composePlugin, filepath.Join(d, "cli-plugins", "docker-compose"))
+	composePluginFile := "docker-compose"
+	if runtime.GOOS == "windows" {
+		composePluginFile += ".exe"
+	}
+	composePlugin, _ := findExecutable(composePluginFile, []string{"../../bin", "../../../bin"})
+	err = CopyFile(composePlugin, filepath.Join(d, "cli-plugins", composePluginFile))
 	if err != nil {
 		panic(err)
 	}

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -252,6 +252,18 @@ func (c *E2eCLI) WaitForCmdResult(command icmd.Cmd, predicate func(*icmd.Result)
 	poll.WaitOn(c.test, checkStopped, poll.WithDelay(delay), poll.WithTimeout(timeout))
 }
 
+// WaitForOutputResult check the output of a running cmd until it matches given predicate
+func (c *E2eCLI) WaitForOutputResult(running *icmd.Result, predicate func(*icmd.Result) bool, timeout time.Duration, delay time.Duration) {
+	assert.Assert(c.test, timeout.Nanoseconds() > delay.Nanoseconds(), "timeout must be greater than delay")
+	checkStopped := func(logt poll.LogT) poll.Result {
+		if !predicate(running) {
+			return poll.Continue("Cmd output did not match requirement: %q", running.Combined())
+		}
+		return poll.Success()
+	}
+	poll.WaitOn(c.test, checkStopped, poll.WithDelay(delay), poll.WithTimeout(timeout))
+}
+
 // PathEnvVar returns path (os sensitive) for running test
 func (c *E2eCLI) PathEnvVar() string {
 	path := c.BinDir + ":" + os.Getenv("PATH")

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -257,11 +257,22 @@ func (c *E2eCLI) WaitForOutputResult(running *icmd.Result, predicate func(*icmd.
 	assert.Assert(c.test, timeout.Nanoseconds() > delay.Nanoseconds(), "timeout must be greater than delay")
 	checkStopped := func(logt poll.LogT) poll.Result {
 		if !predicate(running) {
-			return poll.Continue("Cmd output did not match requirement: %q", running.Combined())
+			return poll.Continue("Cmd output did not match requirement: %q", running.Stdout())
 		}
 		return poll.Success()
 	}
 	poll.WaitOn(c.test, checkStopped, poll.WithDelay(delay), poll.WithTimeout(timeout))
+}
+
+// WaitForCondition wait for predicate to execute to true
+func (c *E2eCLI) WaitForCondition(predicate func() bool, description string, timeout time.Duration, delay time.Duration) {
+	checkStopped := func(logt poll.LogT) poll.Result {
+		if !predicate() {
+			return poll.Continue("Condition not met: %q", description)
+		}
+		return poll.Success()
+	}
+	poll.WaitOn(c.test, checkStopped, poll.WithDelay(1*time.Second), poll.WithTimeout(3*time.Second))
 }
 
 // PathEnvVar returns path (os sensitive) for running test

--- a/utils/e2e/mockmetrics.go
+++ b/utils/e2e/mockmetrics.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package main
+package e2e
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
**What I did**
Keep ACI/ECS backend but ship compose command in docker cli (default context) as a cli plugin to make it easier in terms of deployment esp. on linux. 

Need some additional changes : packaging as a cli plugin in Desktop & CE-packaging (linux)
This PR includes deploying the compose CLI plugin as part of the linux install script.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci
/test-ecs
/test-windows
/test-kube

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
