### PR TITLE
Add `ignore-push-failures` flag to `compose push`

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -48,7 +48,7 @@ func (cs *aciComposeService) Build(ctx context.Context, project *types.Project, 
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Push(ctx context.Context, project *types.Project) error {
+func (cs *aciComposeService) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -32,7 +32,7 @@ func (c *composeService) Build(ctx context.Context, project *types.Project, opti
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Push(ctx context.Context, project *types.Project) error {
+func (c *composeService) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -30,7 +30,7 @@ type Service interface {
 	// Build executes the equivalent to a `compose build`
 	Build(ctx context.Context, project *types.Project, options BuildOptions) error
 	// Push executes the equivalent ot a `compose push`
-	Push(ctx context.Context, project *types.Project) error
+	Push(ctx context.Context, project *types.Project, options PushOptions) error
 	// Pull executes the equivalent of a `compose pull`
 	Pull(ctx context.Context, project *types.Project) error
 	// Create executes the equivalent to a `compose create`
@@ -131,6 +131,11 @@ type ConvertOptions struct {
 	Format string
 	// Output defines the path to save the application model
 	Output string
+}
+
+// PushOptions group options of the Push API
+type PushOptions struct {
+	IgnoreFailures bool
 }
 
 // KillOptions group options of the Kill API

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -22,12 +22,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 )
 
 type pushOptions struct {
 	*projectOptions
 	composeOptions
+
+	Ignorefailures bool
 }
 
 func pushCommand(p *projectOptions) *cobra.Command {
@@ -41,6 +44,8 @@ func pushCommand(p *projectOptions) *cobra.Command {
 			return runPush(cmd.Context(), opts, args)
 		},
 	}
+	pushCmd.Flags().BoolVar(&opts.Ignorefailures, "ignore-push-failures", false, "Push what it can and ignores images with push failures")
+
 	return pushCmd
 }
 
@@ -56,7 +61,9 @@ func runPush(ctx context.Context, opts pushOptions, services []string) error {
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().Push(ctx, project)
+		return "", c.ComposeService().Push(ctx, project, compose.PushOptions{
+			IgnoreFailures: opts.Ignorefailures,
+		})
 	})
 	return err
 }

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -36,8 +36,8 @@ func (e ecsLocalSimulation) Build(ctx context.Context, project *types.Project, o
 	return e.compose.Build(ctx, project, options)
 }
 
-func (e ecsLocalSimulation) Push(ctx context.Context, project *types.Project) error {
-	return e.compose.Push(ctx, project)
+func (e ecsLocalSimulation) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
+	return e.compose.Push(ctx, project, options)
 }
 
 func (e ecsLocalSimulation) Pull(ctx context.Context, project *types.Project) error {

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -35,7 +35,7 @@ func (b *ecsAPIService) Build(ctx context.Context, project *types.Project, optio
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Push(ctx context.Context, project *types.Project) error {
+func (b *ecsAPIService) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -169,7 +169,7 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 }
 
 // Push executes the equivalent ot a `compose push`
-func (s *composeService) Push(ctx context.Context, project *types.Project) error {
+func (s *composeService) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
 	return errdefs.ErrNotImplemented
 }
 


### PR DESCRIPTION
Added `ignore-push-failures` flag to `compose push`.

```
$ docker compose push
[+] Running 0/16
 ⠴ Pushing frontend: f009a503aca1 Layer already exists                                                1.5s
...                                                                                                                                 1.5s
 ⠏ Pushing frontend: 14be20d881b0 Waiting                                                             2.9s
 ⠏ Pushing frontend: 44f7d9f20b3a Preparing                                                           2.9s
 ⠴ Pushing backend: cb381a32b229 Waiting                                                              1.5s
The new 'docker compose' command is currently experimental. To provide feedback or request new features please open issues at https://github.com/docker/compose-cli
denied: requested access to the resource is denied


$ echo $?
1

```
```
$ docker compose push --ignore-push-failures
[+] Running 0/16
 ⠦ Pushing backend: afb7f92158d1 Waiting                                                                4.6s
 ⠦ Pushing frontend: f009a503aca1 Layer already exists                                                  4.6s
 ...
 ⠦ Pushing backend: 2317ed5b21e3 Waiting                                                                4.6s
 ⠦ Pushing backend: cb381a32b229 Waiting                                                                8.4s
 ⠼ Pushing frontend: 44f7d9f20b3a Pushed                                                                8.4s
 ⠿ Pushing backend: denied: requested access to the resource is denied denied: requested access to t...                                                                      0.0s


$ echo $?
0

```