### PR TITLE
Add connection flags to root command

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -20,9 +20,14 @@ import (
 	gocontext "context"
 
 	"golang.org/x/net/context"
+
+	configfile "github.com/docker/cli/cli/config/configfile"
+	cliflags "github.com/docker/cli/cli/flags"
 )
 
 type currentContextKey struct{}
+type cliOptionsKey struct{}
+type configKey struct{}
 
 // WithCurrentContext sets the name of the current docker context
 func WithCurrentContext(ctx gocontext.Context, contextName string) context.Context {
@@ -32,5 +37,27 @@ func WithCurrentContext(ctx gocontext.Context, contextName string) context.Conte
 // CurrentContext returns the current context name
 func CurrentContext(ctx context.Context) string {
 	cc, _ := ctx.Value(currentContextKey{}).(string)
+	return cc
+}
+
+// WithCliOptions sets CLI options
+func WithCliOptions(ctx gocontext.Context, options cliflags.CommonOptions) context.Context {
+	return context.WithValue(ctx, cliOptionsKey{}, options)
+}
+
+// CliOptions returns the current context name
+func CliOptions(ctx context.Context) cliflags.CommonOptions {
+	cc, _ := ctx.Value(cliOptionsKey{}).(cliflags.CommonOptions)
+	return cc
+}
+
+// WithConfig sets docker config
+func WithConfig(ctx gocontext.Context, config configfile.ConfigFile) context.Context {
+	return context.WithValue(ctx, configKey{}, config)
+}
+
+// Config returns the docker config
+func Config(ctx context.Context) configfile.ConfigFile {
+	cc, _ := ctx.Value(cliOptionsKey{}).(configfile.ConfigFile)
 	return cc
 }

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -21,13 +21,11 @@ import (
 
 	"golang.org/x/net/context"
 
-	configfile "github.com/docker/cli/cli/config/configfile"
 	cliflags "github.com/docker/cli/cli/flags"
 )
 
 type currentContextKey struct{}
 type cliOptionsKey struct{}
-type configKey struct{}
 
 // WithCurrentContext sets the name of the current docker context
 func WithCurrentContext(ctx gocontext.Context, contextName string) context.Context {
@@ -48,16 +46,5 @@ func WithCliOptions(ctx gocontext.Context, options cliflags.CommonOptions) conte
 // CliOptions returns the current context name
 func CliOptions(ctx context.Context) cliflags.CommonOptions {
 	cc, _ := ctx.Value(cliOptionsKey{}).(cliflags.CommonOptions)
-	return cc
-}
-
-// WithConfig sets docker config
-func WithConfig(ctx gocontext.Context, config configfile.ConfigFile) context.Context {
-	return context.WithValue(ctx, configKey{}, config)
-}
-
-// Config returns the docker config
-func Config(ctx context.Context) configfile.ConfigFile {
-	cc, _ := ctx.Value(cliOptionsKey{}).(configfile.ConfigFile)
 	return cc
 }

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -43,7 +43,7 @@ func WithCliOptions(ctx gocontext.Context, options cliflags.CommonOptions) conte
 	return context.WithValue(ctx, cliOptionsKey{}, options)
 }
 
-// CliOptions returns the current context name
+// CliOptions returns common cli options
 func CliOptions(ctx context.Context) cliflags.CommonOptions {
 	cc, _ := ctx.Value(cliOptionsKey{}).(cliflags.CommonOptions)
 	return cc

--- a/cli/main.go
+++ b/cli/main.go
@@ -212,7 +212,7 @@ func main() {
 		compose.Command(ctype),
 		volume.Command(ctype),
 	)
-	if ctype == store.LocalContextType {
+	if ctype == store.DefaultContextType || ctype == store.LocalContextType {
 		if len(opts.Hosts) > 0 {
 			opts.Context = ""
 			currentContext = "default"

--- a/cli/main.go
+++ b/cli/main.go
@@ -195,6 +195,10 @@ func main() {
 	ctx = config.WithDir(ctx, configDir)
 
 	currentContext := determineCurrentContext(opts.Context, configDir)
+	if len(opts.Hosts) > 0 {
+		opts.Context = ""
+		currentContext = "default"
+	}
 
 	s, err := store.New(configDir)
 	if err != nil {
@@ -213,8 +217,6 @@ func main() {
 		volume.Command(ctype),
 	)
 
-	ctx = apicontext.WithCurrentContext(ctx, currentContext)
-
 	cnxOptions := cliflags.CommonOptions{
 		Context:   opts.Context,
 		Debug:     opts.Debug,
@@ -223,13 +225,12 @@ func main() {
 		TLS:       opts.TLS,
 		TLSVerify: opts.TLSVerify,
 	}
-	if len(opts.Hosts) == 0 {
-		cnxOptions.Context = currentContext
-	}
+
 	if opts.TLSVerify {
 		cnxOptions.TLSOptions = opts.TLSOptions
 	}
 	ctx = apicontext.WithCliOptions(ctx, cnxOptions)
+	ctx = apicontext.WithCurrentContext(ctx, currentContext)
 	ctx = store.WithContextStore(ctx, s)
 
 	if err = root.ExecuteContext(ctx); err != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -47,7 +47,6 @@ import (
 	"github.com/docker/compose-cli/cli/mobycli"
 	cliopts "github.com/docker/compose-cli/cli/options"
 
-	cliconfig "github.com/docker/cli/cli/config"
 	cliflags "github.com/docker/cli/cli/flags"
 
 	// Backend registrations
@@ -214,12 +213,6 @@ func main() {
 		volume.Command(ctype),
 	)
 
-	configFile, err := cliconfig.Load(opts.Config)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to load docker config: %s\n", opts.Config)
-		os.Exit(1)
-	}
-	ctx = apicontext.WithConfig(ctx, *configFile)
 	ctx = apicontext.WithCurrentContext(ctx, currentContext)
 
 	cnxOptions := cliflags.CommonOptions{

--- a/cli/main.go
+++ b/cli/main.go
@@ -195,10 +195,6 @@ func main() {
 	ctx = config.WithDir(ctx, configDir)
 
 	currentContext := determineCurrentContext(opts.Context, configDir)
-	if len(opts.Hosts) > 0 {
-		opts.Context = ""
-		currentContext = "default"
-	}
 
 	s, err := store.New(configDir)
 	if err != nil {
@@ -216,20 +212,26 @@ func main() {
 		compose.Command(ctype),
 		volume.Command(ctype),
 	)
+	if ctype == store.LocalContextType {
+		if len(opts.Hosts) > 0 {
+			opts.Context = ""
+			currentContext = "default"
+		}
 
-	cnxOptions := cliflags.CommonOptions{
-		Context:   opts.Context,
-		Debug:     opts.Debug,
-		Hosts:     opts.Hosts,
-		LogLevel:  opts.LogLevel,
-		TLS:       opts.TLS,
-		TLSVerify: opts.TLSVerify,
-	}
+		cnxOptions := cliflags.CommonOptions{
+			Context:   opts.Context,
+			Debug:     opts.Debug,
+			Hosts:     opts.Hosts,
+			LogLevel:  opts.LogLevel,
+			TLS:       opts.TLS,
+			TLSVerify: opts.TLSVerify,
+		}
 
-	if opts.TLSVerify {
-		cnxOptions.TLSOptions = opts.TLSOptions
+		if opts.TLSVerify {
+			cnxOptions.TLSOptions = opts.TLSOptions
+		}
+		ctx = apicontext.WithCliOptions(ctx, cnxOptions)
 	}
-	ctx = apicontext.WithCliOptions(ctx, cnxOptions)
 	ctx = apicontext.WithCurrentContext(ctx, currentContext)
 	ctx = store.WithContextStore(ctx, s)
 

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -44,20 +44,24 @@ func TestDetermineCurrentContext(t *testing.T) {
 	assert.NilError(t, err)
 
 	// If nothing set, fallback to default
-	c := determineCurrentContext("", "")
+	c := determineCurrentContext("", "", []string{})
 	assert.Equal(t, c, "default")
 
 	// If context flag set, use that
-	c = determineCurrentContext("other-context", "")
+	c = determineCurrentContext("other-context", "", []string{})
 	assert.Equal(t, c, "other-context")
 
 	// If no context flag, use config
-	c = determineCurrentContext("", d)
+	c = determineCurrentContext("", d, []string{})
 	assert.Equal(t, c, "some-context")
 
 	// Ensure context flag overrides config
-	c = determineCurrentContext("other-context", d)
+	c = determineCurrentContext("other-context", d, []string{})
 	assert.Equal(t, "other-context", c)
+
+	// Ensure host flag overrides context
+	c = determineCurrentContext("other-context", d, []string{"hostname"})
+	assert.Equal(t, "default", c)
 }
 
 func TestCheckOwnCommand(t *testing.T) {

--- a/cli/options/options.go
+++ b/cli/options/options.go
@@ -17,16 +17,14 @@
 package options
 
 import (
-	apicontext "github.com/docker/compose-cli/api/context"
 	cliconfig "github.com/docker/compose-cli/cli/config"
+
+	cliflags "github.com/docker/cli/cli/flags"
 )
 
 // GlobalOpts contains the global CLI options
 type GlobalOpts struct {
-	apicontext.ContextFlags
 	cliconfig.ConfigFlags
-	Debug    bool
-	LogLevel string
-	Version  bool
-	Host     string
+	cliflags.CommonOptions
+	Version bool
 }

--- a/local/backend.go
+++ b/local/backend.go
@@ -22,13 +22,17 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/cloud"
+
 	"github.com/docker/compose-cli/api/compose"
+	apiconfig "github.com/docker/compose-cli/api/config"
 	"github.com/docker/compose-cli/api/containers"
 	apicontext "github.com/docker/compose-cli/api/context"
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	local_compose "github.com/docker/compose-cli/local/compose"
+
+	cliconfig "github.com/docker/cli/cli/config"
 )
 
 type local struct {
@@ -43,9 +47,12 @@ func init() {
 
 func service(ctx context.Context) (backend.Service, error) {
 	options := apicontext.CliOptions(ctx)
-	config := apicontext.Config(ctx)
-
-	apiClient, err := command.NewAPIClientFromFlags(&options, &config)
+	config := apiconfig.Dir(ctx)
+	configFile, err := cliconfig.Load(config)
+	if err != nil {
+		return nil, err
+	}
+	apiClient, err := command.NewAPIClientFromFlags(&options, configFile)
 	if err != nil {
 		return nil, err
 	}

--- a/local/backend.go
+++ b/local/backend.go
@@ -19,12 +19,12 @@ package local
 import (
 	"context"
 
-	"github.com/docker/docker/client"
-
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/cloud"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/containers"
+	apicontext "github.com/docker/compose-cli/api/context"
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
@@ -42,7 +42,10 @@ func init() {
 }
 
 func service(ctx context.Context) (backend.Service, error) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	options := apicontext.CliOptions(ctx)
+	config := apicontext.Config(ctx)
+
+	apiClient, err := command.NewAPIClientFromFlags(&options, &config)
 	if err != nil {
 		return nil, err
 	}

--- a/local/containers.go
+++ b/local/containers.go
@@ -39,10 +39,11 @@ import (
 )
 
 type containerService struct {
-	apiClient *client.Client
+	apiClient client.APIClient
 }
 
 func (cs *containerService) Inspect(ctx context.Context, id string) (containers.Container, error) {
+
 	c, err := cs.apiClient.ContainerInspect(ctx, id)
 	if err != nil {
 		return containers.Container{}, err

--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -398,7 +398,7 @@ func TestLegacy(t *testing.T) {
 	t.Run("host flag", func(t *testing.T) {
 		stderr := "dial tcp: lookup nonexistent"
 		if runtime.GOOS == "windows" {
-			stderr = "error during connect: Get http://nonexitent:123"
+			stderr = "dial tcp: lookup nonexistent: no such host"
 		}
 		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
 		res.Assert(t, icmd.Expected{

--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -396,14 +396,14 @@ func TestLegacy(t *testing.T) {
 	})
 
 	t.Run("host flag", func(t *testing.T) {
-		stderr := []string{"dial tcp: lookup nonexistent", "no such host"}
-		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
-		res.Assert(t, icmd.Expected{
-			ExitCode: 1,
-		})
-		for _, s := range stderr {
-			assert.Assert(t, strings.Contains(res.Stderr(), s), res.Stderr())
+		stderr := "dial tcp: lookup nonexistent"
+		if runtime.GOOS == "windows" {
+			stderr = "dial tcp: lookup nonexistent: no such host"
 		}
+		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
+		assert.Assert(t, res.ExitCode == 1)
+		assert.Assert(t, strings.Contains(res.Stdout(), stderr), res.Stdout())
+
 	})
 
 	t.Run("existing contexts delegate", func(t *testing.T) {

--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -396,15 +396,15 @@ func TestLegacy(t *testing.T) {
 	})
 
 	t.Run("host flag", func(t *testing.T) {
-		stderr := "nonexistent: Name or service not known"
+		stderr := "dial tcp: lookup nonexistent"
 		if runtime.GOOS == "windows" {
 			stderr = "error during connect: Get http://nonexitent:123"
 		}
 		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
-			Err:      stderr,
 		})
+		assert.Assert(t, strings.Contains(res.Stderr(), stderr), res.Stderr())
 	})
 
 	t.Run("existing contexts delegate", func(t *testing.T) {

--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -396,11 +396,11 @@ func TestLegacy(t *testing.T) {
 	})
 
 	t.Run("host flag", func(t *testing.T) {
-		stderr := "Cannot connect to the Docker daemon at tcp://localhost:123"
+		stderr := "nonexistent: Name or service not known"
 		if runtime.GOOS == "windows" {
-			stderr = "error during connect: Get http://localhost:123"
+			stderr = "error during connect: Get http://nonexitent:123"
 		}
-		res := c.RunDockerOrExitError("-H", "tcp://localhost:123", "version")
+		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 			Err:      stderr,

--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -396,15 +396,14 @@ func TestLegacy(t *testing.T) {
 	})
 
 	t.Run("host flag", func(t *testing.T) {
-		stderr := "dial tcp: lookup nonexistent"
-		if runtime.GOOS == "windows" {
-			stderr = "dial tcp: lookup nonexistent: no such host"
-		}
+		stderr := []string{"dial tcp: lookup nonexistent", "no such host"}
 		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
 		res.Assert(t, icmd.Expected{
 			ExitCode: 1,
 		})
-		assert.Assert(t, strings.Contains(res.Stderr(), stderr), res.Stderr())
+		for _, s := range stderr {
+			assert.Assert(t, strings.Contains(res.Stderr(), s), res.Stderr())
+		}
 	})
 
 	t.Run("existing contexts delegate", func(t *testing.T) {

--- a/local/volumes.go
+++ b/local/volumes.go
@@ -29,7 +29,7 @@ import (
 )
 
 type volumeService struct {
-	apiClient *client.Client
+	apiClient client.APIClient
 }
 
 func (vs *volumeService) List(ctx context.Context) ([]volumes.Volume, error) {


### PR DESCRIPTION
**What I did**
Added common flags to the root command: tls, cert flags etc.

Initialized the API client with the docker/cli `NewAPIClientFromFlags` which processes the config and tls options. This way we avoid duplicating the code that is already in the original cli. 


Set up a secured Docker engine following https://docs.docker.com/engine/security/protect-access/#use-tls-https-to-protect-the-docker-daemon-socket

```
$ docker -H=127.0.0.1:2376 compose ps
The new 'docker compose' command is currently experimental. To provide feedback or request new features please open issues at https://github.com/docker/compose-cli
Error response from daemon: Client sent an HTTP request to an HTTPS server.

```
```
$ docker --tlsverify --tlscacert=/tmp/certs/ca.pem --tlscert=/tmp/certs/cert.pem --tlskey=/tmp/certs/key.pem -H=127.0.0.1:2376 compose ps
NAME                SERVICE             STATUS              PORTS
```

```
$ docker --tlsverify --tlscacert=/tmp/certs/ca.pem --tlscert=/tmp/certs/cert.pem --tlskey=/tmp/certs/key.pem -H=127.0.0.1:2376 compose up -d
[+] Running 1/1
 ⠿ Container compose-cli_web_1  Started                                                                                                                                      0.8s
```
```
$ docker --tlsverify --tlscacert=/tmp/certs/ca.pem --tlscert=/tmp/certs/cert.pem --tlskey=/tmp/certs/key.pem -H=127.0.0.1:2376 compose ps
NAME                SERVICE             STATUS              PORTS
compose-cli_web_1   web                 running             0.0.0.0:8080->80/tcp
```
```
$ docker --tlsverify --tlscacert=/tmp/certs/ca.pem --tlscert=/tmp/certs/cert.pem --tlskey=/tmp/certs/key.pem -H=127.0.0.1:2376 compose down
[+] Running 2/2
 ⠿ Container compose-cli_web_1    Removed                                                                                                                                    0.5s
 ⠿ Network "compose-cli_default"  Removed                                                                                                                                    0.5s


```




```
$ docker context use sshcontext
sshcontext

$ docker context ls
NAME                TYPE                DESCRIPTION                               DOCKER ENDPOINT               KUBERNETES ENDPOINT                 ORCHESTRATOR
default             moby                Current DOCKER_HOST based configuration   unix:///var/run/docker.sock   https://127.0.0.1:42745 (default)   swarm
sshcontext *        moby                My HOME server                            ssh://host                                                         
```

```
$ docker compose up
[+] Running 2/1
 ⠿ Network "compose-cli_default"  Created       0.3s
 ⠿ Container compose-cli_web_1    Created       0.0s
Attaching to compose-cli_web_1
...
```

```
$ docker -H ssh://host compose ps
NAME                SERVICE             STATUS              PORTS
compose-cli_web_1   web                 running             0.0.0.0:8080->80/tcp
```
```
$ docker compose ps
NAME                SERVICE             STATUS              PORTS
compose-cli_web_1   web                 running             0.0.0.0:8080->80/tcp

```
 

/test-kube
/test-aci
/test-ecs
/test-windows