### PR TITLE
Add remote engine context e2e

### DIFF
--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -396,14 +396,19 @@ func TestLegacy(t *testing.T) {
 	})
 
 	t.Run("host flag", func(t *testing.T) {
-		stderr := "dial tcp: lookup nonexistent"
-		if runtime.GOOS == "windows" {
-			stderr = "dial tcp: lookup nonexistent: no such host"
-		}
 		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
 		assert.Assert(t, res.ExitCode == 1)
-		assert.Assert(t, strings.Contains(res.Stdout(), stderr), res.Stdout())
+		assert.Assert(t, strings.Contains(res.Stdout(), "dial tcp: lookup nonexistent"), res.Stdout())
 
+	})
+
+	t.Run("remote engine context", func(t *testing.T) {
+		c.RunDockerCmd("context", "create", "test-remote-engine", "--docker", "host=tcp://nonexistent:1234")
+		c.RunDockerCmd("context", "use", "test-remote-engine")
+
+		res := c.RunDockerOrExitError("version")
+		assert.Assert(t, res.ExitCode == 1)
+		assert.Assert(t, strings.Contains(res.Stdout(), "dial tcp: lookup nonexistent"), res.Stdout())
 	})
 
 	t.Run("existing contexts delegate", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* validate docker context endpoint is used to get client API, after [change](https://github.com/docker/compose-cli/pull/1400/files#diff-be34777339b68875b2a1c4923c82e1e4761b90f632d6993f8b859a25bcb952feR55) from #1400 
* Add e2e test for context pointing to remote engine

**Related issue**

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
