### PR TITLE
refactoring: create backend in main then pass as command target

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -17,7 +17,6 @@
 package aci
 
 import (
-	"context"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
@@ -68,9 +67,9 @@ func init() {
 	backend.Register(backendType, backendType, service, getCloudService)
 }
 
-func service(ctx context.Context) (backend.Service, error) {
-	contextStore := store.ContextStore(ctx)
-	currentContext := apicontext.CurrentContext(ctx)
+func service() (backend.Service, error) {
+	contextStore := store.Instance()
+	currentContext := apicontext.Current()
 	var aciContext store.AciContext
 
 	if err := contextStore.GetEndpoint(currentContext, &aciContext); err != nil {

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -28,17 +27,16 @@ import (
 	"github.com/docker/compose-cli/api/context/store"
 )
 
-type dirKey struct{}
+var configDir string
 
 // WithDir sets the config directory path in the context
-func WithDir(ctx context.Context, path string) context.Context {
-	return context.WithValue(ctx, dirKey{}, path)
+func WithDir(path string) {
+	configDir = path
 }
 
 // Dir returns the config directory path
-func Dir(ctx context.Context) string {
-	cd, _ := ctx.Value(dirKey{}).(string)
-	return cd
+func Dir() string {
+	return configDir
 }
 
 // LoadFile loads the docker configuration

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -16,35 +16,14 @@
 
 package context
 
-import (
-	gocontext "context"
-
-	"golang.org/x/net/context"
-
-	cliflags "github.com/docker/cli/cli/flags"
-)
-
-type currentContextKey struct{}
-type cliOptionsKey struct{}
+var current string
 
 // WithCurrentContext sets the name of the current docker context
-func WithCurrentContext(ctx gocontext.Context, contextName string) context.Context {
-	return context.WithValue(ctx, currentContextKey{}, contextName)
+func WithCurrentContext(contextName string) {
+	current = contextName
 }
 
-// CurrentContext returns the current context name
-func CurrentContext(ctx context.Context) string {
-	cc, _ := ctx.Value(currentContextKey{}).(string)
-	return cc
-}
-
-// WithCliOptions sets CLI options
-func WithCliOptions(ctx gocontext.Context, options cliflags.CommonOptions) context.Context {
-	return context.WithValue(ctx, cliOptionsKey{}, options)
-}
-
-// CliOptions returns common cli options
-func CliOptions(ctx context.Context) cliflags.CommonOptions {
-	cc, _ := ctx.Value(cliOptionsKey{}).(cliflags.CommonOptions)
-	return cc
+// Current returns the current context name
+func Current() string {
+	return current
 }

--- a/api/context/store/store.go
+++ b/api/context/store/store.go
@@ -17,7 +17,6 @@
 package store
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -67,17 +66,16 @@ const (
 	metaFile          = "meta.json"
 )
 
-type contextStoreKey struct{}
+var instance Store
 
 // WithContextStore adds the store to the context
-func WithContextStore(ctx context.Context, store Store) context.Context {
-	return context.WithValue(ctx, contextStoreKey{}, store)
+func WithContextStore(store Store) {
+	instance = store
 }
 
-// ContextStore returns the store from the context
-func ContextStore(ctx context.Context) Store {
-	s, _ := ctx.Value(contextStoreKey{}).(Store)
-	return s
+// Instance returns the store from the context
+func Instance() Store {
+	return instance
 }
 
 // Store is the context store

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -63,7 +63,7 @@ func buildCommand(p *projectOptions) *cobra.Command {
 }
 
 func runBuild(ctx context.Context, opts buildOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -77,7 +77,7 @@ func convertCommand(p *projectOptions) *cobra.Command {
 
 func runConvert(ctx context.Context, opts convertOptions, services []string) error {
 	var json []byte
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func runConvert(ctx context.Context, opts convertOptions, services []string) err
 	}
 
 	if opts.resolve {
-		configFile, err := cliconfig.Load(config.Dir(ctx))
+		configFile, err := cliconfig.Load(config.Dir())
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -69,7 +69,7 @@ func downCommand(p *projectOptions, contextType string) *cobra.Command {
 }
 
 func runDown(ctx context.Context, opts downOptions) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/events.go
+++ b/cli/cmd/compose/events.go
@@ -51,7 +51,7 @@ func eventsCommand(p *projectOptions) *cobra.Command {
 }
 
 func runEvents(ctx context.Context, opts eventsOpts, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/exec.go
+++ b/cli/cmd/compose/exec.go
@@ -75,7 +75,7 @@ func execCommand(p *projectOptions) *cobra.Command {
 }
 
 func runExec(ctx context.Context, opts execOpts) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/kill.go
+++ b/cli/cmd/compose/kill.go
@@ -49,7 +49,7 @@ func killCommand(p *projectOptions) *cobra.Command {
 }
 
 func runKill(ctx context.Context, opts killOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -69,7 +69,7 @@ func runList(ctx context.Context, opts lsOptions) error {
 		return err
 	}
 
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -62,7 +62,7 @@ func logsCommand(p *projectOptions, contextType string) *cobra.Command {
 }
 
 func runLogs(ctx context.Context, opts logsOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/pause.go
+++ b/cli/cmd/compose/pause.go
@@ -44,7 +44,7 @@ func pauseCommand(p *projectOptions) *cobra.Command {
 }
 
 func runPause(ctx context.Context, opts pauseOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func unpauseCommand(p *projectOptions) *cobra.Command {
 }
 
 func runUnPause(ctx context.Context, opts unpauseOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -58,7 +58,7 @@ func psCommand(p *projectOptions) *cobra.Command {
 }
 
 func runPs(ctx context.Context, opts psOptions) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -49,7 +49,7 @@ func pullCommand(p *projectOptions) *cobra.Command {
 }
 
 func runPull(ctx context.Context, opts pullOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -50,7 +50,7 @@ func pushCommand(p *projectOptions) *cobra.Command {
 }
 
 func runPush(ctx context.Context, opts pushOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/remove.go
+++ b/cli/cmd/compose/remove.go
@@ -61,7 +61,7 @@ Any data which is not in a volume will be lost.`,
 }
 
 func runRemove(ctx context.Context, opts removeOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -45,7 +45,7 @@ func startCommand(p *projectOptions) *cobra.Command {
 }
 
 func runStart(ctx context.Context, opts startOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/stop.go
+++ b/cli/cmd/compose/stop.go
@@ -52,7 +52,7 @@ func stopCommand(p *projectOptions) *cobra.Command {
 }
 
 func runStop(ctx context.Context, opts stopOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/top.go
+++ b/cli/cmd/compose/top.go
@@ -49,7 +49,7 @@ func topCommand(p *projectOptions) *cobra.Command {
 }
 
 func runTop(ctx context.Context, opts topOptions, services []string) error {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -338,7 +338,7 @@ func setServiceScale(project *types.Project, name string, replicas int) error {
 }
 
 func setup(ctx context.Context, opts composeOptions, services []string) (*client.Client, *types.Project, error) {
-	c, err := client.NewWithDefaultLocalBackend(ctx)
+	c, err := client.New(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/cmd/context/create.go
+++ b/cli/cmd/context/create.go
@@ -17,7 +17,6 @@
 package context
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -103,15 +102,15 @@ func createLocalCommand() *cobra.Command {
 		Args:   cobra.ExactArgs(1),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return createDockerContext(cmd.Context(), args[0], store.LocalContextType, opts.description, store.LocalContext{})
+			return createDockerContext(args[0], store.LocalContextType, opts.description, store.LocalContext{})
 		},
 	}
 	addDescriptionFlag(cmd, &opts.description)
 	return cmd
 }
 
-func createDockerContext(ctx context.Context, name string, contextType string, description string, data interface{}) error {
-	s := store.ContextStore(ctx)
+func createDockerContext(name string, contextType string, description string, data interface{}) error {
+	s := store.Instance()
 	result := s.Create(
 		name,
 		contextType,
@@ -122,8 +121,8 @@ func createDockerContext(ctx context.Context, name string, contextType string, d
 	return result
 }
 
-func contextExists(ctx context.Context, name string) bool {
-	s := store.ContextStore(ctx)
+func contextExists(name string) bool {
+	s := store.Instance()
 	return s.ContextExists(name)
 }
 

--- a/cli/cmd/context/create_aci.go
+++ b/cli/cmd/context/create_aci.go
@@ -57,7 +57,7 @@ func createAciCommand() *cobra.Command {
 }
 
 func runCreateAci(ctx context.Context, contextName string, opts aci.ContextParams) error {
-	if contextExists(ctx, contextName) {
+	if contextExists(contextName) {
 		return errors.Wrapf(errdefs.ErrAlreadyExists, "context %s", contextName)
 	}
 	contextData, description, err := getAciContextData(ctx, opts)
@@ -67,7 +67,7 @@ func runCreateAci(ctx context.Context, contextName string, opts aci.ContextParam
 		}
 		return err
 	}
-	return createDockerContext(ctx, contextName, store.AciContextType, description, contextData)
+	return createDockerContext(contextName, store.AciContextType, description, contextData)
 
 }
 

--- a/cli/cmd/context/create_ecs.go
+++ b/cli/cmd/context/create_ecs.go
@@ -109,7 +109,7 @@ func parseAccessKeysFile(file string, opts *ecs.ContextParams) error {
 }
 
 func runCreateLocalSimulation(ctx context.Context, contextName string, opts ecs.ContextParams) error {
-	if contextExists(ctx, contextName) {
+	if contextExists(contextName) {
 		return errors.Wrapf(errdefs.ErrAlreadyExists, "context %q", contextName)
 	}
 	cs, err := client.GetCloudService(ctx, store.EcsLocalSimulationContextType)
@@ -120,18 +120,18 @@ func runCreateLocalSimulation(ctx context.Context, contextName string, opts ecs.
 	if err != nil {
 		return err
 	}
-	return createDockerContext(ctx, contextName, store.EcsLocalSimulationContextType, description, data)
+	return createDockerContext(contextName, store.EcsLocalSimulationContextType, description, data)
 }
 
 func runCreateEcs(ctx context.Context, contextName string, opts ecs.ContextParams) error {
-	if contextExists(ctx, contextName) {
+	if contextExists(contextName) {
 		return errors.Wrapf(errdefs.ErrAlreadyExists, "context %q", contextName)
 	}
 	contextData, description, err := getEcsContextData(ctx, opts)
 	if err != nil {
 		return err
 	}
-	return createDockerContext(ctx, contextName, store.EcsContextType, description, contextData)
+	return createDockerContext(contextName, store.EcsContextType, description, contextData)
 
 }
 

--- a/cli/cmd/context/create_kube.go
+++ b/cli/cmd/context/create_kube.go
@@ -19,8 +19,6 @@
 package context
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -45,7 +43,7 @@ func createKubeCommand() *cobra.Command {
 		Short: "Create context for a Kubernetes Cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCreateKube(cmd.Context(), args[0], opts)
+			return runCreateKube(args[0], opts)
 		},
 	}
 
@@ -56,8 +54,8 @@ func createKubeCommand() *cobra.Command {
 	return cmd
 }
 
-func runCreateKube(ctx context.Context, contextName string, opts kube.ContextParams) error {
-	if contextExists(ctx, contextName) {
+func runCreateKube(contextName string, opts kube.ContextParams) error {
+	if contextExists(contextName) {
 		return errors.Wrapf(errdefs.ErrAlreadyExists, "context %q", contextName)
 	}
 
@@ -65,5 +63,5 @@ func runCreateKube(ctx context.Context, contextName string, opts kube.ContextPar
 	if err != nil {
 		return err
 	}
-	return createDockerContext(ctx, contextName, store.KubeContextType, description, contextData)
+	return createDockerContext(contextName, store.KubeContextType, description, contextData)
 }

--- a/cli/cmd/context/ls.go
+++ b/cli/cmd/context/ls.go
@@ -73,9 +73,8 @@ func runList(cmd *cobra.Command, opts lsOpts) error {
 		return nil
 	}
 
-	ctx := cmd.Context()
-	currentContext := apicontext.CurrentContext(ctx)
-	s := store.ContextStore(ctx)
+	currentContext := apicontext.Current()
+	s := store.Instance()
 	contexts, err := s.List()
 	if err != nil {
 		return err

--- a/cli/cmd/context/rm.go
+++ b/cli/cmd/context/rm.go
@@ -17,7 +17,6 @@
 package context
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -41,7 +40,7 @@ func removeCommand() *cobra.Command {
 		Aliases: []string{"remove"},
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), args, opts.force)
+			return runRemove(args, opts.force)
 		},
 	}
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force removing current context")
@@ -49,15 +48,15 @@ func removeCommand() *cobra.Command {
 	return cmd
 }
 
-func runRemove(ctx context.Context, args []string, force bool) error {
-	currentContext := apicontext.CurrentContext(ctx)
-	s := store.ContextStore(ctx)
+func runRemove(args []string, force bool) error {
+	currentContext := apicontext.Current()
+	s := store.Instance()
 
 	var errs *multierror.Error
 	for _, contextName := range args {
 		if currentContext == contextName {
 			if force {
-				if err := runUse(ctx, "default"); err != nil {
+				if err := runUse("default"); err != nil {
 					errs = multierror.Append(errs, errors.New("cannot delete current context"))
 				} else {
 					errs = removeContext(s, contextName, errs)

--- a/cli/cmd/context/show.go
+++ b/cli/cmd/context/show.go
@@ -17,7 +17,6 @@
 package context
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -32,16 +31,16 @@ func showCommand() *cobra.Command {
 		Short: "Print the current context",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runShow(cmd.Context())
+			return runShow()
 		},
 	}
 }
 
-func runShow(ctx context.Context) error {
-	name := apicontext.CurrentContext(ctx)
+func runShow() error {
+	name := apicontext.Current()
 	// Match behavior of existing CLI
 	if name != store.DefaultContextName {
-		s := store.ContextStore(ctx)
+		s := store.Instance()
 		if _, err := s.Get(name); err != nil {
 			return err
 		}

--- a/cli/cmd/context/update.go
+++ b/cli/cmd/context/update.go
@@ -72,7 +72,7 @@ $ docker context update my-context --description "some description" --docker "ho
 }
 
 func runUpdate(cmd *cobra.Command, name string) error {
-	s := store.ContextStore(cmd.Context())
+	s := store.Instance()
 	dockerContext, err := s.Get(name)
 	if err == nil && dockerContext != nil {
 		if dockerContext.Type() != store.DefaultContextType {

--- a/cli/cmd/context/use.go
+++ b/cli/cmd/context/use.go
@@ -17,7 +17,6 @@
 package context
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -32,20 +31,20 @@ func useCommand() *cobra.Command {
 		Short: "Set the default context",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUse(cmd.Context(), args[0])
+			return runUse(args[0])
 		},
 	}
 }
 
-func runUse(ctx context.Context, name string) error {
-	s := store.ContextStore(ctx)
+func runUse(name string) error {
+	s := store.Instance()
 	// Match behavior of existing CLI
 	if name != store.DefaultContextName {
 		if _, err := s.Get(name); err != nil {
 			return err
 		}
 	}
-	if err := config.WriteCurrentContext(config.Dir(ctx), name); err != nil {
+	if err := config.WriteCurrentContext(config.Dir(), name); err != nil {
 		return err
 	}
 	fmt.Println(name)

--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -39,9 +39,9 @@ const ComDockerCli = "com.docker.cli"
 
 // ExecIfDefaultCtxType delegates to com.docker.cli if on moby context
 func ExecIfDefaultCtxType(ctx context.Context, root *cobra.Command) {
-	currentContext := apicontext.CurrentContext(ctx)
+	currentContext := apicontext.Current()
 
-	s := store.ContextStore(ctx)
+	s := store.Instance()
 
 	currentCtx, err := s.Get(currentContext)
 	// Only run original docker command if the current context is not ours.

--- a/cli/server/interceptor.go
+++ b/cli/server/interceptor.go
@@ -40,7 +40,7 @@ func unaryServerInterceptor(clictx context.Context) grpc.UnaryServerInterceptor 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		currentContext, err := getIncomingContext(ctx)
 		if err != nil {
-			currentContext, err = getConfigContext(clictx)
+			currentContext, err = getConfigContext()
 			if err != nil {
 				return nil, err
 			}
@@ -59,7 +59,7 @@ func streamServerInterceptor(clictx context.Context) grpc.StreamServerIntercepto
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		currentContext, err := getIncomingContext(ss.Context())
 		if err != nil {
-			currentContext, err = getConfigContext(clictx)
+			currentContext, err = getConfigContext()
 			if err != nil {
 				return err
 			}
@@ -77,8 +77,8 @@ func streamServerInterceptor(clictx context.Context) grpc.StreamServerIntercepto
 }
 
 // Returns the current context from the configuration file
-func getConfigContext(ctx context.Context) (string, error) {
-	configDir := config.Dir(ctx)
+func getConfigContext() (string, error) {
+	configDir := config.Dir()
 	configFile, err := config.LoadFile(configDir)
 	if err != nil {
 		return "", err
@@ -100,9 +100,9 @@ func getIncomingContext(ctx context.Context) (string, error) {
 // configureContext populates the request context with objects the client
 // needs: the context store and the api client
 func configureContext(ctx context.Context, currentContext string, method string) (context.Context, error) {
-	configDir := config.Dir(ctx)
+	configDir := config.Dir()
 
-	ctx = apicontext.WithCurrentContext(ctx, currentContext)
+	apicontext.WithCurrentContext(currentContext)
 
 	// The contexts service doesn't need the client
 	if !strings.Contains(method, "/com.docker.api.protos.context.v1.Contexts") {
@@ -118,7 +118,7 @@ func configureContext(ctx context.Context, currentContext string, method string)
 	if err != nil {
 		return nil, err
 	}
-	ctx = store.WithContextStore(ctx, s)
+	store.WithContextStore(s)
 
 	return ctx, nil
 }

--- a/cli/server/interceptor_test.go
+++ b/cli/server/interceptor_test.go
@@ -41,7 +41,7 @@ func testContext(t *testing.T) context.Context {
 	})
 
 	ctx := context.Background()
-	ctx = config.WithDir(ctx, dir)
+	config.WithDir(dir)
 	err = ioutil.WriteFile(path.Join(dir, "config.json"), []byte(`{"currentContext": "default"}`), 0644)
 	assert.NilError(t, err)
 
@@ -100,7 +100,7 @@ func callStream(ctx context.Context, t *testing.T, interceptor grpc.StreamServer
 	}, &grpc.StreamServerInfo{
 		FullMethod: "/com.docker.api.protos.context.v1.Contexts/test",
 	}, func(srv interface{}, stream grpc.ServerStream) error {
-		currentContext = apicontext.CurrentContext(stream.Context())
+		currentContext = apicontext.Current()
 		return nil
 	})
 
@@ -114,7 +114,7 @@ func callUnary(ctx context.Context, t *testing.T, interceptor grpc.UnaryServerIn
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
 		FullMethod: "/com.docker.api.protos.context.v1.Contexts/test",
 	}, func(ctx context.Context, req interface{}) (interface{}, error) {
-		currentContext = apicontext.CurrentContext(ctx)
+		currentContext = apicontext.Current()
 		return nil, nil
 	})
 

--- a/cli/server/proxy/contexts.go
+++ b/cli/server/proxy/contexts.go
@@ -37,7 +37,7 @@ func (cp *contextsProxy) SetCurrent(ctx context.Context, request *contextsv1.Set
 }
 
 func (cp *contextsProxy) List(ctx context.Context, request *contextsv1.ListRequest) (*contextsv1.ListResponse, error) {
-	s := store.ContextStore(ctx)
+	s := store.Instance()
 	configFile, err := config.LoadFile(cp.configDir)
 	if err != nil {
 		return nil, err

--- a/cli/server/proxy/proxy.go
+++ b/cli/server/proxy/proxy.go
@@ -62,7 +62,7 @@ type proxy struct {
 
 // New creates a new proxy server
 func New(ctx context.Context) Proxy {
-	configDir := config.Dir(ctx)
+	configDir := config.Dir()
 	return &proxy{
 		configDir: configDir,
 		streams:   map[string]*streams.Stream{},

--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -63,9 +63,9 @@ func init() {
 	backend.Register(backendType, backendType, service, getCloudService)
 }
 
-func service(ctx context.Context) (backend.Service, error) {
-	contextStore := store.ContextStore(ctx)
-	currentContext := apicontext.CurrentContext(ctx)
+func service() (backend.Service, error) {
+	contextStore := store.Instance()
+	currentContext := apicontext.Current()
 	var ecsContext store.EcsContext
 
 	if err := contextStore.GetEndpoint(currentContext, &ecsContext); err != nil {

--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -104,7 +104,7 @@ func (b *ecsAPIService) Convert(ctx context.Context, project *types.Project, opt
 }
 
 func (b *ecsAPIService) resolveServiceImagesDigests(ctx context.Context, project *types.Project) error {
-	configFile, err := cliconfig.Load(config.Dir(ctx))
+	configFile, err := cliconfig.Load(config.Dir())
 	if err != nil {
 		return err
 	}

--- a/ecs/local/backend.go
+++ b/ecs/local/backend.go
@@ -17,8 +17,6 @@
 package local
 
 import (
-	"context"
-
 	local_compose "github.com/docker/compose-cli/local/compose"
 
 	"github.com/docker/docker/client"
@@ -44,7 +42,7 @@ type ecsLocalSimulation struct {
 	compose compose.Service
 }
 
-func service(ctx context.Context) (backend.Service, error) {
+func service() (backend.Service, error) {
 	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/fasttemplate v1.2.1 // indirect
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	google.golang.org/grpc v1.33.2

--- a/kube/backend.go
+++ b/kube/backend.go
@@ -19,8 +19,6 @@
 package kube
 
 import (
-	"context"
-
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/cloud"
 	"github.com/docker/compose-cli/api/compose"
@@ -41,8 +39,8 @@ func init() {
 	backend.Register(backendType, backendType, service, cloud.NotImplementedCloudService)
 }
 
-func service(ctx context.Context) (backend.Service, error) {
-	s, err := NewComposeService(ctx)
+func service() (backend.Service, error) {
+	s, err := NewComposeService()
 	if err != nil {
 		return nil, err
 	}

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -42,9 +42,9 @@ type composeService struct {
 }
 
 // NewComposeService create a kubernetes implementation of the compose.Service API
-func NewComposeService(ctx context.Context) (compose.Service, error) {
-	contextStore := store.ContextStore(ctx)
-	currentContext := apicontext.CurrentContext(ctx)
+func NewComposeService() (compose.Service, error) {
+	contextStore := store.Instance()
+	currentContext := apicontext.Current()
 	var kubeContext store.KubeContext
 
 	if err := contextStore.GetEndpoint(currentContext, &kubeContext); err != nil {

--- a/local/backend.go
+++ b/local/backend.go
@@ -17,22 +17,15 @@
 package local
 
 import (
-	"context"
+	"github.com/docker/docker/client"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose-cli/api/backend"
-	"github.com/docker/compose-cli/api/cloud"
-
 	"github.com/docker/compose-cli/api/compose"
-	apiconfig "github.com/docker/compose-cli/api/config"
 	"github.com/docker/compose-cli/api/containers"
-	apicontext "github.com/docker/compose-cli/api/context"
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
 	local_compose "github.com/docker/compose-cli/local/compose"
-
-	cliconfig "github.com/docker/cli/cli/config"
 )
 
 type local struct {
@@ -41,27 +34,13 @@ type local struct {
 	composeService   compose.Service
 }
 
-func init() {
-	backend.Register("local", "local", service, cloud.NotImplementedCloudService)
-}
-
-func service(ctx context.Context) (backend.Service, error) {
-	options := apicontext.CliOptions(ctx)
-	config := apiconfig.Dir(ctx)
-	configFile, err := cliconfig.Load(config)
-	if err != nil {
-		return nil, err
-	}
-	apiClient, err := command.NewAPIClientFromFlags(&options, configFile)
-	if err != nil {
-		return nil, err
-	}
-
+// NewService build a backend for "local" context, using Docker API client
+func NewService(apiClient client.APIClient) backend.Service {
 	return &local{
 		containerService: &containerService{apiClient},
 		volumeService:    &volumeService{apiClient},
 		composeService:   local_compose.NewComposeService(apiClient),
-	}, nil
+	}
 }
 
 func (s *local) ContainerService() containers.Service {

--- a/local/compose/pull.go
+++ b/local/compose/pull.go
@@ -37,7 +37,7 @@ import (
 )
 
 func (s *composeService) Pull(ctx context.Context, project *types.Project) error {
-	configFile, err := cliconfig.Load(config.Dir(ctx))
+	configFile, err := cliconfig.Load(config.Dir())
 	if err != nil {
 		return err
 	}

--- a/local/compose/push.go
+++ b/local/compose/push.go
@@ -39,7 +39,7 @@ import (
 )
 
 func (s *composeService) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
-	configFile, err := cliconfig.Load(config.Dir(ctx))
+	configFile, err := cliconfig.Load(config.Dir())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What I did**
Changed architecture: backend is created from `main`(where init can depend on actual CLI flags) then pass to commands as target to execute

/test-ecs
/test-aci
/test-windows
/test-kube