### PR TITLE
Adding support for compose file attributes

### DIFF
--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -189,6 +189,7 @@ func (s *composeService) toBuildOptions(service types.ServiceConfig, contextPath
 		Target:    service.Build.Target,
 		Exports:   []bclient.ExportEntry{{Type: "image", Attrs: map[string]string{}}},
 		Platforms: plats,
+		Labels:    service.Labels,
 	}, nil
 }
 

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -289,6 +289,12 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		Resources:    resources,
 		VolumeDriver: service.VolumeDriver,
 		VolumesFrom:  service.VolumesFrom,
+		DNS:          service.DNS,
+		DNSSearch:    service.DNSSearch,
+		DNSOptions:   service.DNSOpts,
+		ExtraHosts:   service.ExtraHosts,
+		SecurityOpt:  service.SecurityOpt,
+		UsernsMode:   container.UsernsMode(service.UserNSMode),
 	}
 
 	networkConfig := buildDefaultNetworkConfig(service, networkMode, getContainerName(p.Name, service, number))


### PR DESCRIPTION
**What I did**

* Add a few obvious mappings to support more attributes in Composefiles

**Related issue**


<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
