### PR TITLE
Fix build image label mapping

### DIFF
--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -189,7 +189,7 @@ func (s *composeService) toBuildOptions(service types.ServiceConfig, contextPath
 		Target:    service.Build.Target,
 		Exports:   []bclient.ExportEntry{{Type: "image", Attrs: map[string]string{}}},
 		Platforms: plats,
-		Labels:    service.Labels,
+		Labels:    service.Build.Labels,
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Fix mapping of composefile attribute service.build.labels

**Related issue**
Following #1417 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
