### PR TITLE
Map composefiles privileged, isolation

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -260,8 +260,7 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		Env:             convert.ToMobyEnv(service.Environment),
 		Healthcheck:     convert.ToMobyHealthCheck(service.HealthCheck),
 		Volumes:         volumeMounts,
-
-		StopTimeout: convert.ToSeconds(service.StopGracePeriod),
+		StopTimeout:     convert.ToSeconds(service.StopGracePeriod),
 	}
 
 	portBindings := buildContainerPortBindingOptions(service)
@@ -295,6 +294,8 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		ExtraHosts:   service.ExtraHosts,
 		SecurityOpt:  service.SecurityOpt,
 		UsernsMode:   container.UsernsMode(service.UserNSMode),
+		Privileged:   service.Privileged,
+		Isolation:    container.Isolation(service.Isolation),
 	}
 
 	networkConfig := buildDefaultNetworkConfig(service, networkMode, getContainerName(p.Name, service, number))


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* 2 more obvious mappings from composefile attributes

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
