### PR TITLE
Sorting services in order to make cloudformation template file generation idempotent

### DIFF
--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/docker/compose-cli/api/compose"
@@ -148,6 +149,11 @@ func (b *ecsAPIService) convert(ctx context.Context, project *types.Project) (*c
 	b.createNFSMountTarget(project, resources, template)
 
 	b.createAccessPoints(project, resources, template)
+
+	//order services for idempotence between calls (because of following rule orders)
+	sort.Slice(project.Services, func(i, j int) bool {
+		return project.Services[i].Name < project.Services[j].Name
+	})
 
 	for _, service := range project.Services {
 		err := b.createService(project, service, template, resources)


### PR DESCRIPTION
Sorted services in order to make cloudformation template generation the same for the same set of services

**Related issue**
#1427 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/7790172/111054238-e090d800-8449-11eb-8aa0-bb7604e3ba51.png)
