### PR TITLE
Fix log expectation with random exec order

### DIFF
--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -139,10 +140,9 @@ func TestAttachRestart(t *testing.T) {
 	res := c.RunDockerOrExitError("compose", "--ansi=never", "--project-directory", "fixtures/attach-restart", "up")
 	output := res.Stdout()
 
-	assert.Assert(t, strings.Contains(output, `another_1  | world
-attach-restart_another_1 exited with code 1
-another_1  | world
-attach-restart_another_1 exited with code 1
-another_1  | world
-attach-restart_another_1 exited with code 1`), res.Combined())
+	exitRegex := regexp.MustCompile("attach-restart_another_1 exited with code 1")
+	assert.Equal(t, len(exitRegex.FindAllStringIndex(output, -1)), 3, res.Combined())
+
+	execRegex := regexp.MustCompile(`another_1  \| world`)
+	assert.Equal(t, len(execRegex.FindAllStringIndex(output, -1)), 3, res.Combined())
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
count expected log lines rather than expect a specific order

**Related issue**
Flaky test error, one example: https://github.com/docker/compose-cli/pull/1422/checks?check_run_id=2096259440#step:9:15

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
