### PR TITLE
introduce --parallel  and --no-parallel (hidden, deprecated) flags

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
@@ -113,7 +114,7 @@ func Command(contextType string) *cobra.Command {
 					return errors.New(aec.Apply(`cannot specify DEPRECATED "--workdir" and "--project-directory". Please use only "--project-directory" instead.`, aec.RedF))
 				}
 				opts.ProjectDir = opts.WorkDir
-				fmt.Println(aec.Apply(`option "--workdir" is DEPRECATED at root level! Please use "--project-directory" instead.`, aec.RedF))
+				fmt.Fprint(os.Stderr, aec.Apply(`option "--workdir" is DEPRECATED at root level! Please use "--project-directory" instead.\n`, aec.RedF))
 			}
 			if contextType == store.DefaultContextType || contextType == store.LocalContextType {
 				Warning = "The new 'docker compose' command is currently experimental. " +

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -18,7 +18,10 @@ package compose
 
 import (
 	"context"
+	"fmt"
+	"os"
 
+	"github.com/morikuni/aec"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
@@ -29,6 +32,8 @@ type pullOptions struct {
 	*projectOptions
 	composeOptions
 	quiet       bool
+	parallel    bool
+	noParallel  bool
 	includeDeps bool
 }
 
@@ -40,11 +45,19 @@ func pullCommand(p *projectOptions) *cobra.Command {
 		Use:   "pull [SERVICE...]",
 		Short: "Pull service images",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.noParallel {
+				fmt.Fprint(os.Stderr, aec.Apply(`option "--no-parallel" is DEPRECATED and will be ignored.\n`, aec.RedF))
+			}
 			return runPull(cmd.Context(), opts, args)
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Pull without printing progress information")
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Pull without printing progress information")
 	cmd.Flags().BoolVar(&opts.includeDeps, "include-deps", false, "Also pull services declared as dependencies")
+	cmd.Flags().BoolVar(&opts.parallel, "parallel", true, "DEPRECATED pull multiple images in parallel.")
+	flags.MarkHidden("parallel") //nolint:errcheck
+	cmd.Flags().BoolVar(&opts.parallel, "no-parallel", true, "DEPRECATED disable parallel pulling.")
+	flags.MarkHidden("no-parallel") //nolint:errcheck
 	return cmd
 }
 


### PR DESCRIPTION
**What I did**
introduce --parallel  and --no-parallel (hidden, deprecated) flags

this prevent backward compatibility issues for users migrating from docker-compose
marked deprecated, implemented as no-op


close https://github.com/docker/compose-cli/issues/1441