### PR TITLE
introduce config --services, --volumes, --hash for backward compatibility

### DIFF
--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -24,6 +24,8 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/docker/compose-cli/utils"
 )
 
 // Containers is a set of moby Container
@@ -69,14 +71,14 @@ type containerPredicate func(c moby.Container) bool
 func isService(services ...string) containerPredicate {
 	return func(c moby.Container) bool {
 		service := c.Labels[serviceLabel]
-		return contains(services, service)
+		return utils.StringContains(services, service)
 	}
 }
 
 func isNotService(services ...string) containerPredicate {
 	return func(c moby.Container) bool {
 		service := c.Labels[serviceLabel]
-		return !contains(services, service)
+		return !utils.StringContains(services, service)
 	}
 }
 

--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 	status "github.com/docker/compose-cli/local/moby"
+	"github.com/docker/compose-cli/utils"
 )
 
 const (
@@ -97,7 +98,7 @@ func (s *composeService) ensureService(ctx context.Context, project *types.Proje
 		return nil
 	}
 
-	expected, err := jsonHash(service)
+	expected, err := utils.ServiceHash(service)
 	if err != nil {
 		return err
 	}
@@ -249,7 +250,7 @@ func (s *composeService) recreateContainer(ctx context.Context, project *types.P
 // setDependentLifecycle define the Lifecycle strategy for all services to depend on specified service
 func setDependentLifecycle(project *types.Project, service string, strategy string) {
 	for i, s := range project.Services {
-		if contains(s.GetDependencies(), service) {
+		if utils.StringContains(s.GetDependencies(), service) {
 			if s.Extensions == nil {
 				s.Extensions = map[string]interface{}{}
 			}

--- a/local/compose/dependencies.go
+++ b/local/compose/dependencies.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/docker/compose-cli/utils"
 )
 
 // ServiceStatus indicates the status of a service
@@ -313,7 +315,7 @@ func (g *Graph) HasCycles() (bool, error) {
 		path := []string{
 			vertex.Key,
 		}
-		if !contains(discovered, vertex.Key) && !contains(finished, vertex.Key) {
+		if !utils.StringContains(discovered, vertex.Key) && !utils.StringContains(finished, vertex.Key) {
 			var err error
 			discovered, finished, err = g.visit(vertex.Key, path, discovered, finished)
 
@@ -331,11 +333,11 @@ func (g *Graph) visit(key string, path []string, discovered []string, finished [
 
 	for _, v := range g.Vertices[key].Children {
 		path := append(path, v.Key)
-		if contains(discovered, v.Key) {
+		if utils.StringContains(discovered, v.Key) {
 			return nil, nil, fmt.Errorf("cycle found: %s", strings.Join(path, " -> "))
 		}
 
-		if !contains(finished, v.Key) {
+		if !utils.StringContains(finished, v.Key) {
 			if _, _, err := g.visit(v.Key, path, discovered, finished); err != nil {
 				return nil, nil, err
 			}

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -43,7 +43,7 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 	}
 	if len(options.Services) > 0 {
 		ignore = func(s string) bool {
-			return !contains(options.Services, s)
+			return !utils.StringContains(options.Services, s)
 		}
 	}
 

--- a/utils/hash.go
+++ b/utils/hash.go
@@ -14,27 +14,21 @@
    limitations under the License.
 */
 
-package compose
+package utils
 
 import (
 	"encoding/json"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/opencontainers/go-digest"
 )
 
-func jsonHash(o interface{}) (string, error) {
+// ServiceHash compute configuration has for a service
+// TODO move this to compose-go
+func ServiceHash(o types.ServiceConfig) (string, error) {
 	bytes, err := json.Marshal(o)
 	if err != nil {
 		return "", err
 	}
-	return digest.SHA256.FromBytes(bytes).String(), nil
-}
-
-func contains(slice []string, item string) bool {
-	for _, v := range slice {
-		if v == item {
-			return true
-		}
-	}
-	return false
+	return digest.SHA256.FromBytes(bytes).Encoded(), nil
 }


### PR DESCRIPTION
**What I did**
Implemented --services, --volumes, --hash pseudo-commands on `compose config`

this will prevent compatibility issues with docker-compose

**Related issue**
close https://github.com/docker/compose-cli/issues/1442