### PR TITLE
Deprecated flag --no-ansi

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -111,7 +111,7 @@ func Command(contextType string) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if noAnsi {
 				if ansi != "auto" {
-					return errors.New(aec.Apply(`cannot specify DEPRECATED "--no-ansi" and "--ansi". Please use only "--ansi".`, aec.RedF))
+					return errors.New(`cannot specify DEPRECATED "--no-ansi" and "--ansi". Please use only "--ansi"`)
 				}
 				ansi = "never"
 				fmt.Fprint(os.Stderr, aec.Apply("option '--no-ansi' is DEPRECATED ! Please use '--ansi' instead.\n", aec.RedF))
@@ -119,7 +119,7 @@ func Command(contextType string) *cobra.Command {
 			formatter.SetANSIMode(ansi)
 			if opts.WorkDir != "" {
 				if opts.ProjectDir != "" {
-					return errors.New(aec.Apply(`cannot specify DEPRECATED "--workdir" and "--project-directory". Please use only "--project-directory" instead.`, aec.RedF))
+					return errors.New(`cannot specify DEPRECATED "--workdir" and "--project-directory". Please use only "--project-directory" instead`)
 				}
 				opts.ProjectDir = opts.WorkDir
 				fmt.Fprint(os.Stderr, aec.Apply("option '--workdir' is DEPRECATED at root level! Please use '--project-directory' instead.\n", aec.RedF))

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -47,7 +47,7 @@ func pullCommand(p *projectOptions) *cobra.Command {
 		Short: "Pull service images",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.noParallel {
-				fmt.Fprint(os.Stderr, aec.Apply(`option "--no-parallel" is DEPRECATED and will be ignored.\n`, aec.RedF))
+				fmt.Fprint(os.Stderr, aec.Apply("option '--no-parallel' is DEPRECATED and will be ignored.\n", aec.RedF))
 			}
 			return runPull(cmd.Context(), opts, args)
 		},


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Add deprecated `--no-ansi` (hidden) for backward compatibility

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
