### PR TITLE
Added deprecated build flags parallel, compress, force-rm

### DIFF
--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -59,6 +59,13 @@ func buildCommand(p *projectOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.pull, "pull", false, "Always attempt to pull a newer version of the image.")
 	cmd.Flags().StringVar(&opts.progress, "progress", "auto", `Set type of progress output ("auto", "plain", "tty")`)
 	cmd.Flags().StringArrayVar(&opts.args, "build-arg", []string{}, "Set build-time variables for services.")
+	cmd.Flags().Bool("parallel", true, "Build images in parallel. DEPRECATED")
+	cmd.Flags().MarkHidden("parallel") //nolint:errcheck
+	cmd.Flags().Bool("compress", true, "Compress the build context using gzip. DEPRECATED")
+	cmd.Flags().MarkHidden("compress") //nolint:errcheck
+	cmd.Flags().Bool("force-rm", true, "Always remove intermediate containers. DEPRECATED")
+	cmd.Flags().MarkHidden("force-rm") //nolint:errcheck
+
 	return cmd
 }
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

**Related issue**
Fixes #1440 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
