### PR TITLE
Test install script as non root user (still sudoer to be able to install)

### DIFF
--- a/scripts/install/test.Dockerfile
+++ b/scripts/install/test.Dockerfile
@@ -24,13 +24,25 @@ FROM centos:7 AS base-centos
 RUN curl https://get.docker.com | sh
 
 FROM base-${DISTRO} AS install
+
+RUN apt-get update && apt-get -y install sudo
+RUN adduser --disabled-password --gecos '' newuser
+RUN adduser newuser sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+USER newuser
+WORKDIR /home/newuser
+
 COPY install_linux.sh /scripts/install_linux.sh
-RUN chmod +x /scripts/install_linux.sh
+RUN sudo chmod +x /scripts/install_linux.sh
 ARG DOWNLOAD_URL=
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
 
 FROM install AS upgrade
+
+USER newuser
+WORKDIR /home/newuser
+
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
 


### PR DESCRIPTION


Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Run Docker tests for install script as non root user
* Test it with `docker build -f scripts/install/test.Dockerfile scripts/install/`

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
