### PR TITLE
Down sigterm

### DIFF
--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -83,7 +83,7 @@ func (s *composeService) attach(ctx context.Context, project *types.Project, lis
 					s.attachContainer(ctx, container, listener, project) // nolint: errcheck
 					delete(crashed, event.Container)
 
-					s.waitContainer(ctx, container, listener)
+					s.waitContainer(container, listener)
 				}
 				return nil
 			},

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -51,14 +51,14 @@ func (s *composeService) Start(ctx context.Context, project *types.Project, opti
 	for _, c := range containers {
 		c := c
 		go func() {
-			s.waitContainer(ctx, c, options.Attach)
+			s.waitContainer(c, options.Attach)
 		}()
 	}
 	return nil
 }
 
-func (s *composeService) waitContainer(ctx context.Context, c moby.Container, listener compose.ContainerEventListener) {
-	statusC, errC := s.apiClient.ContainerWait(ctx, c.ID, container.WaitConditionNotRunning)
+func (s *composeService) waitContainer(c moby.Container, listener compose.ContainerEventListener) {
+	statusC, errC := s.apiClient.ContainerWait(context.Background(), c.ID, container.WaitConditionNotRunning)
 	name := getContainerNameWithoutProject(c)
 	select {
 	case status := <-statusC:


### PR DESCRIPTION
**What I did**
run `containerWait` in background so it's not interrupted by context cancelation, and catch container exit to stop when all are done.
Also add support for second SIGTERM to kill the services (to align with docker-compose)

**Related issue**
fix https://github.com/docker/compose-cli/issues/1447

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
