### PR TITLE
Add IPC support

### DIFF
--- a/local/e2e/compose/fixtures/ipc-test/compose.yaml
+++ b/local/e2e/compose/fixtures/ipc-test/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  service:
+    image: busybox
+    command: top
+    ipc: "service:shareable"
+  container:
+    image: busybox
+    command: top
+    ipc: "container:ipc_mode_container"
+  shareable:
+    image: busybox
+    command: top
+    ipc: shareable

--- a/local/e2e/compose/ipc_test.go
+++ b/local/e2e/compose/ipc_test.go
@@ -1,0 +1,65 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/icmd"
+
+	. "github.com/docker/compose-cli/utils/e2e"
+)
+
+func TestIPC(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	const projectName = "ipc_e2e"
+	var cid string
+	t.Run("create ipc mode container", func(t *testing.T) {
+		res := c.RunDockerCmd("run", "-d", "--rm", "--ipc=shareable", "--name", "ipc_mode_container", "busybox", "top")
+		cid = strings.Trim(res.Stdout(), "\n")
+	})
+
+	t.Run("up", func(t *testing.T) {
+		c.RunDockerCmd("compose", "-f", "./fixtures/ipc-test/compose.yaml", "--project-name", projectName, "up", "-d")
+	})
+
+	t.Run("check running project", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "-p", projectName, "ps")
+		res.Assert(t, icmd.Expected{Out: `shareable`})
+	})
+
+	t.Run("check ipcmode in container inspect", func(t *testing.T) {
+		res := c.RunDockerCmd("inspect", projectName+"_shareable_1")
+		res.Assert(t, icmd.Expected{Out: `"IpcMode": "shareable",`})
+
+		res = c.RunDockerCmd("inspect", projectName+"_service_1")
+		res.Assert(t, icmd.Expected{Out: `"IpcMode": "container:`})
+
+		res = c.RunDockerCmd("inspect", projectName+"_container_1")
+		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`"IpcMode": "container:%s",`, cid)})
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerCmd("compose", "--project-name", projectName, "down")
+	})
+	t.Run("stop ipc mode container", func(t *testing.T) {
+		_ = c.RunDockerCmd("stop", "ipc_mode_container")
+	})
+}


### PR DESCRIPTION
Added support for IPC mode:

```yaml
services:
  service:
    image: busybox
    command: top
    ipc: "service:shareable"
  shareable:
    image: busybox
    command: top
    ipc: shareable
```

```shell
$ docker compose up -d
[+] Running 3/3
 ⠿ Network "myproject_default"      Created                                                                              0.4s
 ⠿ Container myproject_shareable_1  Started                                                                              0.7s
 ⠿ Container myproject_service_1    Started                                                                              1.4s

```
```shell
$ docker inspect myproject_shareable_1 | grep IpcMode
            "IpcMode": "shareable",
$ docker inspect myproject_service_1 | grep IpcMode
            "IpcMode": "container:8c3a9cb94f0c36adbace19db4982ec6b64fccfc74e6c61e30b2cfb03f32f0478",
```

Closes https://github.com/docker/dev-tooling-team/issues/284

