### PR TITLE
Add plain tail messages on progress writer

### DIFF
--- a/api/progress/noop.go
+++ b/api/progress/noop.go
@@ -30,5 +30,8 @@ func (p *noopWriter) Start(ctx context.Context) error {
 func (p *noopWriter) Event(e Event) {
 }
 
+func (p *noopWriter) TailMsgf(_ string, _ ...interface{}) {
+}
+
 func (p *noopWriter) Stop() {
 }

--- a/api/progress/plain.go
+++ b/api/progress/plain.go
@@ -40,6 +40,10 @@ func (p *plainWriter) Event(e Event) {
 	fmt.Fprintln(p.out, e.ID, e.Text, e.StatusText)
 }
 
+func (p *plainWriter) TailMsgf(m string, args ...interface{}) {
+	fmt.Fprintln(p.out, append([]interface{}{m}, args...)...)
+}
+
 func (p *plainWriter) Stop() {
 	p.done <- true
 }

--- a/api/progress/writer.go
+++ b/api/progress/writer.go
@@ -31,6 +31,7 @@ type Writer interface {
 	Start(context.Context) error
 	Stop()
 	Event(Event)
+	TailMsgf(string, ...interface{})
 }
 
 type writerKey struct{}

--- a/local/compose/pull.go
+++ b/local/compose/pull.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 
@@ -72,13 +71,7 @@ func (s *composeService) Pull(ctx context.Context, project *types.Project, opts 
 				if !opts.IgnoreFailures {
 					return err
 				}
-				// If IgnoreFailures we still want to show the error message
-				w.Event(progress.Event{
-					ID:         fmt.Sprintf("Pulling %s:", service.Name),
-					Text:       fmt.Sprintf("%v", err),
-					Status:     progress.Error,
-					StatusText: fmt.Sprintf("%s", err),
-				})
+				w.TailMsgf("Pulling %s: %s", service.Name, err.Error())
 			}
 			return nil
 		})

--- a/local/compose/push.go
+++ b/local/compose/push.go
@@ -70,12 +70,7 @@ func (s *composeService) Push(ctx context.Context, project *types.Project, optio
 				if !options.IgnoreFailures {
 					return err
 				}
-				w.Event(progress.Event{
-					ID:         fmt.Sprintf("Pushing %s:", service.Name),
-					Text:       fmt.Sprintf("%v", err),
-					Status:     progress.Error,
-					StatusText: fmt.Sprintf("%s", err),
-				})
+				w.TailMsgf("Pushing %s: %s", service.Name, err.Error())
 			}
 			return nil
 		})


### PR DESCRIPTION
**What I did**
This allows progress writer to print plain text after printing all the `tty` messages.