### PR TITLE
Add `no-cache` build flag

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -82,6 +82,8 @@ type BuildOptions struct {
 	Progress string
 	// Args set build-time args
 	Args types.Mapping
+	// NoCache disables cache use
+	NoCache bool
 }
 
 // CreateOptions group options of the Create API

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -35,6 +35,8 @@ type buildOptions struct {
 	pull     bool
 	progress string
 	args     []string
+	noCache  bool
+	memory   string
 }
 
 func buildCommand(p *projectOptions) *cobra.Command {
@@ -65,6 +67,11 @@ func buildCommand(p *projectOptions) *cobra.Command {
 	cmd.Flags().MarkHidden("compress") //nolint:errcheck
 	cmd.Flags().Bool("force-rm", true, "Always remove intermediate containers. DEPRECATED")
 	cmd.Flags().MarkHidden("force-rm") //nolint:errcheck
+	cmd.Flags().BoolVar(&opts.noCache, "no-cache", false, "Do not use cache when building the image")
+	cmd.Flags().Bool("no-rm", false, "Do not remove intermediate containers after a successful build. DEPRECATED")
+	cmd.Flags().MarkHidden("no-rm") //nolint:errcheck
+	cmd.Flags().StringVarP(&opts.memory, "memory", "m", "", "Set memory limit for the build container. DEPRECATED")
+	cmd.Flags().MarkHidden("memory") //nolint:errcheck
 
 	return cmd
 }
@@ -85,6 +92,7 @@ func runBuild(ctx context.Context, opts buildOptions, services []string) error {
 			Pull:     opts.pull,
 			Progress: opts.progress,
 			Args:     types.NewMapping(opts.args),
+			NoCache:  opts.noCache,
 		})
 	})
 	return err

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/compose-spec/compose-go/types"
@@ -47,6 +48,9 @@ func buildCommand(p *projectOptions) *cobra.Command {
 		Use:   "build [SERVICE...]",
 		Short: "Build or rebuild services",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.memory != "" {
+				fmt.Println("WARNING --memory is ignored as not supported in buildkit.")
+			}
 			if opts.quiet {
 				devnull, err := os.Open(os.DevNull)
 				if err != nil {
@@ -70,7 +74,7 @@ func buildCommand(p *projectOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.noCache, "no-cache", false, "Do not use cache when building the image")
 	cmd.Flags().Bool("no-rm", false, "Do not remove intermediate containers after a successful build. DEPRECATED")
 	cmd.Flags().MarkHidden("no-rm") //nolint:errcheck
-	cmd.Flags().StringVarP(&opts.memory, "memory", "m", "", "Set memory limit for the build container. DEPRECATED")
+	cmd.Flags().StringVarP(&opts.memory, "memory", "m", "", "Set memory limit for the build container. Not supported on buildkit yet.")
 	cmd.Flags().MarkHidden("memory") //nolint:errcheck
 
 	return cmd

--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -50,6 +50,7 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 			}
 			buildOptions.Pull = options.Pull
 			buildOptions.BuildArgs = options.Args
+			buildOptions.NoCache = options.NoCache
 			opts[imageName] = buildOptions
 			buildOptions.CacheFrom, err = build.ParseCacheEntry(service.Build.CacheFrom)
 			if err != nil {


### PR DESCRIPTION
Added remaining build flags. Only one applied is the `no-cache` one.


```
$ docker compose build                                                                                                                             
[+] Building 0.3s (18/18) FINISHED                                                                                                                       
 => [nginx-golang-postgres_backend internal] load build definition from Dockerfile                                                                  0.0s
 => => transferring dockerfile: 32B                                                                                                                 0.0s
 => [nginx-golang-postgres_proxy internal] load build definition from Dockerfile                                                                    0.0s
 => => transferring dockerfile: 31B                                                                                                                 0.0s
 => [nginx-golang-postgres_backend internal] load .dockerignore                                                                                     0.0s
 => => transferring context: 2B                                                                                                                     0.0s
 => [nginx-golang-postgres_proxy internal] load .dockerignore                                                                                       0.0s
 => => transferring context: 2B                                                                                                                     0.0s
 => [nginx-golang-postgres_backend internal] load metadata for docker.io/library/alpine:3.12                                                        0.2s
 => [nginx-golang-postgres_backend internal] load metadata for docker.io/library/golang:1.13-alpine                                                 0.2s
 => [nginx-golang-postgres_proxy internal] load metadata for docker.io/library/nginx:1.13-alpine                                                    0.1s
 => [nginx-golang-postgres_proxy internal] load build context                                                                                       0.0s
 => => transferring context: 157B                                                                                                                   0.0s
 => [nginx-golang-postgres_proxy 1/2] FROM docker.io/library/nginx:1.13-alpine@sha256:9d46fd628d54ebe1633ee3cf0fe2acfcc419cfae541c63056530e39cd562  0.0s
 => CACHED [nginx-golang-postgres_proxy 2/2] COPY conf /etc/nginx/conf.d/default.conf                                                               0.0s
 => [nginx-golang-postgres_backend] exporting to image                                                                                              0.0s
 => => exporting layers                                                                                                                             0.0s
 => => writing image sha256:fa6741fd561e047833a7c244a2c989a94e5404c839017d3f5efdf64cd4fe0388                                                        0.0s
 => => naming to docker.io/library/nginx-golang-postgres_proxy                                                                                      0.0s
 => => writing image sha256:7809a9a2a8ef872738fbe5e78fe1554cd339f633b69a160256d8f947415b30c4                                                        0.0s
 => => naming to docker.io/library/nginx-golang-postgres_backend                                                                                    0.0s
 => [nginx-golang-postgres_backend stage-1 1/2] FROM docker.io/library/alpine:3.12@sha256:d1eaae2a6814b4b10a722fa75e8a6b53db42d1bf531395a107fea045  0.0s
 => [nginx-golang-postgres_backend build 1/4] FROM docker.io/library/golang:1.13-alpine@sha256:e74b83b94d499cb34c7edf55fbdff9d3cfabd238a35f9cb1b59  0.0s
 => [nginx-golang-postgres_backend internal] load build context                                                                                     0.0s
 => => transferring context: 2.21kB                                                                                                                 0.0s
 => CACHED [nginx-golang-postgres_backend build 2/4] WORKDIR /go/src/github.com/org/repo                                                            0.0s
 => CACHED [nginx-golang-postgres_backend build 3/4] COPY . .                                                                                       0.0s
 => CACHED [nginx-golang-postgres_backend build 4/4] RUN go build -o server .                                                                       0.0s
 => CACHED [nginx-golang-postgres_backend stage-1 2/2] COPY --from=build /go/src/github.com/org/repo/server /server                                 0.0s

```


With `--no-cache`

```                                                                          
18:18 $ docker compose build --no-cache                                                                                                                  
[+] Building 2.7s (18/18) FINISHED                                                                                                                       
 => [nginx-golang-postgres_backend internal] load build definition from Dockerfile                                                                  0.0s
 => => transferring dockerfile: 32B                                                                                                                 0.0s
 => [nginx-golang-postgres_proxy internal] load build definition from Dockerfile                                                                    0.0s
 => => transferring dockerfile: 31B                                                                                                                 0.0s
 => [nginx-golang-postgres_backend internal] load .dockerignore                                                                                     0.0s
 => => transferring context: 2B                                                                                                                     0.0s
 => [nginx-golang-postgres_proxy internal] load .dockerignore                                                                                       0.0s
 => => transferring context: 2B                                                                                                                     0.0s
 => [nginx-golang-postgres_backend internal] load metadata for docker.io/library/golang:1.13-alpine                                                 0.4s
 => [nginx-golang-postgres_backend internal] load metadata for docker.io/library/alpine:3.12                                                        0.4s
 => [nginx-golang-postgres_proxy internal] load metadata for docker.io/library/nginx:1.13-alpine                                                    0.4s
 => [nginx-golang-postgres_proxy internal] load build context                                                                                       0.0s
 => => transferring context: 157B                                                                                                                   0.0s
 => CACHED [nginx-golang-postgres_proxy 1/2] FROM docker.io/library/nginx:1.13-alpine@sha256:9d46fd628d54ebe1633ee3cf0fe2acfcc419cfae541c63056530e  0.0s
 => [nginx-golang-postgres_backend build 1/4] FROM docker.io/library/golang:1.13-alpine@sha256:e74b83b94d499cb34c7edf55fbdff9d3cfabd238a35f9cb1b59  0.0s
 => CACHED [nginx-golang-postgres_backend stage-1 1/2] FROM docker.io/library/alpine:3.12@sha256:d1eaae2a6814b4b10a722fa75e8a6b53db42d1bf531395a10  0.0s
 => [nginx-golang-postgres_backend internal] load build context                                                                                     0.0s
 => => transferring context: 85B                                                                                                                    0.0s
 => CACHED [nginx-golang-postgres_backend build 2/4] WORKDIR /go/src/github.com/org/repo                                                            0.0s
 => [nginx-golang-postgres_proxy 2/2] COPY conf /etc/nginx/conf.d/default.conf                                                                      0.0s
 => [nginx-golang-postgres_backend build 3/4] COPY . .                                                                                              0.0s
 => [nginx-golang-postgres_backend] exporting to image                                                                                              0.9s
 => => exporting layers                                                                                                                             0.9s
 => => writing image sha256:fa6741fd561e047833a7c244a2c989a94e5404c839017d3f5efdf64cd4fe0388                                                        0.0s
 => => naming to docker.io/library/nginx-golang-postgres_proxy                                                                                      0.0s
 => => writing image sha256:6e9485cc210170ed8e4d91b59f0dd286c07dd5b1bc6ad158e061d7ef02d46aa4                                                        0.0s
 => => naming to docker.io/library/nginx-golang-postgres_backend                                                                                    0.0s
 => [nginx-golang-postgres_backend build 4/4] RUN go build -o server .                                                                              1.2s 
 => [nginx-golang-postgres_backend stage-1 2/2] COPY --from=build /go/src/github.com/org/repo/server /server     
```

Closes https://github.com/docker/compose-cli/issues/1468