### PR TITLE
Removed race in e2e test

### DIFF
--- a/local/e2e/compose/restart_test.go
+++ b/local/e2e/compose/restart_test.go
@@ -45,8 +45,9 @@ func TestRestart(t *testing.T) {
 		res := c.RunDockerOrExitError("compose", "-f", "./fixtures/restart-test/compose.yml", "--project-name", projectName, "up", "-d")
 		assert.Assert(t, strings.Contains(res.Combined(), "Container e2e-restart_restart_1  Started"), res.Combined())
 
-		// Give the time for it to exit
-		time.Sleep(time.Second)
+		c.WaitForCmdResult(c.NewDockerCmd("compose", "--project-name", projectName, "ps", "-a", "--format", "json"),
+			StdoutContains(`"State":"exited"`),
+			10*time.Second, 1*time.Second)
 
 		res = c.RunDockerOrExitError("compose", "--project-name", projectName, "ps", "-a")
 		testify.Regexp(t, getServiceRegx("restart", "exited"), res.Stdout())


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
replace Sleep() by waiting for the expected container state

**Related issue**
https://github.com/docker/compose-cli/runs/2228293860

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
