### PR TITLE
Set our own docker CLI on windows nodes

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Setup docker CLI
         run: |
           docker version
+          curl -L -o docker.exe https://github.com/StefanScherer/docker-cli-builder/releases/download/20.10.5/docker.exe
+          mv -Force ./docker.exe "C:\Program Files\Docker\"
+          docker version
 
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Pin our own docker cli on windows GHA nodes 

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
