### PR TITLE
make metrics' source configuration (see compose-switch)

### DIFF
--- a/cli/metrics/client.go
+++ b/cli/metrics/client.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -37,9 +38,16 @@ type Command struct {
 	Status  string `json:"status"`
 }
 
+// CLISource is sent for cli metrics
+var CLISource = "cli"
+
+func init() {
+	if v, ok := os.LookupEnv("DOCKER_METRICS_SOURCE"); ok {
+		CLISource = v
+	}
+}
+
 const (
-	// CLISource is sent for cli metrics
-	CLISource = "cli"
 	// APISource is sent for API metrics
 	APISource = "api"
 	// SuccessStatus is sent for API metrics


### PR DESCRIPTION
**What I did**
Made metrics' source configurable by environment variable

close https://github.com/docker/dev-tooling-team/issues/291
see https://github.com/docker/compose-v1v2-switch/blob/master/main.go#L181

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
