### PR TITLE
pause/unpause only need project name. use getContainers where possible

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -72,11 +72,11 @@ func (cs *aciComposeService) Stop(ctx context.Context, project *types.Project, o
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Pause(ctx context.Context, project *types.Project) error {
+func (cs *aciComposeService) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) UnPause(ctx context.Context, project *types.Project) error {
+func (cs *aciComposeService) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -96,11 +96,11 @@ func (c *composeService) Exec(ctx context.Context, project *types.Project, opts 
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Pause(ctx context.Context, project *types.Project) error {
+func (c *composeService) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (c *composeService) UnPause(ctx context.Context, project *types.Project) error {
+func (c *composeService) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -63,9 +63,9 @@ type Service interface {
 	// Exec executes a command in a running service container
 	Exec(ctx context.Context, project *types.Project, opts RunOptions) error
 	// Pause executes the equivalent to a `compose pause`
-	Pause(ctx context.Context, project *types.Project) error
+	Pause(ctx context.Context, project string, options PauseOptions) error
 	// UnPause executes the equivalent to a `compose unpause`
-	UnPause(ctx context.Context, project *types.Project) error
+	UnPause(ctx context.Context, project string, options PauseOptions) error
 	// Top executes the equivalent to a `compose top`
 	Top(ctx context.Context, projectName string, services []string) ([]ContainerProcSummary, error)
 	// Events executes the equivalent to a `compose events`
@@ -301,6 +301,12 @@ type LogOptions struct {
 	Tail       string
 	Follow     bool
 	Timestamps bool
+}
+
+// PauseOptions group options of the Pause API
+type PauseOptions struct {
+	// Services passed in the command line to be started
+	Services []string
 }
 
 const (

--- a/cli/cmd/compose/pause.go
+++ b/cli/cmd/compose/pause.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 )
 
@@ -49,13 +50,15 @@ func runPause(ctx context.Context, opts pauseOptions, services []string) error {
 		return err
 	}
 
-	project, err := opts.toProject(services)
+	project, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().Pause(ctx, project)
+		return "", c.ComposeService().Pause(ctx, project, compose.PauseOptions{
+			Services: services,
+		})
 	})
 	return err
 }
@@ -84,13 +87,15 @@ func runUnPause(ctx context.Context, opts unpauseOptions, services []string) err
 		return err
 	}
 
-	project, err := opts.toProject(services)
+	project, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().UnPause(ctx, project)
+		return "", c.ComposeService().UnPause(ctx, project, compose.PauseOptions{
+			Services: services,
+		})
 	})
 	return err
 }

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -188,12 +188,12 @@ func (e ecsLocalSimulation) Exec(ctx context.Context, project *types.Project, op
 	return errdefs.ErrNotImplemented
 }
 
-func (e ecsLocalSimulation) Pause(ctx context.Context, project *types.Project) error {
-	return e.compose.Pause(ctx, project)
+func (e ecsLocalSimulation) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
+	return e.compose.Pause(ctx, project, options)
 }
 
-func (e ecsLocalSimulation) UnPause(ctx context.Context, project *types.Project) error {
-	return e.compose.UnPause(ctx, project)
+func (e ecsLocalSimulation) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
+	return e.compose.UnPause(ctx, project, options)
 }
 
 func (e ecsLocalSimulation) Top(ctx context.Context, projectName string, services []string) ([]compose.ContainerProcSummary, error) {

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -59,11 +59,11 @@ func (b *ecsAPIService) Stop(ctx context.Context, project *types.Project, option
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Pause(ctx context.Context, project *types.Project) error {
+func (b *ecsAPIService) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) UnPause(ctx context.Context, project *types.Project) error {
+func (b *ecsAPIService) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -252,11 +252,11 @@ func (s *composeService) Exec(ctx context.Context, project *types.Project, opts 
 	return errdefs.ErrNotImplemented
 }
 
-func (s *composeService) Pause(ctx context.Context, project *types.Project) error {
+func (s *composeService) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 
-func (s *composeService) UnPause(ctx context.Context, project *types.Project) error {
+func (s *composeService) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
 	return errdefs.ErrNotImplemented
 }
 

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -33,7 +33,7 @@ import (
 )
 
 func (s *composeService) attach(ctx context.Context, project *types.Project, listener compose.ContainerEventListener, selectedServices []string) (Containers, error) {
-	containers, err := s.getContainers(ctx, project, oneOffExclude, selectedServices)
+	containers, err := s.getContainers(ctx, project.Name, oneOffExclude, true, selectedServices...)
 	if err != nil {
 		return nil, err
 	}

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -26,7 +26,6 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
@@ -69,10 +68,7 @@ func (s *composeService) Create(ctx context.Context, project *types.Project, opt
 	}
 
 	var observedState Containers
-	observedState, err = s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(project.Name)),
-		All:     true,
-	})
+	observedState, err = s.getContainers(ctx, project.Name, oneOffInclude, true)
 	if err != nil {
 		return err
 	}

--- a/local/compose/down.go
+++ b/local/compose/down.go
@@ -39,10 +39,7 @@ func (s *composeService) Down(ctx context.Context, projectName string, options c
 	resourceToRemove := false
 
 	var containers Containers
-	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(projectName)),
-		All:     true,
-	})
+	containers, err := s.getContainers(ctx, projectName, oneOffInclude, true)
 	if err != nil {
 		return err
 	}

--- a/local/compose/kill.go
+++ b/local/compose/kill.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/compose-cli/api/compose"
@@ -32,10 +31,7 @@ func (s *composeService) Kill(ctx context.Context, project *types.Project, optio
 	w := progress.ContextWriter(ctx)
 
 	var containers Containers
-	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(project.Name)),
-		All:     true,
-	})
+	containers, err := s.getContainers(ctx, project.Name, oneOffInclude, true)
 	if err != nil {
 		return err
 	}

--- a/local/compose/labels.go
+++ b/local/compose/labels.go
@@ -18,8 +18,6 @@ package compose
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/docker/docker/api/types/filters"
 
@@ -45,10 +43,6 @@ const (
 
 func projectFilter(projectName string) filters.KeyValuePair {
 	return filters.Arg("label", fmt.Sprintf("%s=%s", projectLabel, projectName))
-}
-
-func oneOffFilter(oneOff bool) filters.KeyValuePair {
-	return filters.Arg("label", fmt.Sprintf("%s=%s", oneoffLabel, strings.Title(strconv.FormatBool(oneOff))))
 }
 
 func serviceFilter(serviceName string) filters.KeyValuePair {

--- a/local/compose/pause.go
+++ b/local/compose/pause.go
@@ -19,15 +19,15 @@ package compose
 import (
 	"context"
 
-	"github.com/compose-spec/compose-go/types"
 	moby "github.com/docker/docker/api/types"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 )
 
-func (s *composeService) Pause(ctx context.Context, project *types.Project) error {
-	containers, err := s.getContainers(ctx, project, oneOffExclude, nil)
+func (s *composeService) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
+	containers, err := s.getContainers(ctx, project, oneOffExclude, true, options.Services...)
 	if err != nil {
 		return err
 	}
@@ -48,8 +48,8 @@ func (s *composeService) Pause(ctx context.Context, project *types.Project) erro
 	return eg.Wait()
 }
 
-func (s *composeService) UnPause(ctx context.Context, project *types.Project) error {
-	containers, err := s.getContainers(ctx, project, oneOffExclude, nil)
+func (s *composeService) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
+	containers, err := s.getContainers(ctx, project, oneOffExclude, true, options.Services...)
 	if err != nil {
 		return err
 	}

--- a/local/compose/ps.go
+++ b/local/compose/ps.go
@@ -20,18 +20,13 @@ import (
 	"context"
 	"fmt"
 
-	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/compose-cli/api/compose"
 )
 
 func (s *composeService) Ps(ctx context.Context, projectName string, options compose.PsOptions) ([]compose.ContainerSummary, error) {
-	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(projectName)),
-		All:     options.All,
-	})
+	containers, err := s.getContainers(ctx, projectName, oneOffInclude, options.All)
 	if err != nil {
 		return nil, err
 	}

--- a/local/compose/remove.go
+++ b/local/compose/remove.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (s *composeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) ([]string, error) {
-	containers, err := s.getContainers(ctx, project, oneOffInclude, nil)
+	containers, err := s.getContainers(ctx, project.Name, oneOffInclude, true)
 	if err != nil {
 		return nil, err
 	}

--- a/local/compose/run.go
+++ b/local/compose/run.go
@@ -30,10 +30,7 @@ import (
 )
 
 func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {
-	observedState, err := s.apiClient.ContainerList(ctx, apitypes.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(project.Name)),
-		All:     true,
-	})
+	observedState, err := s.getContainers(ctx, project.Name, oneOffInclude, true)
 	if err != nil {
 		return 0, err
 	}

--- a/local/compose/status.go
+++ b/local/compose/status.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/pkg/errors"
 )
 
@@ -103,12 +102,7 @@ func GetContextContainerState(ctx context.Context) (ContainersState, error) {
 }
 
 func (s composeService) getUpdatedContainersStateContext(ctx context.Context, projectName string) (context.Context, error) {
-	observedState, err := s.apiClient.ContainerList(ctx, types.ContainerListOptions{
-		Filters: filters.NewArgs(
-			projectFilter(projectName),
-		),
-		All: true,
-	})
+	observedState, err := s.getContainers(ctx, projectName, oneOffInclude, true)
 	if err != nil {
 		return nil, err
 	}

--- a/local/compose/top.go
+++ b/local/compose/top.go
@@ -20,16 +20,12 @@ import (
 	"context"
 
 	"github.com/docker/compose-cli/api/compose"
-	moby "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/sync/errgroup"
 )
 
 func (s *composeService) Top(ctx context.Context, projectName string, services []string) ([]compose.ContainerProcSummary, error) {
 	var containers Containers
-	containers, err := s.apiClient.ContainerList(ctx, moby.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(projectName)),
-	})
+	containers, err := s.getContainers(ctx, projectName, oneOffInclude, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What I did**
removed requirement for original compose file to invoke pause/unpause commands

also use `getContainers` where possible to reduce code duplication

