### PR TITLE
Avoid race between parallel tests, add specific build sample for scan_message_test

### DIFF
--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -69,9 +69,9 @@ func TestLocalComposeUp(t *testing.T) {
 	t.Run("top", func(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-p", projectName, "top")
 		output := res.Stdout()
-		assert.Assert(t, strings.Contains(output, `UID    PID     PPID    C    STIME   TTY   TIME       CMD`))
-		assert.Assert(t, strings.Contains(output, `java -Xmx8m -Xms8m -jar /app/words.jar`))
-		assert.Assert(t, strings.Contains(output, `/dispatcher`))
+		assert.Assert(t, strings.Contains(output, `UID    PID     PPID    C    STIME   TTY   TIME       CMD`), output)
+		assert.Assert(t, strings.Contains(output, `java -Xmx8m -Xms8m -jar /app/words.jar`), output)
+		assert.Assert(t, strings.Contains(output, `/dispatcher`), output)
 	})
 
 	t.Run("check compose labels", func(t *testing.T) {

--- a/local/e2e/compose/fixtures/simple-build-test/compose.yml
+++ b/local/e2e/compose/fixtures/simple-build-test/compose.yml
@@ -1,0 +1,3 @@
+services:
+  nginx:
+    build: nginx-build

--- a/local/e2e/compose/fixtures/simple-build-test/nginx-build/Dockerfile
+++ b/local/e2e/compose/fixtures/simple-build-test/nginx-build/Dockerfile
@@ -1,0 +1,19 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM nginx
+
+ARG FOO
+LABEL FOO=$FOO
+COPY static /usr/share/nginx/html

--- a/local/e2e/compose/fixtures/simple-build-test/nginx-build/static/index.html
+++ b/local/e2e/compose/fixtures/simple-build-test/nginx-build/static/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Docker Nginx</title>
+</head>
+<body>
+  <h2>Hello from Nginx container</h2>
+</body>
+</html>

--- a/local/e2e/compose/scan_message_test.go
+++ b/local/e2e/compose/scan_message_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestDisplayScanMessageAfterBuild(t *testing.T) {
+
 	c := NewParallelE2eCLI(t, binDir)
 	setupScanPlugin(t, c)
 
@@ -40,7 +41,7 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 	res.Assert(t, icmd.Expected{Out: "scan: Docker Scan"})
 
 	t.Run("display when docker build", func(t *testing.T) {
-		res := c.RunDockerCmd("build", "-t", "test-image-scan-msg", "./fixtures/build-test/nginx-build")
+		res := c.RunDockerCmd("build", "-t", "test-image-scan-msg", "./fixtures/simple-build-test/nginx-build")
 		res.Assert(t, icmd.Expected{Out: "Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them"})
 	})
 
@@ -52,21 +53,21 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 	})
 
 	t.Run("display on compose build", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "-f", "./fixtures/build-test/compose.yml", "build")
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/simple-build-test/compose.yml", "-p", "scan-msg-test", "build")
 		res.Assert(t, icmd.Expected{Out: "Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them"})
 	})
 
-	_ = c.RunDockerOrExitError("rmi", "build-test_nginx")
+	_ = c.RunDockerOrExitError("rmi", "scan-msg-test_nginx")
 
 	t.Run("display on compose up if image is built", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "-f", "./fixtures/build-test/compose.yml", "up", "-d")
-		defer c.RunDockerCmd("compose", "-f", "./fixtures/build-test/compose.yml", "down")
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/simple-build-test/compose.yml", "-p", "scan-msg-test", "up", "-d")
+		defer c.RunDockerCmd("compose", "-f", "./fixtures/simple-build-test/compose.yml", "-p", "scan-msg-test", "down")
 		res.Assert(t, icmd.Expected{Out: "Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them"})
 	})
 
 	t.Run("do not display on compose up if no image built", func(t *testing.T) { // re-run the same Compose aproject
-		res := c.RunDockerCmd("compose", "-f", "./fixtures/build-test/compose.yml", "up", "-d")
-		defer c.RunDockerCmd("compose", "-f", "./fixtures/build-test/compose.yml", "down")
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/simple-build-test/compose.yml", "-p", "scan-msg-test", "up", "-d")
+		defer c.RunDockerCmd("compose", "-f", "./fixtures/simple-build-test/compose.yml", "-p", "scan-msg-test", "down")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
 	})
 
@@ -76,7 +77,7 @@ func TestDisplayScanMessageAfterBuild(t *testing.T) {
 		err := ioutil.WriteFile(scanConfigFile, []byte(`{"optin":true}`), 0644)
 		assert.NilError(t, err)
 
-		res := c.RunDockerCmd("build", "-t", "test-image-scan-msg", "./fixtures/build-test/nginx-build")
+		res := c.RunDockerCmd("build", "-t", "test-image-scan-msg", "./fixtures/simple-build-test/nginx-build")
 		assert.Assert(t, !strings.Contains(res.Combined(), "docker scan"), res.Combined())
 	})
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
* Avoid 2 parallel tests running the same compose stack, and also opening the same port

**Related issue**
Local errors when running `make e2e-local`

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
