### PR TITLE
Avoid panic: concurrent map writes

### DIFF
--- a/local/compose/images.go
+++ b/local/compose/images.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -58,6 +59,7 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 	}
 
 	images := map[string]moby.ImageInspect{}
+	l := sync.Mutex{}
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, img := range imageIDs {
 		img := img
@@ -66,7 +68,9 @@ func (s *composeService) Images(ctx context.Context, projectName string, options
 			if err != nil {
 				return err
 			}
+			l.Lock()
 			images[img] = inspect
+			l.Unlock()
 			return nil
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
use mutex to sync concurrent access to map (quick global pass looking for `eg.Go(` )

**Related issue**
https://github.com/docker/compose-cli/runs/2295818799 (first time seen)

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
