### PR TITLE
don't include stderr in moby exec output

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -136,5 +136,6 @@ func ExecSilent(ctx context.Context, args ...string) ([]byte, error) {
 		args = os.Args[1:]
 	}
 	cmd := exec.CommandContext(ctx, ComDockerCli, args...)
-	return cmd.CombinedOutput()
+	cmd.Stderr = os.Stderr
+	return cmd.Output()
 }

--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -398,8 +398,7 @@ func TestLegacy(t *testing.T) {
 	t.Run("host flag", func(t *testing.T) {
 		res := c.RunDockerOrExitError("-H", "tcp://nonexistent:123", "version")
 		assert.Assert(t, res.ExitCode == 1)
-		assert.Assert(t, strings.Contains(res.Stdout(), "dial tcp: lookup nonexistent"), res.Stdout())
-
+		assert.Assert(t, strings.Contains(res.Stderr(), "dial tcp: lookup nonexistent"), res.Stderr())
 	})
 
 	t.Run("remote engine context", func(t *testing.T) {
@@ -408,7 +407,7 @@ func TestLegacy(t *testing.T) {
 
 		res := c.RunDockerOrExitError("version")
 		assert.Assert(t, res.ExitCode == 1)
-		assert.Assert(t, strings.Contains(res.Stdout(), "dial tcp: lookup nonexistent"), res.Stdout())
+		assert.Assert(t, strings.Contains(res.Stderr(), "dial tcp: lookup nonexistent"), res.Stderr())
 	})
 
 	t.Run("existing contexts delegate", func(t *testing.T) {


### PR DESCRIPTION
**What I did**
only capture stdout when we run a moby command, so that we don't get stderr mixed

**Related issue**
close https://github.com/docker/compose-cli/issues/1515

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
