### PR TITLE
Ignore previous CFM events on update to avoid false positive errors

### DIFF
--- a/ecs/up.go
+++ b/ecs/up.go
@@ -93,6 +93,16 @@ func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, options 
 	if err != nil {
 		return err
 	}
+
+	var previousEvents []string
+	if update {
+		var err error
+		previousEvents, err = b.previousStackEvents(ctx, project.Name)
+		if err != nil {
+			return err
+		}
+	}
+
 	operation := stackCreate
 	if update {
 		operation = stackUpdate
@@ -121,6 +131,6 @@ func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, options 
 		b.Down(ctx, project.Name, compose.DownOptions{}) // nolint:errcheck
 	}()
 
-	err = b.WaitStackCompletion(ctx, project.Name, operation)
+	err = b.WaitStackCompletion(ctx, project.Name, operation, previousEvents...)
 	return err
 }


### PR DESCRIPTION
ECS `up` is pulling all events for CFM stack, which may be having some errors in
the history. For example, if CFM stack update was ever cancelled, `up` will be
exiting with code 1 on every run after that cancellation.

Fixes #1112