### PR TITLE
Set image digest as service image to trigger recreation after build

### DIFF
--- a/cli/cmd/compose/images.go
+++ b/cli/cmd/compose/images.go
@@ -99,8 +99,15 @@ func runImages(ctx context.Context, opts imageOptions, services []string) error 
 			for _, img := range images {
 				id := stringid.TruncateID(img.ID)
 				size := units.HumanSizeWithPrecision(float64(img.Size), 3)
-
-				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", img.ContainerName, img.Repository, img.Tag, id, size)
+				repo := img.Repository
+				if repo == "" {
+					repo = "<none>"
+				}
+				tag := img.Tag
+				if tag == "" {
+					tag = "<none>"
+				}
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", img.ContainerName, repo, tag, id, size)
 			}
 		},
 		"Container", "Repository", "Tag", "Image Id", "Size")

--- a/local/compose/images.go
+++ b/local/compose/images.go
@@ -24,6 +24,7 @@ import (
 
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/compose-cli/api/compose"
@@ -83,6 +84,9 @@ func (s *composeService) getImages(ctx context.Context, images []string) (map[st
 		eg.Go(func() error {
 			inspect, _, err := s.apiClient.ImageInspectWithRaw(ctx, img)
 			if err != nil {
+				if errdefs.IsNotFound(err) {
+					return nil
+				}
 				return err
 			}
 			tag := ""


### PR DESCRIPTION
When an image is updated locally via pull or build, the containers are not being recreated on `compose up` (service hash is not generated with the image digest but with an image repo/tag that could be reassigned on build).

This fixes also the output of `compose images` when the repo/tag changes (aligns with docker-compose).

```
[example]$ docker compose up -d
[+] Running 3/3
 ⠿ Container example_backend_1   Running                                                                                                           0.0s
 ⠿ Container example_backend_2   Running                                                                                                           0.0s
 ⠿ Container example_frontend_1  Running                                                                                                           0.6s
```
```
[example]$ docker compose images
Container            Repository          Tag                 Image Id            Size
example_backend_1    nginx               latest              515ea3e0d096        133MB
example_backend_2    nginx               latest              515ea3e0d096        133MB
example_frontend_1   example_frontend    latest              a7063fa9db03        22.6MB
```
```
[example]$ docker compose build
[+] Building 0.4s (7/7) FINISHED                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 102B                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                                    0.4s
 => [internal] load build context                                                                                                                  0.0s
 => => transferring context: 31B                                                                                                                   0.0s
 => [1/2] FROM docker.io/library/nginx:alpine@sha256:d942e5263869b00ed3174fb76573165dc89e391bfafa43e9134a9c6e0bf0ec87                              0.0s
 => CACHED [2/2] COPY nginx.conf /etc/nginx/conf.d/default.conf                                                                                    0.0s
 => exporting to image                                                                                                                             0.0s
 => => exporting layers                                                                                                                            0.0s
 => => writing image sha256:465f434f2e6a5972145b27945d8c157d5514c981895cc351c0c3c04533b870d4                                                       0.0s
 => => naming to docker.io/library/example_frontend                                                                                                0.0s
```
```
[example]$ docker compose images
Container            Repository          Tag                 Image Id            Size
example_backend_1    nginx               latest              515ea3e0d096        133MB
example_backend_2    nginx               latest              515ea3e0d096        133MB
example_frontend_1   <none>              <none               a7063fa9db03        22.6MB
```
```
[example]$ docker compose up -d
[+] Running 3/3
 ⠿ Container example_backend_1   Running                                                                                                           0.0s
 ⠿ Container example_backend_2   Running                                                                                                           0.0s
 ⠿ Container example_frontend_1  Started                                                                                                           0.8s
```
```
[example]$ docker compose images
Container            Repository          Tag                 Image Id            Size
example_backend_1    nginx               latest              515ea3e0d096        133MB
example_backend_2    nginx               latest              515ea3e0d096        133MB
example_frontend_1   example_frontend    latest              465f434f2e6a        22.6MB

```

Fixes https://github.com/docker/compose-cli/issues/1521