### PR TITLE
[refactoring] package `compose` as a CLI plugin on local backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN --mount=target=. \
     GOARCH=${TARGETARCH} \
     BUILD_TAGS=${BUILD_TAGS} \
     GIT_TAG=${GIT_TAG} \
-    make BINARY=/out/docker -f builder.Makefile cli
+    make BINARY=/out/docker COMPOSE_BINARY=/out/docker-compose -f builder.Makefile cli
 
 FROM base AS make-cross
 ARG BUILD_TAGS
@@ -83,7 +83,7 @@ RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     BUILD_TAGS=${BUILD_TAGS} \
     GIT_TAG=${GIT_TAG} \
-    make BINARY=/out/docker  -f builder.Makefile cross
+    make BINARY=/out/docker COMPOSE_BINARY=/out/docker-compose -f builder.Makefile cross
 
 FROM scratch AS protos
 COPY --from=make-protos /compose-cli/cli/server/protos .

--- a/api/compose/delegator.go
+++ b/api/compose/delegator.go
@@ -1,0 +1,143 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+
+	"github.com/compose-spec/compose-go/types"
+)
+
+// ServiceDelegator implements Service by delegating to another implementation. This allows lazy init
+type ServiceDelegator struct {
+	Delegate Service
+}
+
+//Build implements Service interface
+func (s *ServiceDelegator) Build(ctx context.Context, project *types.Project, options BuildOptions) error {
+	return s.Delegate.Build(ctx, project, options)
+}
+
+//Push implements Service interface
+func (s *ServiceDelegator) Push(ctx context.Context, project *types.Project, options PushOptions) error {
+	return s.Delegate.Push(ctx, project, options)
+}
+
+//Pull implements Service interface
+func (s *ServiceDelegator) Pull(ctx context.Context, project *types.Project, options PullOptions) error {
+	return s.Delegate.Pull(ctx, project, options)
+}
+
+//Create implements Service interface
+func (s *ServiceDelegator) Create(ctx context.Context, project *types.Project, options CreateOptions) error {
+	return s.Delegate.Create(ctx, project, options)
+}
+
+//Start implements Service interface
+func (s *ServiceDelegator) Start(ctx context.Context, project *types.Project, options StartOptions) error {
+	return s.Delegate.Start(ctx, project, options)
+}
+
+//Restart implements Service interface
+func (s *ServiceDelegator) Restart(ctx context.Context, project *types.Project, options RestartOptions) error {
+	return s.Delegate.Restart(ctx, project, options)
+}
+
+//Stop implements Service interface
+func (s *ServiceDelegator) Stop(ctx context.Context, project *types.Project, options StopOptions) error {
+	return s.Delegate.Stop(ctx, project, options)
+}
+
+//Up implements Service interface
+func (s *ServiceDelegator) Up(ctx context.Context, project *types.Project, options UpOptions) error {
+	return s.Delegate.Up(ctx, project, options)
+}
+
+//Down implements Service interface
+func (s *ServiceDelegator) Down(ctx context.Context, project string, options DownOptions) error {
+	return s.Delegate.Down(ctx, project, options)
+}
+
+//Logs implements Service interface
+func (s *ServiceDelegator) Logs(ctx context.Context, project string, consumer LogConsumer, options LogOptions) error {
+	return s.Delegate.Logs(ctx, project, consumer, options)
+}
+
+//Ps implements Service interface
+func (s *ServiceDelegator) Ps(ctx context.Context, project string, options PsOptions) ([]ContainerSummary, error) {
+	return s.Delegate.Ps(ctx, project, options)
+}
+
+//List implements Service interface
+func (s *ServiceDelegator) List(ctx context.Context, options ListOptions) ([]Stack, error) {
+	return s.Delegate.List(ctx, options)
+}
+
+//Convert implements Service interface
+func (s *ServiceDelegator) Convert(ctx context.Context, project *types.Project, options ConvertOptions) ([]byte, error) {
+	return s.Delegate.Convert(ctx, project, options)
+}
+
+//Kill implements Service interface
+func (s *ServiceDelegator) Kill(ctx context.Context, project *types.Project, options KillOptions) error {
+	return s.Delegate.Kill(ctx, project, options)
+}
+
+//RunOneOffContainer implements Service interface
+func (s *ServiceDelegator) RunOneOffContainer(ctx context.Context, project *types.Project, options RunOptions) (int, error) {
+	return s.Delegate.RunOneOffContainer(ctx, project, options)
+}
+
+//Remove implements Service interface
+func (s *ServiceDelegator) Remove(ctx context.Context, project *types.Project, options RemoveOptions) ([]string, error) {
+	return s.Delegate.Remove(ctx, project, options)
+}
+
+//Exec implements Service interface
+func (s *ServiceDelegator) Exec(ctx context.Context, project *types.Project, options RunOptions) error {
+	return s.Delegate.Exec(ctx, project, options)
+}
+
+//Pause implements Service interface
+func (s *ServiceDelegator) Pause(ctx context.Context, project string, options PauseOptions) error {
+	return s.Delegate.Pause(ctx, project, options)
+}
+
+//UnPause implements Service interface
+func (s *ServiceDelegator) UnPause(ctx context.Context, project string, options PauseOptions) error {
+	return s.Delegate.UnPause(ctx, project, options)
+}
+
+//Top implements Service interface
+func (s *ServiceDelegator) Top(ctx context.Context, project string, services []string) ([]ContainerProcSummary, error) {
+	return s.Delegate.Top(ctx, project, services)
+}
+
+//Events implements Service interface
+func (s *ServiceDelegator) Events(ctx context.Context, project string, options EventsOptions) error {
+	return s.Delegate.Events(ctx, project, options)
+}
+
+//Port implements Service interface
+func (s *ServiceDelegator) Port(ctx context.Context, project string, service string, port int, options PortOptions) (string, int, error) {
+	return s.Delegate.Port(ctx, project, service, port, options)
+}
+
+//Images implements Service interface
+func (s *ServiceDelegator) Images(ctx context.Context, project string, options ImagesOptions) ([]ImageSummary, error) {
+	return s.Delegate.Images(ctx, project, options)
+}

--- a/api/compose/noimpl.go
+++ b/api/compose/noimpl.go
@@ -1,0 +1,143 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+
+	"github.com/compose-spec/compose-go/types"
+
+	"github.com/docker/compose-cli/api/errdefs"
+)
+
+// NoImpl implements Service to return ErrNotImplemented
+type NoImpl struct{}
+
+//Build implements Service interface
+func (s NoImpl) Build(ctx context.Context, project *types.Project, options BuildOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Push implements Service interface
+func (s NoImpl) Push(ctx context.Context, project *types.Project, options PushOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Pull implements Service interface
+func (s NoImpl) Pull(ctx context.Context, project *types.Project, options PullOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Create implements Service interface
+func (s NoImpl) Create(ctx context.Context, project *types.Project, options CreateOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Start implements Service interface
+func (s NoImpl) Start(ctx context.Context, project *types.Project, options StartOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Restart implements Service interface
+func (s NoImpl) Restart(ctx context.Context, project *types.Project, options RestartOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Stop implements Service interface
+func (s NoImpl) Stop(ctx context.Context, project *types.Project, options StopOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Up implements Service interface
+func (s NoImpl) Up(ctx context.Context, project *types.Project, options UpOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Down implements Service interface
+func (s NoImpl) Down(ctx context.Context, project string, options DownOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Logs implements Service interface
+func (s NoImpl) Logs(ctx context.Context, project string, consumer LogConsumer, options LogOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Ps implements Service interface
+func (s NoImpl) Ps(ctx context.Context, project string, options PsOptions) ([]ContainerSummary, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+//List implements Service interface
+func (s NoImpl) List(ctx context.Context, options ListOptions) ([]Stack, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+//Convert implements Service interface
+func (s NoImpl) Convert(ctx context.Context, project *types.Project, options ConvertOptions) ([]byte, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+//Kill implements Service interface
+func (s NoImpl) Kill(ctx context.Context, project *types.Project, options KillOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//RunOneOffContainer implements Service interface
+func (s NoImpl) RunOneOffContainer(ctx context.Context, project *types.Project, options RunOptions) (int, error) {
+	return 0, errdefs.ErrNotImplemented
+}
+
+//Remove implements Service interface
+func (s NoImpl) Remove(ctx context.Context, project *types.Project, options RemoveOptions) ([]string, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+//Exec implements Service interface
+func (s NoImpl) Exec(ctx context.Context, project *types.Project, options RunOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Pause implements Service interface
+func (s NoImpl) Pause(ctx context.Context, project string, options PauseOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//UnPause implements Service interface
+func (s NoImpl) UnPause(ctx context.Context, project string, options PauseOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Top implements Service interface
+func (s NoImpl) Top(ctx context.Context, project string, services []string) ([]ContainerProcSummary, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+//Events implements Service interface
+func (s NoImpl) Events(ctx context.Context, project string, options EventsOptions) error {
+	return errdefs.ErrNotImplemented
+}
+
+//Port implements Service interface
+func (s NoImpl) Port(ctx context.Context, project string, service string, port int, options PortOptions) (string, int, error) {
+	return "", 0, errdefs.ErrNotImplemented
+}
+
+//Images implements Service interface
+func (s NoImpl) Images(ctx context.Context, project string, options ImagesOptions) ([]ImageSummary, error) {
+	return nil, errdefs.ErrNotImplemented
+}

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -34,6 +34,9 @@ GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 BINARY?=bin/docker
 BINARY_WITH_EXTENSION=$(BINARY)$(EXTENSION)
 
+COMPOSE_BINARY?=bin/docker-compose
+COMPOSE_BINARY_WITH_EXTENSION=$(COMPOSE_BINARY)$(EXTENSION)
+
 WORK_DIR:=$(shell mktemp -d)
 
 TAGS:=
@@ -54,12 +57,12 @@ protos:
 	protoc -I. --go_out=plugins=grpc,paths=source_relative:. ${PROTOS}
 
 .PHONY: cli
-cli:
+cli: compose-plugin
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
 .PHONY: compose-plugin
 compose-plugin:
-	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o ./bin/docker-compose .
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) ./compose_plugin
 
 .PHONY: cross
 cross:

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -57,6 +57,10 @@ protos:
 cli:
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
+.PHONY: compose-plugin
+compose-plugin:
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o ./bin/docker-compose .
+
 .PHONY: cross
 cross:
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-amd64 ./cli

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -45,9 +45,22 @@ ifdef BUILD_TAGS
   LINT_TAGS=--build-tags $(BUILD_TAGS)
 endif
 
-TAR_TRANSFORM:=--transform s/packaging/docker/ --transform s/bin/docker/ --transform s/docker-linux-amd64/docker/ --transform s/docker-darwin-amd64/docker/ --transform s/docker-linux-arm64/docker/ --transform s/docker-linux-armv6/docker/ --transform s/docker-linux-armv7/docker/ --transform s/docker-darwin-arm64/docker/
+TAR_TRANSFORM:=--transform s/packaging/docker/ --transform s/bin/docker/ \
+				--transform s/docker-linux-amd64/docker/ --transform s/docker-linux-arm64/docker/ \
+				--transform s/docker-linux-armv6/docker/ --transform s/docker-linux-armv7/docker/ \
+				--transform s/docker-darwin-amd64/docker/ --transform s/docker-darwin-arm64/docker/ \
+				--transform s/docker-compose-linux-amd64/docker-compose/ --transform s/docker-compose-linux-arm64/docker-compose/ \
+				--transform s/docker-compose-linux-armv6/docker-compose/ --transform s/docker-compose-linux-armv7/docker-compose/ \
+				--transform s/docker-compose-darwin-amd64/docker-compose/ --transform s/docker-compose-darwin-arm64/docker-compose/
+
 ifneq ($(findstring bsd,$(shell tar --version)),)
-  TAR_TRANSFORM=-s /packaging/docker/ -s /bin/docker/ -s /docker-linux-amd64/docker/ -s /docker-darwin-amd64/docker/ -s /docker-linux-arm64/docker/ -s /docker-linux-armv6/docker/ -s /docker-linux-armv7/docker/ -s /docker-darwin-arm64/docker/
+  TAR_TRANSFORM=-s /packaging/docker/ -s /bin/docker/ \
+  				-s /docker-linux-amd64/docker/  -s /docker-linux-arm64/docker/ \
+  				-s /docker-linux-armv6/docker/  -s /docker-linux-armv7/docker/ \
+				-s /docker-darwin-amd64/docker/	 -s /docker-darwin-arm64/docker/ \
+  				-s /docker-compose-linux-amd64/docker-compose/  -s /docker-compose-linux-arm64/docker-compose/ \
+  				-s /docker-compose-linux-armv6/docker-compose/  -s /docker-compose-linux-armv7/docker-compose/ \
+				-s /docker-compose-darwin-amd64/docker-compose/	 -s /docker-compose-darwin-arm64/docker-compose/
 endif
 
 all: cli
@@ -62,10 +75,10 @@ cli: compose-plugin
 
 .PHONY: compose-plugin
 compose-plugin:
-	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) ./compose_plugin
+	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) .
 
 .PHONY: cross
-cross:
+cross: cross-compose-plugin
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-amd64 ./cli
 	GOOS=linux   GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-arm64 ./cli
 	GOOS=linux   GOARM=6 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-armv6 ./cli
@@ -73,6 +86,16 @@ cross:
 	GOOS=darwin  GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-darwin-amd64 ./cli
 	GOOS=darwin  GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(BINARY)-darwin-arm64 ./cli
 	GOOS=windows GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-windows-amd64.exe ./cli
+
+.PHONY: cross-compose-plugin
+cross-compose-plugin:
+	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-amd64 .
+	GOOS=linux   GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-arm64 .
+	GOOS=linux   GOARM=6 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-armv6 .
+	GOOS=linux   GOARM=7 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-linux-armv7 .
+	GOOS=darwin  GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-darwin-amd64 .
+	GOOS=darwin  GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-darwin-arm64 .
+	GOOS=windows GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY)-windows-amd64.exe .
 
 .PHONY: test
 test:
@@ -97,14 +120,15 @@ check-go-mod:
 .PHONY: package
 package: cross
 	mkdir -p dist
-	tar -czf dist/docker-linux-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-amd64
-	tar -czf dist/docker-linux-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-arm64
-	tar -czf dist/docker-linux-armv6.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv6
-	tar -czf dist/docker-linux-armv7.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv7
-	tar -czf dist/docker-darwin-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-amd64
-	tar -czf dist/docker-darwin-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-arm64
+	tar -czf dist/docker-linux-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-amd64 $(COMPOSE_BINARY)-linux-amd64
+	tar -czf dist/docker-linux-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-arm64 $(COMPOSE_BINARY)-linux-arm64
+	tar -czf dist/docker-linux-armv6.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv6 $(COMPOSE_BINARY)-linux-armv6
+	tar -czf dist/docker-linux-armv7.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv7 $(COMPOSE_BINARY)-linux-armv7
+	tar -czf dist/docker-darwin-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-amd64 $(COMPOSE_BINARY)-darwin-amd64
+	tar -czf dist/docker-darwin-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-arm64 $(COMPOSE_BINARY)-darwin-arm64
 	cp $(BINARY)-windows-amd64.exe $(WORK_DIR)/docker.exe
-	rm -f dist/docker-windows-amd64.zip && zip dist/docker-windows-amd64.zip -j packaging/LICENSE $(WORK_DIR)/docker.exe
+	cp $(COMPOSE_BINARY)-windows-amd64.exe $(WORK_DIR)/docker-compose.exe
+	rm -f dist/docker-windows-amd64.zip && zip dist/docker-windows-amd64.zip -j packaging/LICENSE $(WORK_DIR)/docker.exe $(WORK_DIR)/docker-compose.exe
 	rm -r $(WORK_DIR)
 
 .PHONY: yamldocs

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -46,7 +46,7 @@ func buildCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build [SERVICE...]",
 		Short: "Build or rebuild services",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.memory != "" {
 				fmt.Println("WARNING --memory is ignored as not supported in buildkit.")
 			}
@@ -57,8 +57,8 @@ func buildCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 				}
 				os.Stdout = devnull
 			}
-			return runBuild(cmd.Context(), backend, opts, args)
-		},
+			return runBuild(ctx, backend, opts, args)
+		}),
 	}
 	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "Don't print anything to STDOUT")
 	cmd.Flags().BoolVar(&opts.pull, "pull", false, "Always attempt to pull a newer version of the image.")

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -123,6 +123,14 @@ func Command(contextType string, backend compose.Service) *cobra.Command {
 			return fmt.Errorf("unknown docker command: %q", "compose "+args[0])
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			parent := cmd.Root()
+			parentPrerun := parent.PersistentPreRunE
+			if parentPrerun != nil {
+				err := parentPrerun(cmd, args)
+				if err != nil {
+					return err
+				}
+			}
 			if noAnsi {
 				if ansi != "auto" {
 					return errors.New(`cannot specify DEPRECATED "--no-ansi" and "--ansi". Please use only "--ansi"`)

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/context/store"
 	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/cli/metrics"
@@ -105,7 +106,7 @@ func (o *projectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 }
 
 // Command returns the compose command with its child commands
-func Command(contextType string) *cobra.Command {
+func Command(contextType string, backend compose.Service) *cobra.Command {
 	opts := projectOptions{}
 	var ansi string
 	var noAnsi bool
@@ -146,34 +147,34 @@ func Command(contextType string) *cobra.Command {
 	}
 
 	command.AddCommand(
-		upCommand(&opts, contextType),
-		downCommand(&opts, contextType),
-		startCommand(&opts),
-		restartCommand(&opts),
-		stopCommand(&opts),
-		psCommand(&opts),
-		listCommand(contextType),
-		logsCommand(&opts, contextType),
-		convertCommand(&opts),
-		killCommand(&opts),
-		runCommand(&opts),
-		removeCommand(&opts),
-		execCommand(&opts),
-		pauseCommand(&opts),
-		unpauseCommand(&opts),
-		topCommand(&opts),
-		eventsCommand(&opts),
-		portCommand(&opts),
-		imagesCommand(&opts),
+		upCommand(&opts, contextType, backend),
+		downCommand(&opts, contextType, backend),
+		startCommand(&opts, backend),
+		restartCommand(&opts, backend),
+		stopCommand(&opts, backend),
+		psCommand(&opts, backend),
+		listCommand(contextType, backend),
+		logsCommand(&opts, contextType, backend),
+		convertCommand(&opts, backend),
+		killCommand(&opts, backend),
+		runCommand(&opts, backend),
+		removeCommand(&opts, backend),
+		execCommand(&opts, backend),
+		pauseCommand(&opts, backend),
+		unpauseCommand(&opts, backend),
+		topCommand(&opts, backend),
+		eventsCommand(&opts, backend),
+		portCommand(&opts, backend),
+		imagesCommand(&opts, backend),
 		versionCommand(),
 	)
 
 	if contextType == store.LocalContextType || contextType == store.DefaultContextType {
 		command.AddCommand(
-			buildCommand(&opts),
-			pushCommand(&opts),
-			pullCommand(&opts),
-			createCommand(&opts),
+			buildCommand(&opts, backend),
+			pushCommand(&opts, backend),
+			pullCommand(&opts, backend),
+			createCommand(&opts, backend),
 		)
 	}
 	command.Flags().SetInterspersed(false)

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -32,7 +32,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/config"
 	"github.com/docker/compose-cli/utils"
 )
 
@@ -109,10 +108,7 @@ func runConvert(ctx context.Context, backend compose.Service, opts convertOption
 	}
 
 	if opts.resolve {
-		configFile, err := cliconfig.Load(config.Dir())
-		if err != nil {
-			return err
-		}
+		configFile := cliconfig.LoadDefaultConfigFile(os.Stderr)
 
 		resolver := remotes.CreateResolver(configFile)
 		err = project.ResolveImages(func(named reference.Named) (digest.Digest, error) {

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -58,7 +58,7 @@ func convertCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Aliases: []string{"config"},
 		Use:     "convert SERVICES",
 		Short:   "Converts the compose file to platform's canonical format",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.quiet {
 				devnull, err := os.Open(os.DevNull)
 				if err != nil {
@@ -79,8 +79,8 @@ func convertCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 				return runProfiles(opts, args)
 			}
 
-			return runConvert(cmd.Context(), backend, opts, args)
-		},
+			return runConvert(ctx, backend, opts, args)
+		}),
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Format, "format", "yaml", "Format the output. Values: [yaml | json]")

--- a/cli/cmd/compose/create.go
+++ b/cli/cmd/compose/create.go
@@ -17,6 +17,7 @@
 package compose
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -37,14 +38,14 @@ func createCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [SERVICE...]",
 		Short: "Creates containers for a service.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.Build && opts.noBuild {
 				return fmt.Errorf("--build and --no-build are incompatible")
 			}
 			if opts.forceRecreate && opts.noRecreate {
 				return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
 			}
-			return runCreateStart(cmd.Context(), backend, upOptions{
+			return runCreateStart(ctx, backend, upOptions{
 				composeOptions: &composeOptions{
 					projectOptions: p,
 					Build:          opts.Build,
@@ -54,7 +55,7 @@ func createCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 				forceRecreate: opts.forceRecreate,
 				noRecreate:    opts.noRecreate,
 			}, args)
-		},
+		}),
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.Build, "build", false, "Build images before starting containers.")

--- a/cli/cmd/compose/create.go
+++ b/cli/cmd/compose/create.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/docker/compose-cli/api/compose"
 )
 
 type createOptions struct {
@@ -28,7 +30,7 @@ type createOptions struct {
 	noRecreate    bool
 }
 
-func createCommand(p *projectOptions) *cobra.Command {
+func createCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := createOptions{
 		composeOptions: &composeOptions{},
 	}
@@ -42,7 +44,7 @@ func createCommand(p *projectOptions) *cobra.Command {
 			if opts.forceRecreate && opts.noRecreate {
 				return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
 			}
-			return runCreateStart(cmd.Context(), upOptions{
+			return runCreateStart(cmd.Context(), backend, upOptions{
 				composeOptions: &composeOptions{
 					projectOptions: p,
 					Build:          opts.Build,

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -45,15 +45,17 @@ func downCommand(p *projectOptions, contextType string, backend compose.Service)
 	downCmd := &cobra.Command{
 		Use:   "down",
 		Short: "Stop and remove containers, networks",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.timeChanged = cmd.Flags().Changed("timeout")
+		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.images != "" {
 				if opts.images != "all" && opts.images != "local" {
 					return fmt.Errorf("invalid value for --rmi: %q", opts.images)
 				}
 			}
-			return runDown(cmd.Context(), backend, opts)
-		},
+			return runDown(ctx, backend, opts)
+		}),
 	}
 	flags := downCmd.Flags()
 	flags.BoolVar(&opts.removeOrphans, "remove-orphans", false, "Remove containers for services not defined in the Compose file.")

--- a/cli/cmd/compose/events.go
+++ b/cli/cmd/compose/events.go
@@ -40,9 +40,9 @@ func eventsCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "events [options] [--] [SERVICE...]",
 		Short: "Receive real time events from containers.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runEvents(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runEvents(ctx, backend, opts, args)
+		}),
 	}
 
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output events as a stream of json objects")

--- a/cli/cmd/compose/exec.go
+++ b/cli/cmd/compose/exec.go
@@ -24,7 +24,6 @@ import (
 	"github.com/containerd/console"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 )
 
@@ -43,7 +42,7 @@ type execOpts struct {
 	privileged bool
 }
 
-func execCommand(p *projectOptions) *cobra.Command {
+func execCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := execOpts{
 		composeOptions: &composeOptions{
 			projectOptions: p,
@@ -58,7 +57,7 @@ func execCommand(p *projectOptions) *cobra.Command {
 				opts.command = args[1:]
 			}
 			opts.service = args[0]
-			return runExec(cmd.Context(), opts)
+			return runExec(cmd.Context(), backend, opts)
 		},
 	}
 
@@ -74,12 +73,7 @@ func execCommand(p *projectOptions) *cobra.Command {
 	return runCmd
 }
 
-func runExec(ctx context.Context, opts execOpts) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runExec(ctx context.Context, backend compose.Service, opts execOpts) error {
 	project, err := opts.toProject(nil)
 	if err != nil {
 		return err
@@ -114,5 +108,5 @@ func runExec(ctx context.Context, opts execOpts) error {
 		execOpts.Writer = con
 		execOpts.Reader = con
 	}
-	return c.ComposeService().Exec(ctx, project, execOpts)
+	return backend.Exec(ctx, project, execOpts)
 }

--- a/cli/cmd/compose/exec.go
+++ b/cli/cmd/compose/exec.go
@@ -52,13 +52,13 @@ func execCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Use:   "exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]",
 		Short: "Execute a command in a running container.",
 		Args:  cobra.MinimumNArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if len(args) > 1 {
 				opts.command = args[1:]
 			}
 			opts.service = args[0]
-			return runExec(cmd.Context(), backend, opts)
-		},
+			return runExec(ctx, backend, opts)
+		}),
 	}
 
 	runCmd.Flags().BoolVarP(&opts.detach, "detach", "d", false, "Detached mode: Run command in the background.")

--- a/cli/cmd/compose/images.go
+++ b/cli/cmd/compose/images.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/utils"
@@ -40,7 +39,7 @@ type imageOptions struct {
 	Quiet bool
 }
 
-func imagesCommand(p *projectOptions) *cobra.Command {
+func imagesCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := imageOptions{
 		projectOptions: p,
 	}
@@ -48,25 +47,20 @@ func imagesCommand(p *projectOptions) *cobra.Command {
 		Use:   "images [SERVICE...]",
 		Short: "List images used by the created containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runImages(cmd.Context(), opts, args)
+			return runImages(cmd.Context(), backend, opts, args)
 		},
 	}
 	imgCmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs")
 	return imgCmd
 }
 
-func runImages(ctx context.Context, opts imageOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runImages(ctx context.Context, backend compose.Service, opts imageOptions, services []string) error {
 	projectName, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
 
-	images, err := c.ComposeService().Images(ctx, projectName, compose.ImagesOptions{
+	images, err := backend.Images(ctx, projectName, compose.ImagesOptions{
 		Services: services,
 	})
 	if err != nil {

--- a/cli/cmd/compose/images.go
+++ b/cli/cmd/compose/images.go
@@ -46,9 +46,9 @@ func imagesCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	imgCmd := &cobra.Command{
 		Use:   "images [SERVICE...]",
 		Short: "List images used by the created containers",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runImages(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runImages(ctx, backend, opts, args)
+		}),
 	}
 	imgCmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs")
 	return imgCmd

--- a/cli/cmd/compose/kill.go
+++ b/cli/cmd/compose/kill.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 )
 
@@ -30,7 +29,7 @@ type killOptions struct {
 	Signal string
 }
 
-func killCommand(p *projectOptions) *cobra.Command {
+func killCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := killOptions{
 		projectOptions: p,
 	}
@@ -38,7 +37,7 @@ func killCommand(p *projectOptions) *cobra.Command {
 		Use:   "kill [options] [SERVICE...]",
 		Short: "Force stop service containers.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runKill(cmd.Context(), opts, args)
+			return runKill(cmd.Context(), backend, opts, args)
 		},
 	}
 
@@ -48,16 +47,12 @@ func killCommand(p *projectOptions) *cobra.Command {
 	return cmd
 }
 
-func runKill(ctx context.Context, opts killOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
+func runKill(ctx context.Context, backend compose.Service, opts killOptions, services []string) error {
 	project, err := opts.toProject(services)
 	if err != nil {
 		return err
 	}
-	return c.ComposeService().Kill(ctx, project, compose.KillOptions{
+	return backend.Kill(ctx, project, compose.KillOptions{
 		Signal: opts.Signal,
 	})
 }

--- a/cli/cmd/compose/kill.go
+++ b/cli/cmd/compose/kill.go
@@ -36,9 +36,9 @@ func killCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kill [options] [SERVICE...]",
 		Short: "Force stop service containers.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runKill(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runKill(ctx, backend, opts, args)
+		}),
 	}
 
 	flags := cmd.Flags()

--- a/cli/cmd/compose/list.go
+++ b/cli/cmd/compose/list.go
@@ -43,9 +43,9 @@ func listCommand(contextType string, backend compose.Service) *cobra.Command {
 	lsCmd := &cobra.Command{
 		Use:   "ls",
 		Short: "List running compose projects",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), backend, opts)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runList(ctx, backend, opts)
+		}),
 	}
 	lsCmd.Flags().StringVar(&opts.Format, "format", "pretty", "Format the output. Values: [pretty | json].")
 	lsCmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs.")

--- a/cli/cmd/compose/logs.go
+++ b/cli/cmd/compose/logs.go
@@ -44,9 +44,9 @@ func logsCommand(p *projectOptions, contextType string, backend compose.Service)
 	logsCmd := &cobra.Command{
 		Use:   "logs [service...]",
 		Short: "View output from containers",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogs(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runLogs(ctx, backend, opts, args)
+		}),
 	}
 	flags := logsCmd.Flags()
 	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output.")

--- a/cli/cmd/compose/pause.go
+++ b/cli/cmd/compose/pause.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 )
@@ -30,7 +29,7 @@ type pauseOptions struct {
 	*projectOptions
 }
 
-func pauseCommand(p *projectOptions) *cobra.Command {
+func pauseCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := pauseOptions{
 		projectOptions: p,
 	}
@@ -38,25 +37,20 @@ func pauseCommand(p *projectOptions) *cobra.Command {
 		Use:   "pause [SERVICE...]",
 		Short: "pause services",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPause(cmd.Context(), opts, args)
+			return runPause(cmd.Context(), backend, opts, args)
 		},
 	}
 	return cmd
 }
 
-func runPause(ctx context.Context, opts pauseOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runPause(ctx context.Context, backend compose.Service, opts pauseOptions, services []string) error {
 	project, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().Pause(ctx, project, compose.PauseOptions{
+		return "", backend.Pause(ctx, project, compose.PauseOptions{
 			Services: services,
 		})
 	})
@@ -67,7 +61,7 @@ type unpauseOptions struct {
 	*projectOptions
 }
 
-func unpauseCommand(p *projectOptions) *cobra.Command {
+func unpauseCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := unpauseOptions{
 		projectOptions: p,
 	}
@@ -75,25 +69,20 @@ func unpauseCommand(p *projectOptions) *cobra.Command {
 		Use:   "unpause [SERVICE...]",
 		Short: "unpause services",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUnPause(cmd.Context(), opts, args)
+			return runUnPause(cmd.Context(), backend, opts, args)
 		},
 	}
 	return cmd
 }
 
-func runUnPause(ctx context.Context, opts unpauseOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runUnPause(ctx context.Context, backend compose.Service, opts unpauseOptions, services []string) error {
 	project, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().UnPause(ctx, project, compose.PauseOptions{
+		return "", backend.UnPause(ctx, project, compose.PauseOptions{
 			Services: services,
 		})
 	})

--- a/cli/cmd/compose/pause.go
+++ b/cli/cmd/compose/pause.go
@@ -36,9 +36,9 @@ func pauseCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pause [SERVICE...]",
 		Short: "pause services",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPause(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runPause(ctx, backend, opts, args)
+		}),
 	}
 	return cmd
 }
@@ -68,9 +68,9 @@ func unpauseCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unpause [SERVICE...]",
 		Short: "unpause services",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUnPause(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runUnPause(ctx, backend, opts, args)
+		}),
 	}
 	return cmd
 }

--- a/cli/cmd/compose/port.go
+++ b/cli/cmd/compose/port.go
@@ -40,13 +40,13 @@ func portCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Use:   "port [options] [--] SERVICE PRIVATE_PORT",
 		Short: "Print the public port for a port binding.",
 		Args:  cobra.MinimumNArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			port, err := strconv.Atoi(args[1])
 			if err != nil {
 				return err
 			}
-			return runPort(cmd.Context(), backend, opts, args[0], port)
-		},
+			return runPort(ctx, backend, opts, args[0], port)
+		}),
 	}
 	cmd.Flags().StringVar(&opts.protocol, "protocol", "tcp", "tcp or udp")
 	cmd.Flags().IntVar(&opts.index, "index", 1, "index of the container if service has multiple replicas")

--- a/cli/cmd/compose/port.go
+++ b/cli/cmd/compose/port.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 )
 
@@ -33,7 +32,7 @@ type portOptions struct {
 	index    int
 }
 
-func portCommand(p *projectOptions) *cobra.Command {
+func portCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := portOptions{
 		projectOptions: p,
 	}
@@ -46,7 +45,7 @@ func portCommand(p *projectOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPort(cmd.Context(), opts, args[0], port)
+			return runPort(cmd.Context(), backend, opts, args[0], port)
 		},
 	}
 	cmd.Flags().StringVar(&opts.protocol, "protocol", "tcp", "tcp or udp")
@@ -54,17 +53,12 @@ func portCommand(p *projectOptions) *cobra.Command {
 	return cmd
 }
 
-func runPort(ctx context.Context, opts portOptions, service string, port int) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runPort(ctx context.Context, backend compose.Service, opts portOptions, service string, port int) error {
 	projectName, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
-	ip, port, err := c.ComposeService().Port(ctx, projectName, service, port, compose.PortOptions{
+	ip, port, err := backend.Port(ctx, projectName, service, port, compose.PortOptions{
 		Protocol: opts.protocol,
 		Index:    opts.index,
 	})

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/cli/formatter"
 	"github.com/docker/compose-cli/utils"
@@ -40,7 +39,7 @@ type psOptions struct {
 	Services bool
 }
 
-func psCommand(p *projectOptions) *cobra.Command {
+func psCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := psOptions{
 		projectOptions: p,
 	}
@@ -48,7 +47,7 @@ func psCommand(p *projectOptions) *cobra.Command {
 		Use:   "ps",
 		Short: "List containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPs(cmd.Context(), opts)
+			return runPs(cmd.Context(), backend, opts)
 		},
 	}
 	psCmd.Flags().StringVar(&opts.Format, "format", "pretty", "Format the output. Values: [pretty | json].")
@@ -58,17 +57,12 @@ func psCommand(p *projectOptions) *cobra.Command {
 	return psCmd
 }
 
-func runPs(ctx context.Context, opts psOptions) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runPs(ctx context.Context, backend compose.Service, opts psOptions) error {
 	projectName, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
-	containers, err := c.ComposeService().Ps(ctx, projectName, compose.PsOptions{
+	containers, err := backend.Ps(ctx, projectName, compose.PsOptions{
 		All: opts.All,
 	})
 	if err != nil {

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -46,9 +46,9 @@ func psCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	psCmd := &cobra.Command{
 		Use:   "ps",
 		Short: "List containers",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPs(cmd.Context(), backend, opts)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runPs(ctx, backend, opts)
+		}),
 	}
 	psCmd.Flags().StringVar(&opts.Format, "format", "pretty", "Format the output. Values: [pretty | json].")
 	psCmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs")

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -46,12 +46,12 @@ func pullCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull [SERVICE...]",
 		Short: "Pull service images",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.noParallel {
 				fmt.Fprint(os.Stderr, aec.Apply("option '--no-parallel' is DEPRECATED and will be ignored.\n", aec.RedF))
 			}
-			return runPull(cmd.Context(), backend, opts, args)
-		},
+			return runPull(ctx, backend, opts, args)
+		}),
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Pull without printing progress information")

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -24,7 +24,6 @@ import (
 	"github.com/morikuni/aec"
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/utils"
@@ -40,7 +39,7 @@ type pullOptions struct {
 	ignorePullFailures bool
 }
 
-func pullCommand(p *projectOptions) *cobra.Command {
+func pullCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := pullOptions{
 		projectOptions: p,
 	}
@@ -51,7 +50,7 @@ func pullCommand(p *projectOptions) *cobra.Command {
 			if opts.noParallel {
 				fmt.Fprint(os.Stderr, aec.Apply("option '--no-parallel' is DEPRECATED and will be ignored.\n", aec.RedF))
 			}
-			return runPull(cmd.Context(), opts, args)
+			return runPull(cmd.Context(), backend, opts, args)
 		},
 	}
 	flags := cmd.Flags()
@@ -65,12 +64,7 @@ func pullCommand(p *projectOptions) *cobra.Command {
 	return cmd
 }
 
-func runPull(ctx context.Context, opts pullOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runPull(ctx context.Context, backend compose.Service, opts pullOptions, services []string) error {
 	project, err := opts.toProject(services)
 	if err != nil {
 		return err
@@ -94,11 +88,11 @@ func runPull(ctx context.Context, opts pullOptions, services []string) error {
 	}
 
 	if opts.quiet {
-		return c.ComposeService().Pull(ctx, project, apiOpts)
+		return backend.Pull(ctx, project, apiOpts)
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().Pull(ctx, project, apiOpts)
+		return "", backend.Pull(ctx, project, apiOpts)
 	})
 	return err
 }

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -39,9 +39,9 @@ func pushCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	pushCmd := &cobra.Command{
 		Use:   "push [SERVICE...]",
 		Short: "Push service images",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPush(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runPush(ctx, backend, opts, args)
+		}),
 	}
 	pushCmd.Flags().BoolVar(&opts.Ignorefailures, "ignore-push-failures", false, "Push what it can and ignores images with push failures")
 

--- a/cli/cmd/compose/remove.go
+++ b/cli/cmd/compose/remove.go
@@ -48,9 +48,9 @@ By default, anonymous volumes attached to containers will not be removed. You
 can override this with -v. To list all volumes, use "docker volume ls".
 
 Any data which is not in a volume will be lost.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runRemove(ctx, backend, opts, args)
+		}),
 	}
 	f := cmd.Flags()
 	f.BoolVarP(&opts.force, "force", "f", false, "Don't ask to confirm removal")

--- a/cli/cmd/compose/remove.go
+++ b/cli/cmd/compose/remove.go
@@ -78,7 +78,7 @@ func runRemove(ctx context.Context, backend compose.Service, opts removeOptions,
 	}
 
 	reosurces, err := backend.Remove(ctx, project, compose.RemoveOptions{
-		DryRun: true,
+		DryRun:   true,
 		Services: services,
 	})
 	if err != nil {

--- a/cli/cmd/compose/restart.go
+++ b/cli/cmd/compose/restart.go
@@ -38,9 +38,9 @@ func restartCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	restartCmd := &cobra.Command{
 		Use:   "restart",
 		Short: "Restart containers",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRestart(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runRestart(ctx, backend, opts, args)
+		}),
 	}
 	flags := restartCmd.Flags()
 	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -109,7 +109,7 @@ func runCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Use:   "run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l KEY=VALUE...] SERVICE [COMMAND] [ARGS...]",
 		Short: "Run a one-off command on a service.",
 		Args:  cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if len(args) > 1 {
 				opts.Command = args[1:]
 			}
@@ -117,8 +117,8 @@ func runCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 			if len(opts.publish) > 0 && opts.servicePorts {
 				return fmt.Errorf("--service-ports and --publish are incompatible")
 			}
-			return runRun(cmd.Context(), backend, opts)
-		},
+			return runRun(ctx, backend, opts)
+		}),
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.Detach, "detach", "d", false, "Run container in background and print container ID")

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -36,9 +36,9 @@ func startCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	startCmd := &cobra.Command{
 		Use:   "start [SERVICE...]",
 		Short: "Start services",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStart(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runStart(ctx, backend, opts, args)
+		}),
 	}
 	return startCmd
 }

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -19,7 +19,6 @@ package compose
 import (
 	"context"
 
-	"github.com/docker/compose-cli/api/client"
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/progress"
 
@@ -30,7 +29,7 @@ type startOptions struct {
 	*projectOptions
 }
 
-func startCommand(p *projectOptions) *cobra.Command {
+func startCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := startOptions{
 		projectOptions: p,
 	}
@@ -38,25 +37,20 @@ func startCommand(p *projectOptions) *cobra.Command {
 		Use:   "start [SERVICE...]",
 		Short: "Start services",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStart(cmd.Context(), opts, args)
+			return runStart(cmd.Context(), backend, opts, args)
 		},
 	}
 	return startCmd
 }
 
-func runStart(ctx context.Context, opts startOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
-
+func runStart(ctx context.Context, backend compose.Service, opts startOptions, services []string) error {
 	project, err := opts.toProject(services)
 	if err != nil {
 		return err
 	}
 
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
-		return "", c.ComposeService().Start(ctx, project, compose.StartOptions{})
+		return "", backend.Start(ctx, project, compose.StartOptions{})
 	})
 	return err
 }

--- a/cli/cmd/compose/stop.go
+++ b/cli/cmd/compose/stop.go
@@ -39,10 +39,12 @@ func stopCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stop [SERVICE...]",
 		Short: "Stop services",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.timeChanged = cmd.Flags().Changed("timeout")
-			return runStop(cmd.Context(), backend, opts, args)
 		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runStop(ctx, backend, opts, args)
+		}),
 	}
 	flags := cmd.Flags()
 	flags.IntVarP(&opts.timeout, "timeout", "t", 10, "Specify a shutdown timeout in seconds")

--- a/cli/cmd/compose/stop.go
+++ b/cli/cmd/compose/stop.go
@@ -65,7 +65,7 @@ func runStop(ctx context.Context, backend compose.Service, opts stopOptions, ser
 	}
 	_, err = progress.Run(ctx, func(ctx context.Context) (string, error) {
 		return "", backend.Stop(ctx, project, compose.StopOptions{
-			Timeout: timeout,
+			Timeout:  timeout,
 			Services: services,
 		})
 	})

--- a/cli/cmd/compose/top.go
+++ b/cli/cmd/compose/top.go
@@ -27,14 +27,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/docker/compose-cli/api/client"
+	"github.com/docker/compose-cli/api/compose"
 )
 
 type topOptions struct {
 	*projectOptions
 }
 
-func topCommand(p *projectOptions) *cobra.Command {
+func topCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	opts := topOptions{
 		projectOptions: p,
 	}
@@ -42,22 +42,18 @@ func topCommand(p *projectOptions) *cobra.Command {
 		Use:   "top",
 		Short: "Display the running processes",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTop(cmd.Context(), opts, args)
+			return runTop(cmd.Context(), backend, opts, args)
 		},
 	}
 	return topCmd
 }
 
-func runTop(ctx context.Context, opts topOptions, services []string) error {
-	c, err := client.New(ctx)
-	if err != nil {
-		return err
-	}
+func runTop(ctx context.Context, backend compose.Service, opts topOptions, services []string) error {
 	projectName, err := opts.toProjectName()
 	if err != nil {
 		return err
 	}
-	containers, err := c.ComposeService().Top(ctx, projectName, services)
+	containers, err := backend.Top(ctx, projectName, services)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/compose/top.go
+++ b/cli/cmd/compose/top.go
@@ -41,9 +41,9 @@ func topCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	topCmd := &cobra.Command{
 		Use:   "top",
 		Short: "Display the running processes",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTop(cmd.Context(), backend, opts, args)
-		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
+			return runTop(ctx, backend, opts, args)
+		}),
 	}
 	return topCmd
 }

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -148,8 +148,10 @@ func upCommand(p *projectOptions, contextType string, backend compose.Service) *
 	upCmd := &cobra.Command{
 		Use:   "up [SERVICE...]",
 		Short: "Create and start containers",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.timeChanged = cmd.Flags().Changed("timeout")
+		},
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
 				if opts.exitCodeFrom != "" {
@@ -167,11 +169,11 @@ func upCommand(p *projectOptions, contextType string, backend compose.Service) *
 				if opts.recreateDeps && opts.noRecreate {
 					return fmt.Errorf("--always-recreate-deps and --no-recreate are incompatible")
 				}
-				return runCreateStart(cmd.Context(), backend, opts, args)
+				return runCreateStart(ctx, backend, opts, args)
 			default:
-				return runUp(cmd.Context(), backend, opts, args)
+				return runUp(ctx, backend, opts, args)
 			}
-		},
+		}),
 	}
 	flags := upCmd.Flags()
 	flags.StringArrayVarP(&opts.Environment, "environment", "e", []string{}, "Environment variables")

--- a/cli/config/flags_test.go
+++ b/cli/config/flags_test.go
@@ -1,0 +1,61 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/docker/compose-cli/api/config"
+)
+
+var contextSetConfig = []byte(`{
+	"currentContext": "some-context"
+}`)
+
+func TestDetermineCurrentContext(t *testing.T) {
+	d, err := ioutil.TempDir("", "")
+	// nolint errcheck
+	defer os.RemoveAll(d)
+	assert.NilError(t, err)
+	err = ioutil.WriteFile(filepath.Join(d, config.ConfigFileName), contextSetConfig, 0644)
+	assert.NilError(t, err)
+
+	// If nothing set, fallback to default
+	c := GetCurrentContext("", "", []string{})
+	assert.Equal(t, c, "default")
+
+	// If context flag set, use that
+	c = GetCurrentContext("other-context", "", []string{})
+	assert.Equal(t, c, "other-context")
+
+	// If no context flag, use config
+	c = GetCurrentContext("", d, []string{})
+	assert.Equal(t, c, "some-context")
+
+	// Ensure context flag overrides config
+	c = GetCurrentContext("other-context", d, []string{})
+	assert.Equal(t, "other-context", c)
+
+	// Ensure host flag overrides context
+	c = GetCurrentContext("other-context", d, []string{"hostname"})
+	assert.Equal(t, "default", c)
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -221,7 +221,7 @@ func main() {
 
 	root.AddCommand(
 		run.Command(ctype),
-		compose.Command(ctype),
+		compose.Command(ctype, service.ComposeService()),
 		volume.Command(ctype),
 	)
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -294,7 +294,7 @@ func exit(ctx string, err error, ctype string) {
 
 	if errors.Is(err, errdefs.ErrNotImplemented) {
 		name := metrics.GetCommand(os.Args[1:])
-		fmt.Fprintf(os.Stderr, "RootCommand %q not available in current context (%s)\n", name, ctx)
+		fmt.Fprintf(os.Stderr, "Command %q not available in current context (%s)\n", name, ctx)
 
 		os.Exit(1)
 	}
@@ -314,7 +314,7 @@ func checkIfUnknownCommandExistInDefaultContext(err error, currentContext string
 		dockerCommand := string(submatch[1])
 
 		if mobycli.IsDefaultContextCommand(dockerCommand) {
-			fmt.Fprintf(os.Stderr, "RootCommand %q not available in current context (%s), you can use the \"default\" context to run this command\n", dockerCommand, currentContext)
+			fmt.Fprintf(os.Stderr, "Command %q not available in current context (%s), you can use the \"default\" context to run this command\n", dockerCommand, currentContext)
 			metrics.Track(contextType, os.Args[1:], metrics.FailureStatus)
 			os.Exit(1)
 		}

--- a/cli/main.go
+++ b/cli/main.go
@@ -218,7 +218,7 @@ func main() {
 
 	root.AddCommand(
 		run.Command(ctype),
-		compose.Command(ctype, service.ComposeService()),
+		compose.RootCommand(ctype, service.ComposeService()),
 		volume.Command(ctype),
 	)
 
@@ -294,7 +294,7 @@ func exit(ctx string, err error, ctype string) {
 
 	if errors.Is(err, errdefs.ErrNotImplemented) {
 		name := metrics.GetCommand(os.Args[1:])
-		fmt.Fprintf(os.Stderr, "Command %q not available in current context (%s)\n", name, ctx)
+		fmt.Fprintf(os.Stderr, "RootCommand %q not available in current context (%s)\n", name, ctx)
 
 		os.Exit(1)
 	}
@@ -314,7 +314,7 @@ func checkIfUnknownCommandExistInDefaultContext(err error, currentContext string
 		dockerCommand := string(submatch[1])
 
 		if mobycli.IsDefaultContextCommand(dockerCommand) {
-			fmt.Fprintf(os.Stderr, "Command %q not available in current context (%s), you can use the \"default\" context to run this command\n", dockerCommand, currentContext)
+			fmt.Fprintf(os.Stderr, "RootCommand %q not available in current context (%s), you can use the \"default\" context to run this command\n", dockerCommand, currentContext)
 			metrics.Track(contextType, os.Args[1:], metrics.FailureStatus)
 			os.Exit(1)
 		}

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -17,52 +17,16 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
-	"github.com/docker/compose-cli/api/config"
 	"github.com/docker/compose-cli/cli/cmd"
 	"github.com/docker/compose-cli/cli/cmd/context"
 	"github.com/docker/compose-cli/cli/cmd/login"
 	"github.com/docker/compose-cli/cli/cmd/run"
 )
-
-var contextSetConfig = []byte(`{
-	"currentContext": "some-context"
-}`)
-
-func TestDetermineCurrentContext(t *testing.T) {
-	d, err := ioutil.TempDir("", "")
-	// nolint errcheck
-	defer os.RemoveAll(d)
-	assert.NilError(t, err)
-	err = ioutil.WriteFile(filepath.Join(d, config.ConfigFileName), contextSetConfig, 0644)
-	assert.NilError(t, err)
-
-	// If nothing set, fallback to default
-	c := determineCurrentContext("", "", []string{})
-	assert.Equal(t, c, "default")
-
-	// If context flag set, use that
-	c = determineCurrentContext("other-context", "", []string{})
-	assert.Equal(t, c, "other-context")
-
-	// If no context flag, use config
-	c = determineCurrentContext("", d, []string{})
-	assert.Equal(t, c, "some-context")
-
-	// Ensure context flag overrides config
-	c = determineCurrentContext("other-context", d, []string{})
-	assert.Equal(t, "other-context", c)
-
-	// Ensure host flag overrides context
-	c = determineCurrentContext("other-context", d, []string{"hostname"})
-	assert.Equal(t, "default", c)
-}
 
 func TestCheckOwnCommand(t *testing.T) {
 	assert.Assert(t, isContextAgnosticCommand(login.Command()))

--- a/cli/metrics/definitions.go
+++ b/cli/metrics/definitions.go
@@ -55,3 +55,26 @@ var (
 	// PullFailure failure while pulling image
 	PullFailure = FailureCategory{MetricsStatus: PullFailureStatus, ExitCode: 18}
 )
+
+//ByExitCode retrieve FailureCategory based on command exit code
+func ByExitCode(exitCode int) FailureCategory {
+	switch exitCode {
+	case 0:
+		return FailureCategory{MetricsStatus: SuccessStatus, ExitCode: 0}
+	case 14:
+		return FileNotFoundFailure
+	case 15:
+		return ComposeParseFailure
+	case 16:
+		return CommandSyntaxFailure
+	case 17:
+		return BuildFailure
+	case 18:
+		return PullFailure
+	case 130:
+		return FailureCategory{MetricsStatus: CanceledStatus, ExitCode: exitCode}
+	default:
+		return FailureCategory{MetricsStatus: FailureStatus, ExitCode: exitCode}
+	}
+
+}

--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -68,12 +68,8 @@ func Exec(root *cobra.Command) {
 	if err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			exitCode := exiterr.ExitCode()
-			if exitCode == 130 {
-				metrics.Track(store.DefaultContextType, os.Args[1:], metrics.CanceledStatus)
-			} else {
-				metrics.Track(store.DefaultContextType, os.Args[1:], metrics.FailureStatus)
-			}
-			os.Exit(exiterr.ExitCode())
+			metrics.Track(store.DefaultContextType, os.Args[1:], metrics.ByExitCode(exitCode).MetricsStatus)
+			os.Exit(exitCode)
 		}
 		metrics.Track(store.DefaultContextType, os.Args[1:], metrics.FailureStatus)
 		fmt.Fprintln(os.Stderr, err)

--- a/docs/yaml/main/generate.go
+++ b/docs/yaml/main/generate.go
@@ -35,7 +35,7 @@ const descriptionSourcePath = "docs/reference/"
 
 func generateCliYaml(opts *options) error {
 	cmd := &cobra.Command{Use: "docker"}
-	cmd.AddCommand(compose.Command("local"))
+	cmd.AddCommand(compose.Command("local", nil))
 	disableFlagsInUseLine(cmd)
 	source := filepath.Join(opts.source, descriptionSourcePath)
 	if err := loadLongDescription(cmd, source); err != nil {

--- a/docs/yaml/main/generate.go
+++ b/docs/yaml/main/generate.go
@@ -35,7 +35,7 @@ const descriptionSourcePath = "docs/reference/"
 
 func generateCliYaml(opts *options) error {
 	cmd := &cobra.Command{Use: "docker"}
-	cmd.AddCommand(compose.Command("local", nil))
+	cmd.AddCommand(compose.RootCommand("local", nil))
 	disableFlagsInUseLine(cmd)
 	source := filepath.Join(opts.source, descriptionSourcePath)
 	if err := loadLongDescription(cmd, source); err != nil {

--- a/ecs/local/backend.go
+++ b/ecs/local/backend.go
@@ -17,8 +17,9 @@
 package local
 
 import (
-	local_compose "github.com/docker/compose-cli/local/compose"
+	"os"
 
+	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/client"
 
 	"github.com/docker/compose-cli/api/backend"
@@ -29,6 +30,7 @@ import (
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
+	local_compose "github.com/docker/compose-cli/local/compose"
 )
 
 const backendType = store.EcsLocalSimulationContextType
@@ -50,7 +52,7 @@ func service() (backend.Service, error) {
 
 	return &ecsLocalSimulation{
 		moby:    apiClient,
-		compose: local_compose.NewComposeService(apiClient),
+		compose: local_compose.NewComposeService(apiClient, cliconfig.LoadDefaultConfigFile(os.Stderr)),
 	}, nil
 }
 

--- a/local/backend.go
+++ b/local/backend.go
@@ -19,7 +19,9 @@ package local
 import (
 	"os"
 
+	"github.com/docker/cli/cli/command"
 	cliconfig "github.com/docker/cli/cli/config"
+	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/client"
 
 	"github.com/docker/compose-cli/api/backend"
@@ -28,6 +30,7 @@ import (
 	"github.com/docker/compose-cli/api/resources"
 	"github.com/docker/compose-cli/api/secrets"
 	"github.com/docker/compose-cli/api/volumes"
+	cliopts "github.com/docker/compose-cli/cli/options"
 	local_compose "github.com/docker/compose-cli/local/compose"
 )
 
@@ -45,6 +48,31 @@ func NewService(apiClient client.APIClient) backend.Service {
 		volumeService:    &volumeService{apiClient},
 		composeService:   local_compose.NewComposeService(apiClient, file),
 	}
+}
+
+// GetLocalBackend initialize local backend
+func GetLocalBackend(configDir string, opts cliopts.GlobalOpts) (backend.Service, error) {
+	configFile, err := cliconfig.Load(configDir)
+	if err != nil {
+		return nil, err
+	}
+	options := cliflags.CommonOptions{
+		Context:  opts.Context,
+		Debug:    opts.Debug,
+		Hosts:    opts.Hosts,
+		LogLevel: opts.LogLevel,
+	}
+
+	if opts.TLSVerify {
+		options.TLS = opts.TLS
+		options.TLSVerify = opts.TLSVerify
+		options.TLSOptions = opts.TLSOptions
+	}
+	apiClient, err := command.NewAPIClientFromFlags(&options, configFile)
+	if err != nil {
+		return nil, err
+	}
+	return NewService(apiClient), nil
 }
 
 func (s *local) ContainerService() containers.Service {

--- a/local/backend.go
+++ b/local/backend.go
@@ -17,6 +17,9 @@
 package local
 
 import (
+	"os"
+
+	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/client"
 
 	"github.com/docker/compose-cli/api/backend"
@@ -36,10 +39,11 @@ type local struct {
 
 // NewService build a backend for "local" context, using Docker API client
 func NewService(apiClient client.APIClient) backend.Service {
+	file := cliconfig.LoadDefaultConfigFile(os.Stderr)
 	return &local{
 		containerService: &containerService{apiClient},
 		volumeService:    &volumeService{apiClient},
-		composeService:   local_compose.NewComposeService(apiClient),
+		composeService:   local_compose.NewComposeService(apiClient, file),
 	}
 }
 

--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -28,13 +28,11 @@ import (
 	"github.com/docker/buildx/driver"
 	_ "github.com/docker/buildx/driver/docker" // required to get default driver registered
 	"github.com/docker/buildx/util/progress"
-	cliconfig "github.com/docker/cli/cli/config"
 	moby "github.com/docker/docker/api/types"
 	bclient "github.com/moby/buildkit/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/config"
 	composeprogress "github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/metrics"
 	"github.com/docker/compose-cli/utils"
@@ -195,12 +193,7 @@ func (s *composeService) build(ctx context.Context, project *types.Project, opts
 	}
 	const drivername = "default"
 
-	configFile, err := cliconfig.Load(config.Dir())
-	if err != nil {
-		return nil, err
-	}
-
-	d, err := driver.GetDriver(ctx, drivername, nil, s.apiClient, configFile, nil, nil, "", nil, nil, project.WorkingDir)
+	d, err := driver.GetDriver(ctx, drivername, nil, s.apiClient, s.configFile, nil, nil, "", nil, nil, project.WorkingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/local/compose/compose.go
+++ b/local/compose/compose.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/cli/cli/config/configfile"
 	"strings"
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/errdefs"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/cli/cli/config/configfile"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/sanathkr/go-yaml"

--- a/local/compose/compose.go
+++ b/local/compose/compose.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/docker/cli/cli/config/configfile"
 	"strings"
 
 	"github.com/docker/compose-cli/api/compose"
@@ -32,14 +33,16 @@ import (
 )
 
 // NewComposeService create a local implementation of the compose.Service API
-func NewComposeService(apiClient client.APIClient) compose.Service {
+func NewComposeService(apiClient client.APIClient, configFile *configfile.ConfigFile) compose.Service {
 	return &composeService{
-		apiClient: apiClient,
+		apiClient:  apiClient,
+		configFile: configFile,
 	}
 }
 
 type composeService struct {
-	apiClient client.APIClient
+	apiClient  client.APIClient
+	configFile *configfile.ConfigFile
 }
 
 func (s *composeService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {

--- a/local/compose/pull.go
+++ b/local/compose/pull.go
@@ -27,23 +27,17 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	"github.com/distribution/distribution/v3/reference"
 	"github.com/docker/buildx/driver"
-	cliconfig "github.com/docker/cli/cli/config"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/config"
 	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/cli/metrics"
 )
 
 func (s *composeService) Pull(ctx context.Context, project *types.Project, opts compose.PullOptions) error {
-	configFile, err := cliconfig.Load(config.Dir())
-	if err != nil {
-		return err
-	}
 	info, err := s.apiClient.Info(ctx)
 	if err != nil {
 		return err
@@ -67,7 +61,7 @@ func (s *composeService) Pull(ctx context.Context, project *types.Project, opts 
 			continue
 		}
 		eg.Go(func() error {
-			err := s.pullServiceImage(ctx, service, info, configFile, w)
+			err := s.pullServiceImage(ctx, service, info, s.configFile, w)
 			if err != nil {
 				if !opts.IgnoreFailures {
 					return err

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -129,6 +130,15 @@ func TestLocalComposeUp(t *testing.T) {
 		res := c.RunDockerCmd("network", "ls")
 		assert.Assert(t, !strings.Contains(res.Combined(), projectName), res.Combined())
 	})
+}
+
+func TestComposeUsingCliPlugin(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	err := os.Remove(filepath.Join(c.ConfigDir, "cli-plugins", "docker-compose"))
+	assert.NilError(t, err)
+	res := c.RunDockerOrExitError("compose", "ls")
+	res.Assert(t, icmd.Expected{Err: "'compose' is not a docker command", ExitCode: 1})
 }
 
 func TestComposePull(t *testing.T) {

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -141,6 +141,17 @@ func TestComposeUsingCliPlugin(t *testing.T) {
 	res.Assert(t, icmd.Expected{Err: "'compose' is not a docker command", ExitCode: 1})
 }
 
+func TestComposeCliPluginWithoutCloudIntegration(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	err := os.Remove(filepath.Join(binDir, "docker"))
+	assert.NilError(t, err)
+	err = os.Rename(filepath.Join(binDir, "com.docker.cli"), filepath.Join(binDir, "docker"))
+	assert.NilError(t, err)
+	res := c.RunDockerOrExitError("compose", "ls")
+	res.Assert(t, icmd.Expected{Out: "NAME                STATUS", ExitCode: 0})
+}
+
 func TestComposePull(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 

--- a/local/e2e/compose/fixtures/build-infinite/docker-compose.yml
+++ b/local/e2e/compose/fixtures/build-infinite/docker-compose.yml
@@ -1,0 +1,3 @@
+services:
+    service1:
+        build: service1

--- a/local/e2e/compose/fixtures/build-infinite/service1/Dockerfile
+++ b/local/e2e/compose/fixtures/build-infinite/service1/Dockerfile
@@ -1,0 +1,17 @@
+#   Copyright 2020 Docker Compose CLI authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM busybox
+
+RUN sleep infinity

--- a/local/e2e/compose/metrics_test.go
+++ b/local/e2e/compose/metrics_test.go
@@ -17,7 +17,11 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -83,4 +87,70 @@ func TestComposeMetrics(t *testing.T) {
 			`{"command":"compose up","context":"moby","source":"cli","status":"failure-build"}`,
 		}, usage)
 	})
+}
+
+func TestComposeCancel(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+	s := NewMetricsServer(c.MetricsSocket())
+	s.Start()
+	defer s.Stop()
+
+	started := false
+
+	for i := 0; i < 30; i++ {
+		c.RunDockerCmd("help", "ps")
+		if len(s.GetUsage()) > 0 {
+			started = true
+			fmt.Printf("    [%s] Server up in %d ms\n", t.Name(), i*100)
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Assert(t, started, "Metrics mock server not available after 3 secs")
+
+	t.Run("metrics on cancel Compose build", func(t *testing.T) {
+		s.ResetUsage()
+
+		c.RunDockerCmd("compose", "ls")
+		buildProjectPath := "../compose/fixtures/build-infinite/docker-compose.yml"
+
+		// require a separate groupID from the process running tests, in order to simulate ctrl+C from a terminal.
+		// sending kill signal
+		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerCmd("compose", "-f", buildProjectPath, "build", "--progress", "plain"))
+		assert.NilError(t, err)
+
+		c.WaitForCondition(func() (bool, string) {
+			out := stdout.String()
+			errors := stderr.String()
+			return strings.Contains(out, "RUN sleep infinity"), fmt.Sprintf("'RUN sleep infinity' not found in : \n%s\nStderr: \n%s\n", out, errors)
+		}, 30*time.Second, 1*time.Second)
+
+		err = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT) // simulate Ctrl-C : send signal to processGroup, children will have same groupId by default
+
+		assert.NilError(t, err)
+		c.WaitForCondition(func() (bool, string) {
+			out := stdout.String()
+			errors := stderr.String()
+			return strings.Contains(out, "CANCELED"), fmt.Sprintf("'CANCELED' not found in : \n%s\nStderr: \n%s\n", out, errors)
+		}, 10*time.Second, 1*time.Second)
+
+		usage := s.GetUsage()
+		assert.DeepEqual(t, []string{
+			`{"command":"compose ls","context":"moby","source":"cli","status":"success"}`,
+			`{"command":"compose build","context":"moby","source":"cli","status":"canceled"}`,
+		}, usage)
+	})
+}
+
+func StartWithNewGroupID(command icmd.Cmd) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer, error) {
+	cmd := exec.Command(command.Command[0], command.Command[1:]...)
+	cmd.Env = command.Env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Start()
+	return cmd, &stdout, &stderr, err
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli-plugins/manager"
+	"github.com/docker/cli/cli-plugins/plugin"
+	"github.com/docker/cli/cli/command"
+	api "github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/api/context/store"
+	"github.com/docker/compose-cli/cli/cmd/compose"
+	"github.com/docker/compose-cli/internal"
+	impl "github.com/docker/compose-cli/local/compose"
+)
+
+func main() {
+	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
+		lazyInit := api.ServiceDelegator{
+			Delegate: api.NoImpl{},
+		}
+		cmd := compose.Command(store.DefaultContextType, &lazyInit)
+		originalPreRun := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			if err := plugin.PersistentPreRunE(cmd, args); err != nil {
+				return err
+			}
+			lazyInit.Delegate = impl.NewComposeService(dockerCli.Client(), dockerCli.ConfigFile())
+			if originalPreRun != nil {
+				return originalPreRun(cmd, args)
+			}
+			return nil
+		}
+		return cmd
+	},
+		manager.Metadata{
+			SchemaVersion: "0.1.0",
+			Vendor:        "Docker Inc.",
+			Version:       strings.TrimPrefix(internal.Version, "v"),
+		})
+}

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -85,6 +85,13 @@ func newE2eCLI(t *testing.T, binDir string) *E2eCLI {
 		_ = os.RemoveAll(d)
 	})
 
+	_ = os.MkdirAll(filepath.Join(d, "cli-plugins"), 0755)
+	composePlugin, _ := findExecutable("docker-compose", []string{"../../bin", "../../../bin"})
+	err = CopyFile(composePlugin, filepath.Join(d, "cli-plugins", "docker-compose"))
+	if err != nil {
+		panic(err)
+	}
+
 	return &E2eCLI{binDir, d, t}
 }
 
@@ -117,7 +124,7 @@ func SetupExistingCLI() (string, func(), error) {
 		return "", nil, err
 	}
 
-	bin, err := findExecutable([]string{"../../bin", "../../../bin"})
+	bin, err := findExecutable(DockerExecutableName, []string{"../../bin", "../../../bin"})
 	if err != nil {
 		return "", nil, err
 	}
@@ -133,9 +140,9 @@ func SetupExistingCLI() (string, func(), error) {
 	return d, cleanup, nil
 }
 
-func findExecutable(paths []string) (string, error) {
+func findExecutable(executableName string, paths []string) (string, error) {
 	for _, p := range paths {
-		bin, err := filepath.Abs(path.Join(p, DockerExecutableName))
+		bin, err := filepath.Abs(path.Join(p, executableName))
 		if err != nil {
 			return "", err
 		}

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -86,8 +86,12 @@ func newE2eCLI(t *testing.T, binDir string) *E2eCLI {
 	})
 
 	_ = os.MkdirAll(filepath.Join(d, "cli-plugins"), 0755)
-	composePlugin, _ := findExecutable("docker-compose", []string{"../../bin", "../../../bin"})
-	err = CopyFile(composePlugin, filepath.Join(d, "cli-plugins", "docker-compose"))
+	composePluginFile := "docker-compose"
+	if runtime.GOOS == "windows" {
+		composePluginFile += ".exe"
+	}
+	composePlugin, _ := findExecutable(composePluginFile, []string{"../../bin", "../../../bin"})
+	err = CopyFile(composePlugin, filepath.Join(d, "cli-plugins", composePluginFile))
 	if err != nil {
 		panic(err)
 	}

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -252,6 +252,18 @@ func (c *E2eCLI) WaitForCmdResult(command icmd.Cmd, predicate func(*icmd.Result)
 	poll.WaitOn(c.test, checkStopped, poll.WithDelay(delay), poll.WithTimeout(timeout))
 }
 
+// WaitForCondition wait for predicate to execute to true
+func (c *E2eCLI) WaitForCondition(predicate func() (bool, string), timeout time.Duration, delay time.Duration) {
+	checkStopped := func(logt poll.LogT) poll.Result {
+		pass, description := predicate()
+		if !pass {
+			return poll.Continue("Condition not met: %q", description)
+		}
+		return poll.Success()
+	}
+	poll.WaitOn(c.test, checkStopped, poll.WithDelay(delay), poll.WithTimeout(timeout))
+}
+
 // PathEnvVar returns path (os sensitive) for running test
 func (c *E2eCLI) PathEnvVar() string {
 	path := c.BinDir + ":" + os.Getenv("PATH")


### PR DESCRIPTION
**What I did**
pass `compose.Service` to cobra command builder, so that this code doesn't depend on the backend mechanism and is easier to migrate into a compose cli plugin under docker/compose repository

This is based on earlier work on https://github.com/docker/compose-cli/pull/1397. Some of the commits have been cherry-picked.
Main difference is: compose commands have been refactored to adopt a "Dependency Injection by Constructor" pattern, i.e. :
- `FooCommand()` to create cobra compose command `foo` receive the backend's `service.Compose` implementation as parameter, and does not have to know about the context/backend logic. 
- From top-level `main.go` (CLI plugin) the `local.Backend` implementation is created by injecting Docker API client and config file (provided by the CLI plugin framework) as constructor parameters
- Compose cobra command are wrapped with an adaptor to manage exit code in a consistent way with metrics expected exit codes.

/test-aci
/test-ecs
/test-windows