### PR TITLE
don't set aliasses if no network binding was declared

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -850,6 +850,9 @@ func buildTmpfsOptions(tmpfs *types.ServiceVolumeTmpfs) *mount.TmpfsOptions {
 }
 
 func buildDefaultNetworkConfig(s types.ServiceConfig, networkMode container.NetworkMode, containerName string) *network.NetworkingConfig {
+	if len(s.Networks) == 0 {
+		return nil
+	}
 	config := map[string]*network.EndpointSettings{}
 	net := string(networkMode)
 	config[net] = &network.EndpointSettings{


### PR DESCRIPTION
**What I did**
Don't build networkConfig if no network binding is declared
this is same as https://github.com/docker/compose/blob/master/compose/service.py#L817-L818

**Related issue**
close https://github.com/docker/dev-tooling-team/issues/301

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
