### PR TITLE
only start container once we have a wait channel set, to prevent race

### DIFF
--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -43,6 +43,9 @@ func (s *composeService) getContainers(ctx context.Context, project string, oneO
 	f := filters.NewArgs(
 		projectFilter(project),
 	)
+	if len(selectedServices) == 1 {
+		f.Add("label", fmt.Sprintf("%s=%s", serviceLabel, selectedServices[0]))
+	}
 	switch oneOff {
 	case oneOffOnly:
 		f.Add("label", fmt.Sprintf("%s=%s", oneoffLabel, "True"))
@@ -57,7 +60,7 @@ func (s *composeService) getContainers(ctx context.Context, project string, oneO
 	if err != nil {
 		return nil, err
 	}
-	if len(selectedServices) > 0 {
+	if len(selectedServices) > 1 {
 		containers = containers.filter(isService(selectedServices...))
 	}
 	return containers, nil

--- a/local/compose/exec.go
+++ b/local/compose/exec.go
@@ -83,7 +83,7 @@ func (s *composeService) Exec(ctx context.Context, project *types.Project, opts 
 	defer resp.Close()
 
 	if opts.Tty {
-		err := s.monitorTTySize(ctx, exec.ID, s.apiClient.ContainerExecResize)
+		s.monitorTTySize(ctx, exec.ID, s.apiClient.ContainerExecResize)
 		if err != nil {
 			return err
 		}

--- a/local/compose/resize.go
+++ b/local/compose/resize.go
@@ -28,13 +28,13 @@ import (
 	"github.com/docker/docker/pkg/signal"
 )
 
-func (s *composeService) monitorTTySize(ctx context.Context, container string, resize func(context.Context, string, moby.ResizeOptions) error) error {
+func (s *composeService) monitorTTySize(ctx context.Context, container string, resize func(context.Context, string, moby.ResizeOptions) error) {
 	err := resize(ctx, container, moby.ResizeOptions{ // nolint:errcheck
 		Height: uint(goterm.Height()),
 		Width:  uint(goterm.Width()),
 	})
 	if err != nil {
-		return err
+		return
 	}
 
 	sigchan := make(chan os.Signal, 1)
@@ -71,5 +71,4 @@ func (s *composeService) monitorTTySize(ctx context.Context, container string, r
 			}
 		}
 	}()
-	return nil
 }

--- a/local/compose/run.go
+++ b/local/compose/run.go
@@ -96,10 +96,7 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 		return 0, err
 	}
 
-	err = s.monitorTTySize(ctx, containerID, s.apiClient.ContainerResize)
-	if err != nil {
-		return 0, err
-	}
+	s.monitorTTySize(ctx, containerID, s.apiClient.ContainerResize)
 
 	select {
 	case status := <-statusC:

--- a/local/compose/run.go
+++ b/local/compose/run.go
@@ -89,6 +89,8 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 	}
 	defer restore()
 
+	statusC, errC := s.apiClient.ContainerWait(context.Background(), oneoffContainer.ID, container.WaitConditionNextExit)
+
 	err = s.apiClient.ContainerStart(ctx, containerID, apitypes.ContainerStartOptions{})
 	if err != nil {
 		return 0, err
@@ -99,7 +101,6 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 		return 0, err
 	}
 
-	statusC, errC := s.apiClient.ContainerWait(context.Background(), oneoffContainer.ID, container.WaitConditionNotRunning)
 	select {
 	case status := <-statusC:
 		return int(status.StatusCode), nil


### PR DESCRIPTION
**What I did**
change API call order so we wait for container next exit _before_ we start it, otherwise a container to just run `/bin/true` might terminate before we invoke wait, resulting in daemon error "container xx is not running"