### PR TITLE
Fix volume names to print simple volume names

### DIFF
--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -170,8 +170,8 @@ func runVolumes(opts convertOptions) error {
 	if err != nil {
 		return err
 	}
-	for _, v := range project.Volumes {
-		fmt.Println(v.Name)
+	for n := range project.Volumes {
+		fmt.Println(n)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix volume names to print simple volume names instead of `<project>_<volume>`