### PR TITLE
scale must ignore oneoff containers

### DIFF
--- a/local/compose/containers.go
+++ b/local/compose/containers.go
@@ -83,6 +83,11 @@ func isNotService(services ...string) containerPredicate {
 	}
 }
 
+func isNotOneOff(c moby.Container) bool {
+	v, ok := c.Labels[oneoffLabel]
+	return !ok || v == "False"
+}
+
 // filter return Containers with elements to match predicate
 func (containers Containers) filter(predicate containerPredicate) Containers {
 	var filtered Containers

--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -52,7 +52,7 @@ func (s *composeService) ensureScale(ctx context.Context, project *types.Project
 		return nil, nil, err
 	}
 	observedState := cState.GetContainers()
-	actual := observedState.filter(isService(service.Name))
+	actual := observedState.filter(isService(service.Name)).filter(isNotOneOff)
 	scale, err := getScale(service)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
**What I did**
ensureScale must ignore oneoff cotainers which don't have a "number" label

**Related issue**
should fix https://github.com/docker/compose-cli/issues/1537
fix https://github.com/docker/compose-cli/issues/1561

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
