### PR TITLE
Create mount source if it does not exist

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -586,17 +586,12 @@ func (s *composeService) buildContainerVolumes(ctx context.Context, p types.Proj
 	volumeMounts := map[string]struct{}{}
 	binds := []string{}
 	for _, m := range mountOptions {
-
+		volumeMounts[m.Target] = struct{}{}
 		if m.Type == mount.TypeVolume {
-			volumeMounts[m.Target] = struct{}{}
-			if m.Source != "" {
-				binds = append(binds, fmt.Sprintf("%s:%s:rw", m.Source, m.Target))
-			}
-		}
-	}
-	for _, m := range mountOptions {
-		if m.Type == mount.TypeBind || m.Type == mount.TypeTmpfs {
 			mounts = append(mounts, m)
+		}
+		if m.Source != "" && m.Type == mount.TypeBind {
+			binds = append(binds, fmt.Sprintf("%s:%s:rw", m.Source, m.Target))
 		}
 	}
 	return volumeMounts, binds, mounts, nil

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -591,7 +591,11 @@ func (s *composeService) buildContainerVolumes(ctx context.Context, p types.Proj
 			mounts = append(mounts, m)
 		}
 		if m.Source != "" && m.Type == mount.TypeBind {
-			binds = append(binds, fmt.Sprintf("%s:%s:rw", m.Source, m.Target))
+			if m.ReadOnly {
+				binds = append(binds, fmt.Sprintf("%s:%s:ro", m.Source, m.Target))
+			} else {
+				binds = append(binds, fmt.Sprintf("%s:%s", m.Source, m.Target))
+			}
 		}
 	}
 	return volumeMounts, binds, mounts, nil

--- a/local/e2e/compose/volumes_test.go
+++ b/local/e2e/compose/volumes_test.go
@@ -49,8 +49,8 @@ func TestLocalComposeVolume(t *testing.T) {
 		res := c.RunDockerCmd("inspect", "compose-e2e-volume_nginx2_1", "--format", "{{ json .Mounts }}")
 		output := res.Stdout()
 		// nolint
-		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"","RW":true,"Propagation":""`), output)
-		assert.Assert(t, strings.Contains(output, `"Destination":"/myconfig","Mode":"","RW":false,"Propagation":"rprivate"`), output)
+		assert.Assert(t, strings.Contains(output, `"Destination":"/usr/src/app/node_modules","Driver":"local","Mode":"z","RW":true,"Propagation":""`), output)
+		assert.Assert(t, strings.Contains(output, `"Destination":"/myconfig","Mode":"ro","RW":false,"Propagation":"rprivate"`), output)
 	})
 
 	t.Run("check config content", func(t *testing.T) {


### PR DESCRIPTION
Create a directory if a bind-mount source does not exist to align with docker-compose.
```
services:
  frontend:
    image: nginx
    volumes:
      - /tmp/doesnotexist:/test
```
```
[example]$ docker-compose up -d
Creating network "example_default" with the default driver
Creating example_frontend_1 ... done
```
```
[example]$ ls -al /tmp | grep doesnotexist
drwxr-xr-x  2 root root      40 Apr 16 10:45 doesnotexist

```
```
[example]$ docker compose up -d
[+] Running 4/4
 ⠿ Network "example_default"     Created                                                                                                           0.0s
 ⠿ Container example_frontend_1  Started                                                                                                           0.7s
```
```
[example]$ ls -al /tmp | grep doesnotexist
drwxr-xr-x  2 anca users     40 Apr 16 10:45 doesnotexist

```

Closes https://github.com/docker/compose-cli/issues/1543