### PR TITLE
Remove service.Build and service.PullPolicy from config hash

### DIFF
--- a/utils/hash.go
+++ b/utils/hash.go
@@ -26,6 +26,9 @@ import (
 // ServiceHash compute configuration has for a service
 // TODO move this to compose-go
 func ServiceHash(o types.ServiceConfig) (string, error) {
+	// remove the Build config when generating the service hash
+	o.Build = nil
+	o.PullPolicy = ""
 	bytes, err := json.Marshal(o)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Some service properties are added at runtime when requiring a build. This makes the config hash to always be different from `compose up` and triggers a restart.

```
$ docker compose build
[+] Building 0.6s (7/7) FINISHED                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 31B                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                                    0.5s
 => [internal] load build context                                                                                                                  0.0s
 => => transferring context: 31B                                                                                                                   0.0s
 => [1/2] FROM docker.io/library/nginx:alpine@sha256:07ab71a2c8e4ecb19a5a5abcfb3a4f175946c001c8af288b1aa766d67b0d05d2                              0.0s
 => CACHED [2/2] COPY nginx.conf /etc/nginx/conf.d/default.conf                                                                                    0.0s
 => exporting to image                                                                                                                             0.0s
 => => exporting layers                                                                                                                            0.0s
 => => writing image sha256:b3c84d7cd6a2940fac880e6b0b7158504fcd70d01be58e917fe47f9be652a642                                                       0.0s
 => => naming to docker.io/library/nginx                                                                                                           0.0s
```
```
$ docker compose up -d
[+] Running 1/0
 ⠿ Container example_test_1  Running                                                                                                               0.0s
```
```
$ docker compose up -d --build
[+] Building 0.5s (7/7) FINISHED                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                               0.0s
 => => transferring dockerfile: 31B                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                                    0.5s
 => [internal] load build context                                                                                                                  0.0s
 => => transferring context: 31B                                                                                                                   0.0s
 => [1/2] FROM docker.io/library/nginx:alpine@sha256:07ab71a2c8e4ecb19a5a5abcfb3a4f175946c001c8af288b1aa766d67b0d05d2                              0.0s
 => CACHED [2/2] COPY nginx.conf /etc/nginx/conf.d/default.conf                                                                                    0.0s
 => exporting to image                                                                                                                             0.0s
 => => exporting layers                                                                                                                            0.0s
 => => writing image sha256:b3c84d7cd6a2940fac880e6b0b7158504fcd70d01be58e917fe47f9be652a642                                                       0.0s
 => => naming to docker.io/library/nginx                                                                                                           0.0s
[+] Running 1/0
 ⠿ Container example_test_1  Running              
```