### PR TITLE
Fix down not working if run from a different folder than up, because container labels stored relative paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v1.0.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
-	github.com/compose-spec/compose-go v0.0.0-20210421142148-66b18e67d2c0
+	github.com/compose-spec/compose-go v0.0.0-20210422124345-d4bf0e1bfea5
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20210421142148-66b18e67d2c0 h1:aoUSQGFmWi8dn1OfT4H5Mx48u5wHt+n07nLFw5j1JXs=
-github.com/compose-spec/compose-go v0.0.0-20210421142148-66b18e67d2c0/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
+github.com/compose-spec/compose-go v0.0.0-20210422124345-d4bf0e1bfea5 h1:uR5dDxz7FboGxh2YjlMJJBOc7RPl87rbV80VV7WJ9N0=
+github.com/compose-spec/compose-go v0.0.0-20210422124345-d4bf0e1bfea5/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -280,14 +280,6 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		return nil, nil, nil, err
 	}
 
-	shmSize := int64(0)
-	if service.ShmSize != "" {
-		shmSize, err = strconv.ParseInt(service.ShmSize, 10, 64)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	}
-
 	tmpfs := map[string]string{}
 	for _, t := range service.Tmpfs {
 		if arr := strings.SplitN(t, ":", 2); len(arr) > 1 {
@@ -316,7 +308,7 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 		IpcMode:        container.IpcMode(ipcmode),
 		ReadonlyRootfs: service.ReadOnly,
 		RestartPolicy:  getRestartPolicy(service),
-		ShmSize:        shmSize,
+		ShmSize:        int64(service.ShmSize),
 		Sysctls:        service.Sysctls,
 		PortBindings:   portBindings,
 		Resources:      resources,

--- a/local/compose/down.go
+++ b/local/compose/down.go
@@ -19,7 +19,6 @@ package compose
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -208,12 +207,7 @@ func (s *composeService) projectFromContainerLabels(containers Containers, proje
 }
 
 func loadProjectOptionsFromLabels(c moby.Container) (*cli.ProjectOptions, error) {
-	var configFiles []string
-	relativePathConfigFiles := strings.Split(c.Labels[configFilesLabel], ",")
-	for _, c := range relativePathConfigFiles {
-		configFiles = append(configFiles, filepath.Base(c))
-	}
-	return cli.NewProjectOptions(configFiles,
+	return cli.NewProjectOptions(strings.Split(c.Labels[configFilesLabel], ","),
 		cli.WithOsEnv,
 		cli.WithWorkingDirectory(c.Labels[workingDirLabel]),
 		cli.WithName(c.Labels[projectLabel]))

--- a/local/compose/kill_test.go
+++ b/local/compose/kill_test.go
@@ -83,7 +83,7 @@ func testContainer(service string, id string) apitypes.Container {
 }
 
 func containerLabels(service string) map[string]string {
-	return map[string]string{serviceLabel: service, configFilesLabel: "testdata/docker-compose.yml", workingDirLabel: "testdata", projectLabel: testProject}
+	return map[string]string{serviceLabel: service, configFilesLabel: "docker-compose.yml", workingDirLabel: "testdata", projectLabel: testProject}
 }
 
 func anyCancellableContext() gomock.Matcher {

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -141,6 +141,22 @@ func TestComposePull(t *testing.T) {
 	assert.Assert(t, strings.Contains(output, "another Pulled"))
 }
 
+func TestDownComposefileInParentFolder(t *testing.T) {
+
+	c := NewParallelE2eCLI(t, binDir)
+
+	tmpFolder, err := os.MkdirTemp("fixtures/simple-composefile", "test-tmp")
+	projectName := strings.TrimPrefix(tmpFolder, "fixtures/simple-composefile/")
+	defer os.Remove(tmpFolder) //nolint: errcheck
+	assert.NilError(t, err)
+
+	res := c.RunDockerCmd("compose", "--project-directory", tmpFolder, "up", "-d")
+	res.Assert(t, icmd.Expected{Err: "Started", ExitCode: 0})
+
+	res = c.RunDockerCmd("compose", "-p", projectName, "down")
+	res.Assert(t, icmd.Expected{Err: "Removed", ExitCode: 0})
+}
+
 func TestAttachRestart(t *testing.T) {
 	c := NewParallelE2eCLI(t, binDir)
 


### PR DESCRIPTION
This is breaking one Desktop test, and I also ran into this when cleaning up test compose apps manually. 

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Ensure we store absolute paths in container labels, and do not try to reconstruct composefile paths with unrealistic logic when reading labels

**Related issue**
https://ci-next.docker.com/teams-desktop/blue/organizations/jenkins/desktop%2Fdesktop-test-single-pr-mac/detail/desktop-test-single-pr-mac/84670/pipeline

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
