### PR TITLE
Adapt compose tests to pass with Desktop Windows

### DIFF
--- a/local/e2e/compose/cancel_test.go
+++ b/local/e2e/compose/cancel_test.go
@@ -1,0 +1,100 @@
+// +build !windows
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+
+	. "github.com/docker/compose-cli/utils/e2e"
+)
+
+func TestComposeCancel(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+	s := NewMetricsServer(c.MetricsSocket())
+	s.Start()
+	defer s.Stop()
+
+	started := false
+
+	for i := 0; i < 30; i++ {
+		c.RunDockerCmd("help", "ps")
+		if len(s.GetUsage()) > 0 {
+			started = true
+			fmt.Printf("    [%s] Server up in %d ms\n", t.Name(), i*100)
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Assert(t, started, "Metrics mock server not available after 3 secs")
+
+	t.Run("metrics on cancel Compose build", func(t *testing.T) {
+		s.ResetUsage()
+
+		c.RunDockerCmd("compose", "ls")
+		buildProjectPath := "../compose/fixtures/build-infinite/docker-compose.yml"
+
+		// require a separate groupID from the process running tests, in order to simulate ctrl+C from a terminal.
+		// sending kill signal
+		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerCmd("compose", "-f", buildProjectPath, "build", "--progress", "plain"))
+		assert.NilError(t, err)
+
+		c.WaitForCondition(func() (bool, string) {
+			out := stdout.String()
+			errors := stderr.String()
+			return strings.Contains(out, "RUN sleep infinity"), fmt.Sprintf("'RUN sleep infinity' not found in : \n%s\nStderr: \n%s\n", out, errors)
+		}, 30*time.Second, 1*time.Second)
+
+		err = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT) // simulate Ctrl-C : send signal to processGroup, children will have same groupId by default
+
+		assert.NilError(t, err)
+		c.WaitForCondition(func() (bool, string) {
+			out := stdout.String()
+			errors := stderr.String()
+			return strings.Contains(out, "CANCELED"), fmt.Sprintf("'CANCELED' not found in : \n%s\nStderr: \n%s\n", out, errors)
+		}, 10*time.Second, 1*time.Second)
+
+		usage := s.GetUsage()
+		assert.DeepEqual(t, []string{
+			`{"command":"compose ls","context":"moby","source":"cli","status":"success"}`,
+			`{"command":"compose build","context":"moby","source":"cli","status":"canceled"}`,
+		}, usage)
+	})
+}
+
+func StartWithNewGroupID(command icmd.Cmd) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer, error) {
+	cmd := exec.Command(command.Command[0], command.Command[1:]...)
+	cmd.Env = command.Env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Start()
+	return cmd, &stdout, &stderr, err
+}

--- a/local/e2e/compose/compose_test.go
+++ b/local/e2e/compose/compose_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -76,13 +77,12 @@ func TestLocalComposeUp(t *testing.T) {
 	})
 
 	t.Run("check compose labels", func(t *testing.T) {
-		wd, _ := os.Getwd()
 		res := c.RunDockerCmd("inspect", projectName+"_web_1")
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.container-number": "1"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project": "compose-e2e-demo"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.oneoff": "False",`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.config-hash":`})
-		res.Assert(t, icmd.Expected{Out: fmt.Sprintf(`"com.docker.compose.project.config_files": "%s/fixtures/sentences/compose.yaml"`, wd)})
+		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project.config_files":`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.project.working_dir":`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.service": "web"`})
 		res.Assert(t, icmd.Expected{Out: `"com.docker.compose.version":`})
@@ -166,10 +166,10 @@ func TestDownComposefileInParentFolder(t *testing.T) {
 
 	c := NewParallelE2eCLI(t, binDir)
 
-	tmpFolder, err := os.MkdirTemp("fixtures/simple-composefile", "test-tmp")
-	projectName := strings.TrimPrefix(tmpFolder, "fixtures/simple-composefile/")
-	defer os.Remove(tmpFolder) //nolint: errcheck
+	tmpFolder, err := ioutil.TempDir("fixtures/simple-composefile", "test-tmp")
 	assert.NilError(t, err)
+	defer os.Remove(tmpFolder) //nolint: errcheck
+	projectName := filepath.Base(tmpFolder)
 
 	res := c.RunDockerCmd("compose", "--project-directory", tmpFolder, "up", "-d")
 	res.Assert(t, icmd.Expected{Err: "Started", ExitCode: 0})

--- a/local/e2e/compose/metrics_test.go
+++ b/local/e2e/compose/metrics_test.go
@@ -17,12 +17,8 @@
 package e2e
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
 	"runtime"
-	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -92,70 +88,4 @@ func TestComposeMetrics(t *testing.T) {
 			`{"command":"compose up","context":"moby","source":"cli","status":"failure-build"}`,
 		}, usage)
 	})
-}
-
-func TestComposeCancel(t *testing.T) {
-	c := NewParallelE2eCLI(t, binDir)
-	s := NewMetricsServer(c.MetricsSocket())
-	s.Start()
-	defer s.Stop()
-
-	started := false
-
-	for i := 0; i < 30; i++ {
-		c.RunDockerCmd("help", "ps")
-		if len(s.GetUsage()) > 0 {
-			started = true
-			fmt.Printf("    [%s] Server up in %d ms\n", t.Name(), i*100)
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	assert.Assert(t, started, "Metrics mock server not available after 3 secs")
-
-	t.Run("metrics on cancel Compose build", func(t *testing.T) {
-		s.ResetUsage()
-
-		c.RunDockerCmd("compose", "ls")
-		buildProjectPath := "../compose/fixtures/build-infinite/docker-compose.yml"
-
-		// require a separate groupID from the process running tests, in order to simulate ctrl+C from a terminal.
-		// sending kill signal
-		cmd, stdout, stderr, err := StartWithNewGroupID(c.NewDockerCmd("compose", "-f", buildProjectPath, "build", "--progress", "plain"))
-		assert.NilError(t, err)
-
-		c.WaitForCondition(func() (bool, string) {
-			out := stdout.String()
-			errors := stderr.String()
-			return strings.Contains(out, "RUN sleep infinity"), fmt.Sprintf("'RUN sleep infinity' not found in : \n%s\nStderr: \n%s\n", out, errors)
-		}, 30*time.Second, 1*time.Second)
-
-		err = syscall.Kill(-cmd.Process.Pid, syscall.SIGINT) // simulate Ctrl-C : send signal to processGroup, children will have same groupId by default
-
-		assert.NilError(t, err)
-		c.WaitForCondition(func() (bool, string) {
-			out := stdout.String()
-			errors := stderr.String()
-			return strings.Contains(out, "CANCELED"), fmt.Sprintf("'CANCELED' not found in : \n%s\nStderr: \n%s\n", out, errors)
-		}, 10*time.Second, 1*time.Second)
-
-		usage := s.GetUsage()
-		assert.DeepEqual(t, []string{
-			`{"command":"compose ls","context":"moby","source":"cli","status":"success"}`,
-			`{"command":"compose build","context":"moby","source":"cli","status":"canceled"}`,
-		}, usage)
-	})
-}
-
-func StartWithNewGroupID(command icmd.Cmd) (*exec.Cmd, *bytes.Buffer, *bytes.Buffer, error) {
-	cmd := exec.Command(command.Command[0], command.Command[1:]...)
-	cmd.Env = command.Env
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err := cmd.Start()
-	return cmd, &stdout, &stderr, err
 }


### PR DESCRIPTION
Signed-off-by: guillaume.tardif <guillaume.tardif@gmail.com>

**What I did**
Manually run compose tests on my win dev machine (with Docker Desktop), adapted a few path issues.
(not running in CI as GHA CI windows nodes are running a windows engine only
There's still one test `TestComposeCancel`  using signals, that needs to be isolated to not compile/run on windows

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
