### PR TITLE
Install compose cli plugin in addition to compose-cli binary with scripted install

### DIFF
--- a/scripts/install/install_linux.sh
+++ b/scripts/install/install_linux.sh
@@ -120,6 +120,7 @@ if [ $(is_new_cli "docker") -eq 1 ]; then
 		$sh_c "${download_cmd} ${download_dir}/docker-compose-cli.tar.gz ${DOWNLOAD_URL}"
 		$sh_c "tar xzf ${download_dir}/docker-compose-cli.tar.gz -C ${download_dir} --strip-components 1"
 		$sudo_sh_c "install -m 775 ${download_dir}/docker /usr/local/bin/docker"
+		$sh_c "mkdir -p ~/.docker/cli-plugins && cp ${download_dir}/docker-compose ~/.docker/cli-plugins/docker-compose"
 		exit 0
 	fi
 	echo "You already have the Docker Compose CLI installed, in a different location."
@@ -185,6 +186,8 @@ $sudo_sh_c "ln -s ${existing_cli_path} ${link_path}"
 
 # Install downloaded CLI
 $sudo_sh_c "install -m 775 ${download_dir}/docker /usr/local/bin/docker"
+# Install Compose CLI plugin
+$sh_c "mkdir -p ~/.docker/cli-plugins && cp ${download_dir}/docker-compose ~/.docker/cli-plugins/docker-compose"
 
 # Clear cache
 cleared_cache=1

--- a/scripts/install/test.Dockerfile
+++ b/scripts/install/test.Dockerfile
@@ -37,6 +37,7 @@ RUN sudo chmod +x /scripts/install_linux.sh
 ARG DOWNLOAD_URL=
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
+RUN sh -c "docker info || true" | grep "compose: Docker Compose (Docker Inc.,"
 
 FROM install AS upgrade
 
@@ -45,6 +46,7 @@ WORKDIR /home/newuser
 
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
+RUN sh -c "docker info || true" | grep "compose: Docker Compose (Docker Inc.,"
 
 # To run this test locally, start an HTTP server that serves the dist/ folder
 # then run a docker build passing the DOWNLOAD_URL as a build arg:


### PR DESCRIPTION

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
scripted linux install installs compose-cli binary + compose cli plugin

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
