### PR TITLE
On default context, "compose" is implemented by CLI Plugin

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -218,9 +218,13 @@ func main() {
 
 	root.AddCommand(
 		run.Command(ctype),
-		compose.RootCommand(ctype, service.ComposeService()),
 		volume.Command(ctype),
 	)
+
+	if ctype != store.DefaultContextType {
+		// On default context, "compose" is implemented by CLI Plugin
+		root.AddCommand(compose.RootCommand(ctype, service.ComposeService()))
+	}
 
 	if err = root.ExecuteContext(ctx); err != nil {
 		handleError(ctx, err, ctype, currentContext, cc, root)


### PR DESCRIPTION
**What I did**
removed "compose" command for default context type, being implemented as a CLI plugin

