### PR TITLE
load sibling compose-override file when auto-discovered from parent dir

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -112,7 +112,7 @@ func (o *projectOptions) toProjectName() (string, error) {
 func (o *projectOptions) toProject(services []string, po ...cli.ProjectOptionsFn) (*types.Project, error) {
 	options, err := o.toProjectOptions(po...)
 	if err != nil {
-		return nil, err
+		return nil, metrics.WrapComposeError(err)
 	}
 
 	project, err := cli.ProjectFromOptions(options)
@@ -143,6 +143,7 @@ func (o *projectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 			cli.WithDotEnv,
 			cli.WithOsEnv,
 			cli.WithWorkingDirectory(o.ProjectDir),
+			cli.WithDefaultConfigPath,
 			cli.WithName(o.ProjectName))...)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v1.0.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
-	github.com/compose-spec/compose-go v0.0.0-20210422124345-d4bf0e1bfea5
+	github.com/compose-spec/compose-go v0.0.0-20210426122519-7739b749b02f
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20210422124345-d4bf0e1bfea5 h1:uR5dDxz7FboGxh2YjlMJJBOc7RPl87rbV80VV7WJ9N0=
-github.com/compose-spec/compose-go v0.0.0-20210422124345-d4bf0e1bfea5/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
+github.com/compose-spec/compose-go v0.0.0-20210426122519-7739b749b02f h1:t52ow0GxFOfxOwtEEiZKOd5B3yrdz2VuSuP/4xMb06k=
+github.com/compose-spec/compose-go v0.0.0-20210426122519-7739b749b02f/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=


### PR DESCRIPTION
**What I did**
Added support for docker-override files as main compose file sibling when loaded by auto-discovery

**Related issue**
close https://github.com/docker/compose-cli/issues/1546
relies on https://github.com/compose-spec/compose-go/pull/131

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
