### PR TITLE
Update readme and clarify relation to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,36 @@
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Continuous%20integration/badge.svg)](https://github.com/docker/compose-cli/actions)
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Windows%20CI/badge.svg)](https://github.com/docker/compose-cli/actions)
 
-This CLI tool makes it easy to run Docker containers and Docker Compose applications in the cloud using either Amazon
-Elastic Container Service
+This Compose CLI tool makes it easy to run Docker containers and Docker Compose applications:
+* locally as a command in the docker CLI, using `docker compose ...` comands.
+* in the cloud using either Amazon Elastic Container Service
 ([ECS](https://aws.amazon.com/ecs))
 or Microsoft Azure Container Instances
 ([ACI](https://azure.microsoft.com/services/container-instances))
 using the Docker commands you already know.
 
-To get started, all you need is:
+## Local Docker Compose
 
-* An [AWS](https://aws.amazon.com) or [Azure](https://azure.microsoft.com)
-  account
+The `docker compose` local command is meant to be the next major version for docker-compose, and it supports the same commands and flags, in order to be used as a drop-in replacement.
+[Here](https://github.com/docker/compose-cli/issues/1283) is a checklist of docker-compose commands and flags that are implemented in `docker compose`.
+
+This `docker compose` local command :
+* has a better integration with the rest of the docker ecosystem (being written in go, it's easier to share functionality with the Docker CLI and other Docker libraries)
+* is quicker and uses more parallelism to run multiple tasks in parallel. It also uses buildkit by default
+* includes additional commands, like `docker compose ls` to list current compose projects
+
+## Getting started
+
+To get started with Compose CLI, all you need is:
+
 * Windows: The Stable or Edge release of
   [Docker Desktop](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 * macOS: The Stable or Edge release of
   [Docker Desktop](https://hub.docker.com/editions/community/docker-ce-desktop-mac)
 * Linux:
   [Install script](INSTALL.md)
+* An [AWS](https://aws.amazon.com) or [Azure](https://azure.microsoft.com)
+  account in order to use the Compose Cloud integration
 
 Please create [issues](https://github.com/docker/compose-cli/issues) to leave feedback.
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

* clarify relation to `docker-compose`
* link to #1283 command flag list

**Related issue**
Fixes #1473 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
