### PR TITLE
Separate compose CLI plugin version from Cloud integration version

### DIFF
--- a/builder.Makefile
+++ b/builder.Makefile
@@ -28,7 +28,7 @@ STATIC_FLAGS=CGO_ENABLED=0
 
 GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
 
-LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG}"
+LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG} -X $(PKG_NAME)/internal.ComposePluginVersion=2.0.0-beta.1"
 GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 
 BINARY?=bin/docker

--- a/cli/cmd/compose/version.go
+++ b/cli/cmd/compose/version.go
@@ -34,9 +34,10 @@ type versionOptions struct {
 func versionCommand() *cobra.Command {
 	opts := versionOptions{}
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Show the Docker Compose version information",
-		Args:  cobra.MaximumNArgs(0),
+		Use:    "version",
+		Short:  "Show the Docker Compose version information",
+		Args:   cobra.MaximumNArgs(0),
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			runVersion(opts)
 			return nil
@@ -51,7 +52,7 @@ func versionCommand() *cobra.Command {
 }
 
 func runVersion(opts versionOptions) {
-	displayedVersion := strings.TrimPrefix(internal.Version, "v")
+	displayedVersion := strings.TrimPrefix(internal.ComposePluginVersion, "v")
 	if opts.short {
 		fmt.Println(displayedVersion)
 		return

--- a/internal/variables.go
+++ b/internal/variables.go
@@ -26,4 +26,6 @@ const (
 var (
 	// Version is the version of the CLI injected in compilation time
 	Version = "dev"
+	// ComposePluginVersion is the version of the compose cli plugin, injected in compilation time
+	ComposePluginVersion = "dev"
 )

--- a/main.go
+++ b/main.go
@@ -61,6 +61,6 @@ func main() {
 		manager.Metadata{
 			SchemaVersion: "0.1.0",
 			Vendor:        "Docker Inc.",
-			Version:       strings.TrimPrefix(internal.Version, "v"),
+			Version:       strings.TrimPrefix(internal.ComposePluginVersion, "v"),
 		})
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Separate compose CLI plugin version

**Related issue**
https://github.com/docker/dev-tooling-team/issues/285

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
