### PR TITLE
Add rm --all flag for backward compatibility (deprecated - no effect)

### DIFF
--- a/cli/cmd/compose/remove.go
+++ b/cli/cmd/compose/remove.go
@@ -56,6 +56,9 @@ Any data which is not in a volume will be lost.`,
 	f.BoolVarP(&opts.force, "force", "f", false, "Don't ask to confirm removal")
 	f.BoolVarP(&opts.stop, "stop", "s", false, "Stop the containers, if required, before removing")
 	f.BoolVarP(&opts.volumes, "volumes", "v", false, "Remove any anonymous volumes attached to containers")
+	f.BoolP("all", "a", false, "Deprecated - no effect")
+	f.MarkHidden("all") //nolint:errcheck
+
 	return cmd
 }
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Add `rm --all` flag (deprecated in docker-compose, just for backward compat ; flag is hidden).

**Related issue**
https://github.com/docker/compose-cli/issues/1283

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
