### PR TITLE
resolve build args without value from environment

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -83,7 +83,7 @@ type BuildOptions struct {
 	// Progress set type of progress output ("auto", "plain", "tty")
 	Progress string
 	// Args set build-time args
-	Args types.Mapping
+	Args types.MappingWithEquals
 	// NoCache disables cache use
 	NoCache bool
 	// Quiet make the build process not output to the console

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -89,7 +89,7 @@ func runBuild(ctx context.Context, backend compose.Service, opts buildOptions, s
 		return "", backend.Build(ctx, project, compose.BuildOptions{
 			Pull:     opts.pull,
 			Progress: opts.progress,
-			Args:     types.NewMapping(opts.args),
+			Args:     types.NewMappingWithEquals(opts.args),
 			NoCache:  opts.noCache,
 			Quiet:    opts.quiet,
 		})

--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -42,6 +42,14 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 	opts := map[string]build.Options{}
 	imagesToBuild := []string{}
 
+	args := map[string]string{}
+	for k, v := range options.Args.Resolve(func(s string) (string, bool) {
+		s, ok := project.Environment[s]
+		return s, ok
+	}).RemoveEmpty() {
+		args[k] = *v
+	}
+
 	for _, service := range project.Services {
 		if service.Build != nil {
 			imageName := getImageName(service, project.Name)
@@ -51,7 +59,7 @@ func (s *composeService) Build(ctx context.Context, project *types.Project, opti
 				return err
 			}
 			buildOptions.Pull = options.Pull
-			buildOptions.BuildArgs = options.Args
+			buildOptions.BuildArgs = args
 			buildOptions.NoCache = options.NoCache
 			opts[imageName] = buildOptions
 			buildOptions.CacheFrom, err = build.ParseCacheEntry(service.Build.CacheFrom)

--- a/local/e2e/compose/compose_build_test.go
+++ b/local/e2e/compose/compose_build_test.go
@@ -54,6 +54,20 @@ func TestLocalComposeBuild(t *testing.T) {
 		res.Assert(t, icmd.Expected{Out: `"FOO": "BAR"`})
 	})
 
+	t.Run("build with build-arg set by env", func(t *testing.T) {
+		// ensure local test run does not reuse previously build image
+		c.RunDockerOrExitError("rmi", "build-test_nginx")
+		c.RunDockerOrExitError("rmi", "custom-nginx")
+
+		icmd.RunCmd(c.NewDockerCmd("compose", "--project-directory", "fixtures/build-test", "build", "--build-arg", "FOO"),
+			func(cmd *icmd.Cmd) {
+				cmd.Env = append(cmd.Env, "FOO=BAR")
+			})
+
+		res := c.RunDockerCmd("image", "inspect", "build-test_nginx")
+		res.Assert(t, icmd.Expected{Out: `"FOO": "BAR"`})
+	})
+
 	t.Run("build as part of up", func(t *testing.T) {
 		c.RunDockerOrExitError("rmi", "build-test_nginx")
 		c.RunDockerOrExitError("rmi", "custom-nginx")


### PR DESCRIPTION
**What I did**
Resolve build args without value (`--build-arg FOO`) from environment

**Related issue**
close https://github.com/docker/compose-cli/issues/1602
