### PR TITLE
cli.compose: Add missing \n for version

### DIFF
--- a/cli/cmd/compose/version.go
+++ b/cli/cmd/compose/version.go
@@ -61,5 +61,5 @@ func runVersion(opts versionOptions) {
 		fmt.Printf(`{"version":"%s"}\n`, displayedVersion)
 		return
 	}
-	fmt.Printf(`Docker Compose version %s`, displayedVersion)
+	fmt.Printf("Docker Compose version %s\n", displayedVersion)
 }


### PR DESCRIPTION
**What I did**
Add missing `\n` to version output
