### PR TITLE
use highest priority network to declare network aliasses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v1.0.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
-	github.com/compose-spec/compose-go v0.0.0-20210427143821-6d1c5982084f
+	github.com/compose-spec/compose-go v0.0.0-20210503135708-e8ee37c1478c
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20210427143821-6d1c5982084f h1:EJu2tLPcjRTAdFDJZOQj57ehBo+m71Iz6sUf1Q8/BOY=
-github.com/compose-spec/compose-go v0.0.0-20210427143821-6d1c5982084f/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
+github.com/compose-spec/compose-go v0.0.0-20210503135708-e8ee37c1478c h1:XDrhClIbE/zCDU4KWCYSYmceYZj5EBn3DMhQ7hVvyUs=
+github.com/compose-spec/compose-go v0.0.0-20210503135708-e8ee37c1478c/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=

--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -318,8 +318,9 @@ func (s *composeService) createMobyContainer(ctx context.Context, project *types
 		Labels: containerConfig.Labels,
 	}
 	cState.Add(createdContainer)
-	for netName, cfg := range service.Networks {
+	for _, netName := range service.NetworksByPriority() {
 		netwrk := project.Networks[netName]
+		cfg := service.Networks[netName]
 		aliases := []string{getContainerName(project.Name, service, number)}
 		if useNetworkAliases {
 			aliases = append(aliases, service.Name)

--- a/local/e2e/compose/fixtures/network-alias/compose.yaml
+++ b/local/e2e/compose/fixtures/network-alias/compose.yaml
@@ -1,0 +1,15 @@
+services:
+
+  container1:
+    image: nginx
+
+  container2:
+    image: nginx
+    networks:
+      foo:
+        aliases:
+          - alias-of-container2
+
+networks:
+  foo:
+    name: bar

--- a/local/e2e/compose/networks_test.go
+++ b/local/e2e/compose/networks_test.go
@@ -70,3 +70,22 @@ func TestNetworks(t *testing.T) {
 		assert.Assert(t, !strings.Contains(res.Combined(), "microservices"), res.Combined())
 	})
 }
+
+func TestNetworkAliasses(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	const projectName = "network_alias_e2e"
+
+	t.Run("up", func(t *testing.T) {
+		c.RunDockerCmd("compose", "-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName, "up", "-d")
+	})
+
+	t.Run("curl", func(t *testing.T) {
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/network-alias/compose.yaml", "--project-name", projectName, "exec", "-T", "container1", "curl", "http://alias-of-container2/")
+		assert.Assert(t, !strings.Contains(res.Stdout(), "Welcome to nginx!"), res.Stdout())
+	})
+
+	t.Run("down", func(t *testing.T) {
+		_ = c.RunDockerCmd("compose", "--project-name", projectName, "down")
+	})
+}


### PR DESCRIPTION
**What I did**
Fixed networkConfig computation to align with docker-compose
https://github.com/docker/compose/blob/aa45dedb3d5b18df35c5a9c9d54c06cee0cfafe0/compose/service.py#L816

**Related issue**
see https://github.com/docker/compose-cli/issues/1620

note: full-fix will require updates in compose-go to introduce service.networks.priority

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
