### PR TITLE
Display PATH when not finding com.docker.cli, to help debugging

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -89,6 +89,7 @@ func RunDocker(childExit chan bool, args ...string) error {
 	execBinary, err := resolvepath.LookPath(ComDockerCli)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Current PATH : "+os.Getenv("PATH"))
 		os.Exit(1)
 	}
 	cmd := exec.Command(execBinary, args...)


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
When not finding com.docker.cli in the PATH, display current path on stderr to help debugging

**Related issue**
This adds debug info to help fixing #754 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
