### PR TITLE
don't invoke r.Close on error as r == nil

### DIFF
--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -51,11 +51,11 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 				Tail:       options.Tail,
 				Timestamps: options.Timestamps,
 			})
-			defer r.Close() // nolint errcheck
-
 			if err != nil {
 				return err
 			}
+			defer r.Close() // nolint errcheck
+
 			name := getContainerNameWithoutProject(c)
 			w := utils.GetWriter(name, service, func(event compose.ContainerEvent) {
 				consumer.Log(name, service, event.Line)


### PR DESCRIPTION
**What I did**
Prevent panic calling r.Close as r is nil

**Related issue**
https://github.com/docker/compose-cli/issues/1629


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
