### PR TITLE
fix detecting active profiles implied by selected services

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -120,11 +120,13 @@ func (o *projectOptions) toProject(services []string, po ...cli.ProjectOptionsFn
 		return nil, metrics.WrapComposeError(err)
 	}
 
-	s, err := project.GetServices(services...)
-	if err != nil {
-		return nil, err
+	if len(services) > 0 {
+		s, err := project.GetServices(services...)
+		if err != nil {
+			return nil, err
+		}
+		o.Profiles = append(o.Profiles, s.GetProfiles()...)
 	}
-	o.Profiles = append(o.Profiles, s.GetProfiles()...)
 
 	if profiles, ok := options.Environment["COMPOSE_PROFILES"]; ok {
 		o.Profiles = append(o.Profiles, strings.Split(profiles, ",")...)


### PR DESCRIPTION
**What I did**
Only infer implicit profiles to enable when user pass a list of target services, otherwise all service get enabled.

**Related issue**
close https://github.com/docker/compose-cli/issues/1636