### PR TITLE
Fix building compose files with absolute build context / Dockerfile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/awslabs/goformation/v4 v4.15.6
 	github.com/buger/goterm v1.0.0
 	github.com/cnabio/cnab-to-oci v0.3.1-beta1
-	github.com/compose-spec/compose-go v0.0.0-20210503135708-e8ee37c1478c
+	github.com/compose-spec/compose-go v0.0.0-20210505145624-6dcd3d18b38b
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.3
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/compose-spec/compose-go v0.0.0-20210503135708-e8ee37c1478c h1:XDrhClIbE/zCDU4KWCYSYmceYZj5EBn3DMhQ7hVvyUs=
-github.com/compose-spec/compose-go v0.0.0-20210503135708-e8ee37c1478c/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
+github.com/compose-spec/compose-go v0.0.0-20210505145624-6dcd3d18b38b h1:0MPA42m4n8VGsCld8hWmeRYeblPrgRDbiXPvRnjWoLY=
+github.com/compose-spec/compose-go v0.0.0-20210505145624-6dcd3d18b38b/go.mod h1:6eIT9U2OgdHmkRD6szmqatCrWWEEUSwl/j2iJYH4jLo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=

--- a/local/e2e/compose/compose_build_test.go
+++ b/local/e2e/compose/compose_build_test.go
@@ -17,7 +17,10 @@
 package e2e
 
 import (
+	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -104,5 +107,43 @@ func TestLocalComposeBuild(t *testing.T) {
 		c.RunDockerCmd("compose", "--project-directory", "fixtures/build-test", "down")
 		c.RunDockerCmd("rmi", "build-test_nginx")
 		c.RunDockerCmd("rmi", "custom-nginx")
+	})
+}
+
+func TestLocalComposeBuildStaticDockerfilePath(t *testing.T) {
+	c := NewParallelE2eCLI(t, binDir)
+
+	t.Run("build ddev-style compose files", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "ddev")
+		assert.NilError(t, err)
+		defer os.RemoveAll(dir) //nolint:errcheck
+
+		assert.NilError(t, ioutil.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(`services:
+  service1:
+    build:
+      context: `+dir+`/service1
+      dockerfile: Dockerfile
+  service2:
+    build:
+      context: `+dir+`/service2
+      dockerfile: `+dir+`/service2/Dockerfile
+  `), 0644))
+
+		assert.NilError(t, os.Mkdir(filepath.Join(dir, "service1"), 0700))
+		assert.NilError(t, ioutil.WriteFile(filepath.Join(dir, "service1", "Dockerfile"), []byte(`FROM alpine
+		RUN echo "hello"
+		`), 0644))
+
+		assert.NilError(t, os.Mkdir(filepath.Join(dir, "service2"), 0700))
+		assert.NilError(t, ioutil.WriteFile(filepath.Join(dir, "service2", "Dockerfile"), []byte(`FROM alpine
+		RUN echo "world"
+		`), 0644))
+
+		res := c.RunDockerCmd("compose", "-f", filepath.Join(dir, "docker-compose.yml"), "build")
+
+		res.Assert(t, icmd.Expected{Out: `RUN echo "hello"`})
+		res.Assert(t, icmd.Expected{Out: `RUN echo "world"`})
+
+		c.RunDockerCmd("compose", "-f", filepath.Join(dir, "docker-compose.yml"), "down", "--rmi", "all")
 	})
 }


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Allow for absolute build context path / Dockerfile path. These path are encountered using ddev, that generates composefiles.

**Related issue**
Fixes https://github.com/docker/dev-tooling-team/issues/313

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
