### PR TITLE
Bump compose beta version

### DIFF
--- a/builder.Makefile
+++ b/builder.Makefile
@@ -28,7 +28,7 @@ STATIC_FLAGS=CGO_ENABLED=0
 
 GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
 
-LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG} -X $(PKG_NAME)/internal.ComposePluginVersion=2.0.0-beta.1"
+LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG} -X $(PKG_NAME)/internal.ComposePluginVersion=2.0.0-beta.2"
 GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 
 BINARY?=bin/docker


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
2.0.0-beta.1 => 2.0.0-beta.2

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
