### PR TITLE
Use location specified by user if provided, and do not override with group location

### DIFF
--- a/aci/context.go
+++ b/aci/context.go
@@ -99,7 +99,10 @@ func (helper contextCreateACIHelper) createContextData(ctx context.Context, opts
 		}
 	}
 
-	location := *group.Location
+	location := opts.Location
+	if opts.Location == "" {
+		location = *group.Location
+	}
 
 	description := fmt.Sprintf("%s@%s", *group.Name, location)
 	if opts.Description != "" {

--- a/cli/cmd/context/create_aci.go
+++ b/cli/cmd/context/create_aci.go
@@ -49,8 +49,8 @@ func createAciCommand() *cobra.Command {
 	}
 
 	addDescriptionFlag(cmd, &opts.Description)
-	cmd.Flags().StringVar(&opts.Location, "location", "eastus", "Location")
-	cmd.Flags().StringVar(&opts.SubscriptionID, "subscription-id", "", "Location")
+	cmd.Flags().StringVar(&opts.Location, "location", "", "Location")
+	cmd.Flags().StringVar(&opts.SubscriptionID, "subscription-id", "", "Subscription id")
 	cmd.Flags().StringVar(&opts.ResourceGroup, "resource-group", "", "Resource group")
 
 	return cmd


### PR DESCRIPTION
ACI allow deploying in any location regardless of resource group

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Do not always use resource group location, keep user location option if provided

**Related issue**
Fixes #1589 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
/test-aci

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://www.pngkit.com/png/detail/127-1279908_share-this-image-steampunk-octopus-tattoo.png)
