### PR TITLE
Avoid using for variable in go func, as this creates race conditions

### DIFF
--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -147,6 +147,7 @@ func getContainerProgressName(container moby.Container) string {
 func (s *composeService) waitDependencies(ctx context.Context, project *types.Project, service types.ServiceConfig) error {
 	eg, _ := errgroup.WithContext(ctx)
 	for dep, config := range service.DependsOn {
+		dep, config := dep, config
 		eg.Go(func() error {
 			ticker := time.NewTicker(500 * time.Millisecond)
 			defer ticker.Stop()


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**
Update VSCode and saw this nice warning for a quite common race issue : 

![Screenshot 2021-05-06 at 09 28 58](https://user-images.githubusercontent.com/437958/117260676-9c212780-ae4f-11eb-9ddb-2fe0d97aef46.png)


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
