### PR TITLE
compose ps list stopped containers. -a is used to include oneoff

### DIFF
--- a/local/compose/ps.go
+++ b/local/compose/ps.go
@@ -26,7 +26,11 @@ import (
 )
 
 func (s *composeService) Ps(ctx context.Context, projectName string, options compose.PsOptions) ([]compose.ContainerSummary, error) {
-	containers, err := s.getContainers(ctx, projectName, oneOffInclude, options.All, options.Services...)
+	oneOff := oneOffExclude
+	if options.All {
+		oneOff = oneOffInclude
+	}
+	containers, err := s.getContainers(ctx, projectName, oneOff, true, options.Services...)
 	if err != nil {
 		return nil, err
 	}

--- a/local/compose/ps_test.go
+++ b/local/compose/ps_test.go
@@ -37,7 +37,9 @@ func TestPs(t *testing.T) {
 	tested.apiClient = api
 
 	ctx := context.Background()
-	listOpts := apitypes.ContainerListOptions{Filters: filters.NewArgs(projectFilter(testProject)), All: false}
+	args := filters.NewArgs(projectFilter(testProject))
+	args.Add("label", "com.docker.compose.oneoff=False")
+	listOpts := apitypes.ContainerListOptions{Filters: args, All: true}
 	c1, inspect1 := containerDetails("service1", "123", "Running", "healthy")
 	c2, inspect2 := containerDetails("service1", "456", "Running", "")
 	c2.Ports = []apitypes.Port{{PublicPort: 80, PrivatePort: 90, IP: "localhost"}}


### PR DESCRIPTION
**What I did**
Fix behaviour of `compose ps -a` flag, so that `ps` always list stopped services, and `-a` is used to also include one_off containers (created by run command)

**Related issue**
close https://github.com/docker/compose-cli/issues/1552