### PR TITLE
support mulitple bindings for same target port

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -532,7 +532,7 @@ func buildContainerPortBindingOptions(s types.ServiceConfig) nat.PortMap {
 	bindings := nat.PortMap{}
 	for _, port := range s.Ports {
 		p := nat.Port(fmt.Sprintf("%d/%s", port.Target, port.Protocol))
-		bind := []nat.PortBinding{}
+		bind := bindings[p]
 		binding := nat.PortBinding{
 			HostIP: port.HostIP,
 		}


### PR DESCRIPTION
**What I did**
Allow multiple host ports to be bound to a single container port

**Related issue**
close https://github.com/docker/compose-cli/issues/1655
