### PR TITLE
Support Azure login page on WSL 1

### DIFF
--- a/aci/login/helper.go
+++ b/aci/login/helper.go
@@ -122,7 +122,7 @@ func isWsl() bool {
 		return false
 	}
 
-	return strings.Contains(string(b), "microsoft")
+	return strings.Contains(strings.ToLower(string(b)), "microsoft")
 }
 
 func randomString(prefix string, length int) string {


### PR DESCRIPTION
When running `docker login azure` on WSL 1, the browser login prompt is not executed, reverting back to the copy-code-from-console-to-this-URL authentication flow. WSL 2 invocations of the same binary work as expected.

The format reported by `/proc/version` differs between versions of WSL; both report the text "Microsoft", albeit in different cases.

WSL 1 Example:
_`Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #488-Microsoft Mon Sep 01 13:43:00 PST 2020`_

WSL 2 Example:
_`Linux version 4.19.104-microsoft-standard (oe-user@oe-host) (gcc version 8.2.0 (GCC)) #1 SMP Wed Feb 19 06:37:35 UTC 2020`_

Making the `isWsl` check for "microsoft" case-insensitive allows it to work on both WSL versions.