### PR TITLE
ps shows healthcheck only for running container

### DIFF
--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -284,6 +284,7 @@ type ContainerSummary struct {
 	Service    string
 	State      string
 	Health     string
+	ExitCode   int
 	Publishers []PortPublisher
 }
 

--- a/cli/cmd/compose/ps.go
+++ b/cli/cmd/compose/ps.go
@@ -103,8 +103,10 @@ func runPs(ctx context.Context, backend compose.Service, services []string, opts
 					}
 				}
 				status := container.State
-				if container.Health != "" {
+				if status == "running" && container.Health != "" {
 					status = fmt.Sprintf("%s (%s)", container.State, container.Health)
+				} else if status == "exited" || status == "dead" {
+					status = fmt.Sprintf("%s (%d)", container.State, container.ExitCode)
 				}
 				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", container.Name, container.Service, status, strings.Join(ports, ", "))
 			}


### PR DESCRIPTION
**What I did**
updated ps output so
- it does not show healthcheck status but for running container
- it includes exit code for exited containers
- it sort ports for predictable output

**Related issue**
close https://github.com/docker/compose-cli/issues/1671
close https://github.com/docker/compose-cli/issues/1672

