### PR TITLE
named pipe need to be mounted using the bind API

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -604,7 +604,7 @@ MOUNTS:
 	for _, m := range mountOptions {
 		volumeMounts[m.Target] = struct{}{}
 		// `Bind` API is used when host path need to be created if missing, `Mount` is preferred otherwise
-		if m.Type == mount.TypeBind {
+		if m.Type == mount.TypeBind || m.Type == mount.TypeNamedPipe {
 			for _, v := range service.Volumes {
 				if v.Target == m.Target && v.Bind != nil && v.Bind.CreateHostPath {
 					mode := "rw"


### PR DESCRIPTION
**What I did**
Used the `Bind` API for named pipes mount, just like we do for bind mounts

**Related issue**
close https://github.com/docker/compose-cli/issues/1664

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
