### PR TITLE
only start current project services

### DIFF
--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -254,7 +254,9 @@ func runCreateStart(ctx context.Context, backend compose.Service, opts upOptions
 			return "", err
 		}
 		if opts.Detach {
-			err = backend.Start(ctx, project, compose.StartOptions{})
+			err = backend.Start(ctx, project, compose.StartOptions{
+				Services: services,
+			})
 		}
 		return "", err
 	})

--- a/local/compose/attach.go
+++ b/local/compose/attach.go
@@ -33,6 +33,10 @@ import (
 )
 
 func (s *composeService) attach(ctx context.Context, project *types.Project, listener compose.ContainerEventListener, selectedServices []string) (Containers, error) {
+	if len(selectedServices) == 0 {
+		selectedServices = project.ServiceNames()
+	}
+
 	containers, err := s.getContainers(ctx, project.Name, oneOffExclude, true, selectedServices...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What I did**
When I remove a service from my compose file, and run `compose up` it still try to attach to a previously defined service:

```
Attaching to nginx_1, foo_1
no such service: nginx
```

This is due to the "create and start" logic, as the later will list containers with project label, and find stopped ones from a previous run, without a matching service definition
