### PR TITLE
Bump linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosimple
     - govet
     - ineffassign

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #   limitations under the License.
 
 ARG GO_VERSION=1.16-alpine
-ARG GOLANGCI_LINT_VERSION=v1.39.0-alpine
+ARG GOLANGCI_LINT_VERSION=v1.40.1-alpine
 ARG PROTOC_GEN_GO_VERSION=v1.4.3
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk add --no-cache -vv \
     protobuf-dev
 COPY go.* .
 RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
 FROM base AS make-protos
@@ -58,6 +59,7 @@ RUN go get github.com/docker/import-restrictions
 FROM import-restrictions-base AS import-restrictions
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
     make -f builder.Makefile import-restrictions
 
 FROM base AS make-cli
@@ -113,6 +115,7 @@ RUN --mount=target=. \
 FROM base AS make-go-mod-tidy
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
     go mod tidy
 
 FROM scratch AS go-mod-tidy

--- a/aci/convert/convert.go
+++ b/aci/convert/convert.go
@@ -347,7 +347,7 @@ func ContainerGroupToContainer(containerID string, cg containerinstance.Containe
 	status := GetStatus(cc, cg)
 	platform := string(cg.OsType)
 
-	var envVars map[string]string = nil
+	var envVars map[string]string
 	if cc.EnvironmentVariables != nil && len(*cc.EnvironmentVariables) != 0 {
 		envVars = map[string]string{}
 		for _, envVar := range *cc.EnvironmentVariables {

--- a/aci/convert/convert_test.go
+++ b/aci/convert/convert_test.go
@@ -570,7 +570,7 @@ func TestConvertContainerGroupStatus(t *testing.T) {
 }
 
 func container(status *string) containerinstance.Container {
-	var state *containerinstance.ContainerState = nil
+	var state *containerinstance.ContainerState
 	if status != nil {
 		state = &containerinstance.ContainerState{
 			State: status,
@@ -586,7 +586,7 @@ func container(status *string) containerinstance.Container {
 }
 
 func group(status *string) containerinstance.ContainerGroup {
-	var view *containerinstance.ContainerGroupPropertiesInstanceView = nil
+	var view *containerinstance.ContainerGroupPropertiesInstanceView
 	if status != nil {
 		view = &containerinstance.ContainerGroupPropertiesInstanceView{
 			State: status,

--- a/aci/convert/ports.go
+++ b/aci/convert/ports.go
@@ -58,7 +58,7 @@ func convertPortsToAci(service serviceConfigAciHelper) ([]containerinstance.Cont
 			Protocol: groupProtocol,
 		})
 	}
-	var dnsLabelName *string = nil
+	var dnsLabelName *string
 	if service.DomainName != "" {
 		dnsLabelName = &service.DomainName
 	}

--- a/aci/convert/registry_credentials.go
+++ b/aci/convert/registry_credentials.go
@@ -70,7 +70,7 @@ func getRegistryCredentials(project compose.Project, helper registryHelper) ([]c
 		return nil, err
 	}
 
-	var cloudEnvironment *login.CloudEnvironment = nil
+	var cloudEnvironment *login.CloudEnvironment
 	if ce, err := loginService.GetCloudEnvironment(); err != nil {
 		cloudEnvironment = &ce
 	}

--- a/aci/e2e/aci_secrets_resources/web/main.go
+++ b/aci/e2e/aci_secrets_resources/web/main.go
@@ -42,7 +42,7 @@ func main() {
 	}
 }
 
-var healthy bool = true
+var healthy = true
 
 func fail(w http.ResponseWriter, req *http.Request) {
 	healthy = false

--- a/aci/e2e/e2e-aci_test.go
+++ b/aci/e2e/e2e-aci_test.go
@@ -385,7 +385,7 @@ func TestContainerRunAttached(t *testing.T) {
 
 	// Used in subtests
 	var (
-		container         string = "test-container"
+		container         = "test-container"
 		endpoint          string
 		followLogsProcess *icmd.Result
 	)

--- a/aci/login/login_test.go
+++ b/aci/login/login_test.go
@@ -459,7 +459,7 @@ func TestNonstandardCloudEnvironment(t *testing.T) {
 		},
 		"resourceManager": "https://management.docker.com/"
 	}]`)
-	var metadataReqCount int32 = 0
+	var metadataReqCount int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write(dockerCloudMetadata)
 		assert.NilError(t, err)

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -220,8 +220,5 @@ func startDependencies(ctx context.Context, backend compose.Service, project typ
 	if err := backend.Create(ctx, &project, compose.CreateOptions{}); err != nil {
 		return err
 	}
-	if err := backend.Start(ctx, &project, compose.StartOptions{}); err != nil {
-		return err
-	}
-	return nil
+	return backend.Start(ctx, &project, compose.StartOptions{})
 }

--- a/cli/formatter/colors.go
+++ b/cli/formatter/colors.go
@@ -86,7 +86,7 @@ func makeColorFunc(code string) colorFunc {
 	}
 }
 
-var nextColor func() colorFunc = rainbowColor
+var nextColor = rainbowColor
 
 func rainbowColor() colorFunc {
 	return <-loop

--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -116,7 +116,7 @@ func (kc *KubeClient) GetLogs(ctx context.Context, projectName string, consumer 
 
 // WaitForPodState blocks until pods reach desired state
 func (kc KubeClient) WaitForPodState(ctx context.Context, opts WaitForStatusOptions) error {
-	var timeout time.Duration = time.Minute
+	var timeout = time.Minute
 	if opts.Timeout != nil {
 		timeout = *opts.Timeout
 	}

--- a/local/volumes.go
+++ b/local/volumes.go
@@ -63,10 +63,7 @@ func (vs *volumeService) Create(ctx context.Context, name string, options interf
 }
 
 func (vs *volumeService) Delete(ctx context.Context, volumeID string, options interface{}) error {
-	if err := vs.apiClient.VolumeRemove(ctx, volumeID, false); err != nil {
-		return err
-	}
-	return nil
+	return vs.apiClient.VolumeRemove(ctx, volumeID, false)
 }
 
 func (vs *volumeService) Inspect(ctx context.Context, volumeID string) (volumes.Volume, error) {


### PR DESCRIPTION
**What I did**
* Mounted the Go cache wherever we mount the module cache
* Bumped golangci-lint 
* Replaced golint with revive based on prompt that golint is deprecated
* Fixed linting errors
