### PR TITLE
validate and pre-process flags in PreRun

### DIFF
--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -46,7 +46,7 @@ func buildCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build [SERVICE...]",
 		Short: "Build or rebuild services",
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.memory != "" {
 				fmt.Println("WARNING --memory is ignored as not supported in buildkit.")
 			}
@@ -57,6 +57,9 @@ func buildCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 				}
 				os.Stdout = devnull
 			}
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runBuild(ctx, backend, opts, args)
 		}),
 	}

--- a/cli/cmd/compose/convert.go
+++ b/cli/cmd/compose/convert.go
@@ -58,7 +58,7 @@ func convertCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Aliases: []string{"config"},
 		Use:     "convert SERVICES",
 		Short:   "Converts the compose file to platform's canonical format",
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.quiet {
 				devnull, err := os.Open(os.DevNull)
 				if err != nil {
@@ -66,6 +66,9 @@ func convertCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 				}
 				os.Stdout = devnull
 			}
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.services {
 				return runServices(opts)
 			}

--- a/cli/cmd/compose/cp.go
+++ b/cli/cmd/compose/cp.go
@@ -46,14 +46,16 @@ func copyCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	docker compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH`,
 		Short: "Copy files/folders between a service container and the local filesystem",
 		Args:  cli.ExactArgs(2),
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if args[0] == "" {
 				return errors.New("source can not be empty")
 			}
 			if args[1] == "" {
 				return errors.New("destination can not be empty")
 			}
-
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			opts.source = args[0]
 			opts.destination = args[1]
 			return runCopy(ctx, backend, opts)

--- a/cli/cmd/compose/create.go
+++ b/cli/cmd/compose/create.go
@@ -38,13 +38,16 @@ func createCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [SERVICE...]",
 		Short: "Creates containers for a service.",
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.Build && opts.noBuild {
 				return fmt.Errorf("--build and --no-build are incompatible")
 			}
 			if opts.forceRecreate && opts.noRecreate {
 				return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
 			}
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runCreateStart(ctx, backend, upOptions{
 				composeOptions: &composeOptions{
 					projectOptions: p,

--- a/cli/cmd/compose/down.go
+++ b/cli/cmd/compose/down.go
@@ -48,12 +48,15 @@ func downCommand(p *projectOptions, contextType string, backend compose.Service)
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.timeChanged = cmd.Flags().Changed("timeout")
 		},
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.images != "" {
 				if opts.images != "all" && opts.images != "local" {
 					return fmt.Errorf("invalid value for --rmi: %q", opts.images)
 				}
 			}
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runDown(ctx, backend, opts)
 		}),
 	}

--- a/cli/cmd/compose/exec.go
+++ b/cli/cmd/compose/exec.go
@@ -53,11 +53,12 @@ func execCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Use:   "exec [options] [-e KEY=VAL...] [--] SERVICE COMMAND [ARGS...]",
 		Short: "Execute a command in a running container.",
 		Args:  cobra.MinimumNArgs(2),
-		RunE: Adapt(func(ctx context.Context, args []string) error {
-			if len(args) > 1 {
-				opts.command = args[1:]
-			}
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			opts.service = args[0]
+			opts.command = args[1:]
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runExec(ctx, backend, opts)
 		}),
 	}

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -46,10 +46,13 @@ func pullCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull [SERVICE...]",
 		Short: "Pull service images",
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
 			if opts.noParallel {
 				fmt.Fprint(os.Stderr, aec.Apply("option '--no-parallel' is DEPRECATED and will be ignored.\n", aec.RedF))
 			}
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runPull(ctx, backend, opts, args)
 		}),
 	}

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -109,14 +109,17 @@ func runCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 		Use:   "run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l KEY=VALUE...] SERVICE [COMMAND] [ARGS...]",
 		Short: "Run a one-off command on a service.",
 		Args:  cobra.MinimumNArgs(1),
-		RunE: Adapt(func(ctx context.Context, args []string) error {
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
+			opts.Service = args[0]
 			if len(args) > 1 {
 				opts.Command = args[1:]
 			}
-			opts.Service = args[0]
 			if len(opts.publish) > 0 && opts.servicePorts {
 				return fmt.Errorf("--service-ports and --publish are incompatible")
 			}
+			return nil
+		}),
+		RunE: Adapt(func(ctx context.Context, args []string) error {
 			return runRun(ctx, backend, opts)
 		}),
 	}

--- a/cli/cmd/compose/up.go
+++ b/cli/cmd/compose/up.go
@@ -151,24 +151,27 @@ func upCommand(p *projectOptions, contextType string, backend compose.Service) *
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.timeChanged = cmd.Flags().Changed("timeout")
 		},
+		PreRunE: Adapt(func(ctx context.Context, args []string) error {
+			if opts.exitCodeFrom != "" {
+				opts.cascadeStop = true
+			}
+			if opts.Build && opts.noBuild {
+				return fmt.Errorf("--build and --no-build are incompatible")
+			}
+			if opts.Detach && (opts.attachDependencies || opts.cascadeStop) {
+				return fmt.Errorf("--detach cannot be combined with --abort-on-container-exit or --attach-dependencies")
+			}
+			if opts.forceRecreate && opts.noRecreate {
+				return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
+			}
+			if opts.recreateDeps && opts.noRecreate {
+				return fmt.Errorf("--always-recreate-deps and --no-recreate are incompatible")
+			}
+			return nil
+		}),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
 			switch contextType {
 			case store.LocalContextType, store.DefaultContextType, store.EcsLocalSimulationContextType:
-				if opts.exitCodeFrom != "" {
-					opts.cascadeStop = true
-				}
-				if opts.Build && opts.noBuild {
-					return fmt.Errorf("--build and --no-build are incompatible")
-				}
-				if opts.Detach && (opts.attachDependencies || opts.cascadeStop) {
-					return fmt.Errorf("--detach cannot be combined with --abort-on-container-exit or --attach-dependencies")
-				}
-				if opts.forceRecreate && opts.noRecreate {
-					return fmt.Errorf("--force-recreate and --no-recreate are incompatible")
-				}
-				if opts.recreateDeps && opts.noRecreate {
-					return fmt.Errorf("--always-recreate-deps and --no-recreate are incompatible")
-				}
 				return runCreateStart(ctx, backend, opts, args)
 			default:
 				return runUp(ctx, backend, opts, args)


### PR DESCRIPTION
**What I did**
Moved flags validation/processing into `PreRunE`, so that `RunE` is dedicated to execution.
Longer terms goal is to be able to directly set plain `compose.Service` method as command's `RunE`

