### PR TITLE
Do not resolve mount linux abs path as windows path on windows 

### DIFF
--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -774,7 +774,9 @@ func isUnixAbs(path string) bool {
 
 func buildMount(project types.Project, volume types.ServiceVolumeConfig) (mount.Mount, error) {
 	source := volume.Source
-	if volume.Type == types.VolumeTypeBind && !filepath.IsAbs(source) {
+	// on windows, filepath.IsAbs(source) is false for unix style abs path like /var/run/docker.sock.
+	// do not replace these with  filepath.Abs(source) that will include a default drive.
+	if volume.Type == types.VolumeTypeBind && !filepath.IsAbs(source) && !strings.HasPrefix(source, "/") {
 		// volume source has already been prefixed with workdir if required, by compose-go project loader
 		var err error
 		source, err = filepath.Abs(source)


### PR DESCRIPTION
(eg. /var/run/docker.sock => c:/var/run/docker.sock folder)

**What I did**
test win mount path with ` filepath.IsAbs()`  and also `HasPrefix("/")  for linux abs path...

**Related issue**
Fixes https://github.com/docker/compose-cli/issues/1591

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
