### PR TITLE
prevent race condition renaming containers

### DIFF
--- a/local/compose/convergence.go
+++ b/local/compose/convergence.go
@@ -105,6 +105,7 @@ func (s *composeService) ensureService(ctx context.Context, project *types.Proje
 	}
 
 	for _, container := range actual {
+		container := container
 		name := getContainerProgressName(container)
 
 		diverged := container.Labels[configHashLabel] != expected


### PR DESCRIPTION
**What I did**
Prevent a race condition with `container` loop variable running recreate in parallel

**Related issue**
maybe will fix https://github.com/docker/compose-cli/issues/1559