### PR TITLE
split compose-cli "docker" and composeV2 cli-plugin release processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       # Ensure we don't discover cross platform build issues at release time.
       # Time used to build linux here is gained back in the build for local E2E step
       - name: Build packages
-        run: make -f builder.Makefile cross
+        run: make -f builder.Makefile cross cross-compose-plugin
 
   build:
     name: Build
@@ -99,7 +99,7 @@ jobs:
       - name: Build for local E2E
         env:
           BUILD_TAGS: e2e
-        run: make -f builder.Makefile cli
+        run: make -f builder.Makefile cli compose-plugin
 
       - name: E2E Test
         run: make e2e-local

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -3,7 +3,7 @@ name: Releaser
 on:
   push:
     tags:
-      - "v*"
+      - "v1*"
 jobs:
   upload-release:
     runs-on: ubuntu-latest
@@ -30,10 +30,10 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Build
-        run: make -f builder.Makefile package
+        run: make -f builder.Makefile cross
 
       - uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/*"
+          artifacts: "bin/*"
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/plugin-release.yaml
+++ b/.github/workflows/plugin-release.yaml
@@ -1,0 +1,39 @@
+name: Releaser
+
+on:
+  push:
+    tags:
+      - "v2*"
+jobs:
+  upload-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+        id: go
+
+      - name: Setup docker CLI
+        run: |
+          curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
+          sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: make -f builder.Makefile cross-compose-plugin
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "bin/*"
+          prerelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 	TEST_FLAGS=-run $(E2E_TEST)
 endif
 
-all: cli
+all: cli compose-plugin
 
 protos: ## Generate go code from .proto files
 	@docker build . --target protos \
@@ -39,6 +39,13 @@ protos: ## Generate go code from .proto files
 
 cli: ## Compile the cli
 	@docker build . --target cli \
+	--platform local \
+	--build-arg BUILD_TAGS=e2e,kube \
+	--build-arg GIT_TAG=$(GIT_TAG) \
+	--output ./bin
+
+compose-plugin: ## Compile the compose cli-plugin
+	@docker build . --target compose-plugin \
 	--platform local \
 	--build-arg BUILD_TAGS=e2e,kube \
 	--build-arg GIT_TAG=$(GIT_TAG) \

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This Compose CLI tool makes it easy to run Docker containers and Docker Compose 
 or Microsoft Azure Container Instances
 ([ACI](https://azure.microsoft.com/services/container-instances))
 using the Docker commands you already know.
+  
+**Note: Compose CLI is released under the 1.x tag, until "Compose v2" gets a new home**
 
-## Local Docker Compose
+## Compose v2 (a.k.a "Local Docker Compose")
 
 The `docker compose` local command is meant to be the next major version for docker-compose, and it supports the same commands and flags, in order to be used as a drop-in replacement.
 [Here](https://github.com/docker/compose-cli/issues/1283) is a checklist of docker-compose commands and flags that are implemented in `docker compose`.
@@ -20,6 +22,8 @@ This `docker compose` local command :
 * has a better integration with the rest of the docker ecosystem (being written in go, it's easier to share functionality with the Docker CLI and other Docker libraries)
 * is quicker and uses more parallelism to run multiple tasks in parallel. It also uses buildkit by default
 * includes additional commands, like `docker compose ls` to list current compose projects
+
+**Note: Compose v2 is released under the 2.x tag, until "Compose v2" gets a new home**
 
 ## Getting started
 

--- a/builder.Makefile
+++ b/builder.Makefile
@@ -28,7 +28,7 @@ STATIC_FLAGS=CGO_ENABLED=0
 
 GIT_TAG?=$(shell git describe --tags --match "v[0-9]*")
 
-LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG} -X $(PKG_NAME)/internal.ComposePluginVersion=2.0.0-beta.2"
+LDFLAGS="-s -w -X $(PKG_NAME)/internal.Version=${GIT_TAG}"
 GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 
 BINARY?=bin/docker
@@ -45,32 +45,12 @@ ifdef BUILD_TAGS
   LINT_TAGS=--build-tags $(BUILD_TAGS)
 endif
 
-TAR_TRANSFORM:=--transform s/packaging/docker/ --transform s/bin/docker/ \
-				--transform s/docker-linux-amd64/docker/ --transform s/docker-linux-arm64/docker/ \
-				--transform s/docker-linux-armv6/docker/ --transform s/docker-linux-armv7/docker/ \
-				--transform s/docker-darwin-amd64/docker/ --transform s/docker-darwin-arm64/docker/ \
-				--transform s/docker-compose-linux-amd64/docker-compose/ --transform s/docker-compose-linux-arm64/docker-compose/ \
-				--transform s/docker-compose-linux-armv6/docker-compose/ --transform s/docker-compose-linux-armv7/docker-compose/ \
-				--transform s/docker-compose-darwin-amd64/docker-compose/ --transform s/docker-compose-darwin-arm64/docker-compose/
-
-ifneq ($(findstring bsd,$(shell tar --version)),)
-  TAR_TRANSFORM=-s /packaging/docker/ -s /bin/docker/ \
-  				-s /docker-linux-amd64/docker/  -s /docker-linux-arm64/docker/ \
-  				-s /docker-linux-armv6/docker/  -s /docker-linux-armv7/docker/ \
-				-s /docker-darwin-amd64/docker/	 -s /docker-darwin-arm64/docker/ \
-  				-s /docker-compose-linux-amd64/docker-compose/  -s /docker-compose-linux-arm64/docker-compose/ \
-  				-s /docker-compose-linux-armv6/docker-compose/  -s /docker-compose-linux-armv7/docker-compose/ \
-				-s /docker-compose-darwin-amd64/docker-compose/	 -s /docker-compose-darwin-arm64/docker-compose/
-endif
-
-all: cli
-
 .PHONY: protos
 protos:
 	protoc -I. --go_out=plugins=grpc,paths=source_relative:. ${PROTOS}
 
 .PHONY: cli
-cli: compose-plugin
+cli:
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(BINARY_WITH_EXTENSION) ./cli
 
 .PHONY: compose-plugin
@@ -78,7 +58,7 @@ compose-plugin:
 	GOOS=${GOOS} GOARCH=${GOARCH} $(GO_BUILD) $(TAGS) -o $(COMPOSE_BINARY_WITH_EXTENSION) .
 
 .PHONY: cross
-cross: cross-compose-plugin
+cross:
 	GOOS=linux   GOARCH=amd64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-amd64 ./cli
 	GOOS=linux   GOARCH=arm64 $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-arm64 ./cli
 	GOOS=linux   GOARM=6 GOARCH=arm $(GO_BUILD) $(TAGS) -o $(BINARY)-linux-armv6 ./cli
@@ -116,20 +96,6 @@ check-license-headers:
 .PHONY: check-go-mod
 check-go-mod:
 	./scripts/validate/check-go-mod
-
-.PHONY: package
-package: cross
-	mkdir -p dist
-	tar -czf dist/docker-linux-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-amd64 $(COMPOSE_BINARY)-linux-amd64
-	tar -czf dist/docker-linux-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-arm64 $(COMPOSE_BINARY)-linux-arm64
-	tar -czf dist/docker-linux-armv6.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv6 $(COMPOSE_BINARY)-linux-armv6
-	tar -czf dist/docker-linux-armv7.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-linux-armv7 $(COMPOSE_BINARY)-linux-armv7
-	tar -czf dist/docker-darwin-amd64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-amd64 $(COMPOSE_BINARY)-darwin-amd64
-	tar -czf dist/docker-darwin-arm64.tar.gz $(TAR_TRANSFORM) packaging/LICENSE $(BINARY)-darwin-arm64 $(COMPOSE_BINARY)-darwin-arm64
-	cp $(BINARY)-windows-amd64.exe $(WORK_DIR)/docker.exe
-	cp $(COMPOSE_BINARY)-windows-amd64.exe $(WORK_DIR)/docker-compose.exe
-	rm -f dist/docker-windows-amd64.zip && zip dist/docker-windows-amd64.zip -j packaging/LICENSE $(WORK_DIR)/docker.exe $(WORK_DIR)/docker-compose.exe
-	rm -r $(WORK_DIR)
 
 .PHONY: yamldocs
 yamldocs:

--- a/cli/cmd/compose/version.go
+++ b/cli/cmd/compose/version.go
@@ -52,7 +52,7 @@ func versionCommand() *cobra.Command {
 }
 
 func runVersion(opts versionOptions) {
-	displayedVersion := strings.TrimPrefix(internal.ComposePluginVersion, "v")
+	displayedVersion := strings.TrimPrefix(internal.Version, "v")
 	if opts.short {
 		fmt.Println(displayedVersion)
 		return

--- a/internal/variables.go
+++ b/internal/variables.go
@@ -26,6 +26,4 @@ const (
 var (
 	// Version is the version of the CLI injected in compilation time
 	Version = "dev"
-	// ComposePluginVersion is the version of the compose cli plugin, injected in compilation time
-	ComposePluginVersion = "dev"
 )

--- a/main.go
+++ b/main.go
@@ -59,6 +59,6 @@ func main() {
 		manager.Metadata{
 			SchemaVersion: "0.1.0",
 			Vendor:        "Docker Inc.",
-			Version:       strings.TrimPrefix(internal.ComposePluginVersion, "v"),
+			Version:       strings.TrimPrefix(internal.Version, "v"),
 		})
 }

--- a/scripts/install/install_linux.sh
+++ b/scripts/install/install_linux.sh
@@ -107,9 +107,9 @@ if ! [ "$(command -v curl)" ]; then
 fi
 
 if [ "$(uname -m)" = "aarch64" ]; then
-	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-arm64.tar.gz" | cut -d : -f 2,3)}
+	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-arm64" | cut -d : -f 2,3)}
 else
-	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-amd64.tar.gz" | cut -d : -f 2,3)}
+	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-amd64" | cut -d : -f 2,3)}
 fi
 
 # Check if the Compose CLI is already installed
@@ -117,10 +117,8 @@ if [ $(is_new_cli "docker") -eq 1 ]; then
 	if [ $(is_new_cli "/usr/local/bin/docker") -eq 1 ]; then
 		echo "You already have the Docker Compose CLI installed, overriding with latest version"
 		download_dir=$($sh_c 'mktemp -d')
-		$sh_c "${download_cmd} ${download_dir}/docker-compose-cli.tar.gz ${DOWNLOAD_URL}"
-		$sh_c "tar xzf ${download_dir}/docker-compose-cli.tar.gz -C ${download_dir} --strip-components 1"
+		$sh_c "${download_cmd} ${download_dir}/docker ${DOWNLOAD_URL}"
 		$sudo_sh_c "install -m 775 ${download_dir}/docker /usr/local/bin/docker"
-		$sh_c "mkdir -p ~/.docker/cli-plugins && cp ${download_dir}/docker-compose ~/.docker/cli-plugins/docker-compose"
 		exit 0
 	fi
 	echo "You already have the Docker Compose CLI installed, in a different location."
@@ -175,8 +173,7 @@ echo "Downloading CLI..."
 
 # Download CLI to temporary directory
 download_dir=$($sh_c 'mktemp -d')
-$sh_c "${download_cmd} ${download_dir}/docker-compose-cli.tar.gz ${DOWNLOAD_URL}"
-$sh_c "tar xzf ${download_dir}/docker-compose-cli.tar.gz -C ${download_dir} --strip-components 1"
+$sh_c "${download_cmd} ${download_dir}/docker ${DOWNLOAD_URL}"
 
 echo "Downloaded CLI!"
 echo "Installing CLI..."
@@ -186,8 +183,6 @@ $sudo_sh_c "ln -s ${existing_cli_path} ${link_path}"
 
 # Install downloaded CLI
 $sudo_sh_c "install -m 775 ${download_dir}/docker /usr/local/bin/docker"
-# Install Compose CLI plugin
-$sh_c "mkdir -p ~/.docker/cli-plugins && cp ${download_dir}/docker-compose ~/.docker/cli-plugins/docker-compose"
 
 # Clear cache
 cleared_cache=1

--- a/scripts/install/test.Dockerfile
+++ b/scripts/install/test.Dockerfile
@@ -37,7 +37,6 @@ RUN sudo chmod +x /scripts/install_linux.sh
 ARG DOWNLOAD_URL=
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
-RUN sh -c "docker info || true" | grep "compose: Docker Compose (Docker Inc.,"
 
 FROM install AS upgrade
 
@@ -46,7 +45,6 @@ WORKDIR /home/newuser
 
 RUN DOWNLOAD_URL=${DOWNLOAD_URL} /scripts/install_linux.sh
 RUN docker version | grep Cloud
-RUN sh -c "docker info || true" | grep "compose: Docker Compose (Docker Inc.,"
 
 # To run this test locally, start an HTTP server that serves the dist/ folder
 # then run a docker build passing the DOWNLOAD_URL as a build arg:


### PR DESCRIPTION
**What I did**
split the release process so `v1.x` will build compose-cli while `v2.x` will build the composev2 cli-plugin. Temporary solution until composev2 code is moved to a new home

see sample release on https://github.com/ndeloof/compose-cli/releases

**Related issue**
close https://github.com/docker/compose-cli/issues/1710
internally tracked as https://docker.atlassian.net/browse/IL-159

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/119813843-0cb8e280-beea-11eb-804f-6d31bf6aa8c6.png)
