### PR TITLE
remove unresolved vars from env set by `exec`

### DIFF
--- a/local/compose/exec.go
+++ b/local/compose/exec.go
@@ -50,11 +50,12 @@ func (s *composeService) Exec(ctx context.Context, project *types.Project, opts 
 	container := containers[0]
 
 	var env []string
-	projectEnv := types.NewMappingWithEquals(opts.Environment).Resolve(func(s string) (string, bool) {
-		v, ok := project.Environment[s]
-		return v, ok
-	})
-	for k, v := range service.Environment.OverrideBy(projectEnv) {
+	for k, v := range service.Environment.OverrideBy(types.NewMappingWithEquals(opts.Environment)).
+		Resolve(func(s string) (string, bool) {
+			v, ok := project.Environment[s]
+			return v, ok
+		}).
+		RemoveEmpty() {
 		env = append(env, fmt.Sprintf("%s=%s", k, *v))
 	}
 


### PR DESCRIPTION
**What I did**
fixed exec environment computation to ignore unset env variable values

**Related issue**
close https://github.com/docker/compose-cli/issues/1712

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/119829022-1565e480-befb-11eb-81a6-21adaf9e67f3.png)
