### PR TITLE
Move progress writter into backend(s)

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -227,8 +227,8 @@ func (cs *aciComposeService) RunOneOffContainer(ctx context.Context, project *ty
 	return 0, errdefs.ErrNotImplemented
 }
 
-func (cs *aciComposeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) ([]string, error) {
-	return nil, errdefs.ErrNotImplemented
+func (cs *aciComposeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) error {
+	return errdefs.ErrNotImplemented
 }
 
 func (cs *aciComposeService) Exec(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {

--- a/api/client/compose.go
+++ b/api/client/compose.go
@@ -88,8 +88,8 @@ func (c *composeService) RunOneOffContainer(ctx context.Context, project *types.
 	return 0, errdefs.ErrNotImplemented
 }
 
-func (c *composeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) ([]string, error) {
-	return nil, errdefs.ErrNotImplemented
+func (c *composeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) error {
+	return errdefs.ErrNotImplemented
 }
 
 func (c *composeService) Exec(ctx context.Context, project *types.Project, opts compose.RunOptions) (int, error) {

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -59,7 +59,7 @@ type Service interface {
 	// RunOneOffContainer creates a service oneoff container and starts its dependencies
 	RunOneOffContainer(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	// Remove executes the equivalent to a `compose rm`
-	Remove(ctx context.Context, project *types.Project, options RemoveOptions) ([]string, error)
+	Remove(ctx context.Context, project *types.Project, options RemoveOptions) error
 	// Exec executes a command in a running service container
 	Exec(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	// Copy copies a file/folder between a service container and the local filesystem
@@ -169,8 +169,9 @@ type PushOptions struct {
 	IgnoreFailures bool
 }
 
-// PullOptions group options of the Push API
+// PullOptions group options of the Pull API
 type PullOptions struct {
+	Quiet          bool
 	IgnoreFailures bool
 }
 

--- a/api/compose/proxy.go
+++ b/api/compose/proxy.go
@@ -41,7 +41,7 @@ type ServiceProxy struct {
 	ConvertFn            func(ctx context.Context, project *types.Project, options ConvertOptions) ([]byte, error)
 	KillFn               func(ctx context.Context, project *types.Project, options KillOptions) error
 	RunOneOffContainerFn func(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
-	RemoveFn             func(ctx context.Context, project *types.Project, options RemoveOptions) ([]string, error)
+	RemoveFn             func(ctx context.Context, project *types.Project, options RemoveOptions) error
 	ExecFn               func(ctx context.Context, project *types.Project, opts RunOptions) (int, error)
 	CopyFn               func(ctx context.Context, project *types.Project, opts CopyOptions) error
 	PauseFn              func(ctx context.Context, project string, options PauseOptions) error
@@ -252,9 +252,9 @@ func (s *ServiceProxy) RunOneOffContainer(ctx context.Context, project *types.Pr
 }
 
 //Remove implements Service interface
-func (s *ServiceProxy) Remove(ctx context.Context, project *types.Project, options RemoveOptions) ([]string, error) {
+func (s *ServiceProxy) Remove(ctx context.Context, project *types.Project, options RemoveOptions) error {
 	if s.RemoveFn == nil {
-		return nil, errdefs.ErrNotImplemented
+		return errdefs.ErrNotImplemented
 	}
 	for _, i := range s.interceptors {
 		i(ctx, project)

--- a/cli/cmd/compose/build.go
+++ b/cli/cmd/compose/build.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 )
 
 type buildOptions struct {
@@ -88,14 +87,11 @@ func runBuild(ctx context.Context, backend compose.Service, opts buildOptions, s
 		return err
 	}
 
-	err = progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Build(ctx, project, compose.BuildOptions{
-			Pull:     opts.pull,
-			Progress: opts.progress,
-			Args:     types.NewMappingWithEquals(opts.args),
-			NoCache:  opts.noCache,
-			Quiet:    opts.quiet,
-		})
+	return backend.Build(ctx, project, compose.BuildOptions{
+		Pull:     opts.pull,
+		Progress: opts.progress,
+		Args:     types.NewMappingWithEquals(opts.args),
+		NoCache:  opts.noCache,
+		Quiet:    opts.quiet,
 	})
-	return err
 }

--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -87,6 +87,20 @@ type projectOptions struct {
 	EnvFile     string
 }
 
+// ProjectFunc does stuff within a types.Project
+type ProjectFunc func(ctx context.Context, project *types.Project) error
+
+// WithServices creates a cobra run command from a ProjectFunc based on configured project options and selected services
+func (o *projectOptions) WithServices(services []string, fn ProjectFunc) func(cmd *cobra.Command, args []string) error {
+	return Adapt(func(ctx context.Context, strings []string) error {
+		project, err := o.toProject(services)
+		if err != nil {
+			return err
+		}
+		return fn(ctx, project)
+	})
+}
+
 func (o *projectOptions) addProjectFlags(f *pflag.FlagSet) {
 	f.StringArrayVar(&o.Profiles, "profile", []string{}, "Specify a profile to enable")
 	f.StringVarP(&o.ProjectName, "project-name", "p", "", "Project name")

--- a/cli/cmd/compose/pause.go
+++ b/cli/cmd/compose/pause.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 )
 
 type pauseOptions struct {
@@ -49,12 +48,9 @@ func runPause(ctx context.Context, backend compose.Service, opts pauseOptions, s
 		return err
 	}
 
-	err = progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Pause(ctx, project, compose.PauseOptions{
-			Services: services,
-		})
+	return backend.Pause(ctx, project, compose.PauseOptions{
+		Services: services,
 	})
-	return err
 }
 
 type unpauseOptions struct {
@@ -81,9 +77,7 @@ func runUnPause(ctx context.Context, backend compose.Service, opts unpauseOption
 		return err
 	}
 
-	return progress.Run(ctx, func(ctx context.Context) error {
-		return backend.UnPause(ctx, project, compose.PauseOptions{
-			Services: services,
-		})
+	return backend.UnPause(ctx, project, compose.PauseOptions{
+		Services: services,
 	})
 }

--- a/cli/cmd/compose/pull.go
+++ b/cli/cmd/compose/pull.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/utils"
 )
 
@@ -86,15 +85,8 @@ func runPull(ctx context.Context, backend compose.Service, opts pullOptions, ser
 		project.Services = enabled
 	}
 
-	apiOpts := compose.PullOptions{
+	return backend.Pull(ctx, project, compose.PullOptions{
+		Quiet:          opts.quiet,
 		IgnoreFailures: opts.ignorePullFailures,
-	}
-
-	if opts.quiet {
-		return backend.Pull(ctx, project, apiOpts)
-	}
-
-	return progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Pull(ctx, project, apiOpts)
 	})
 }

--- a/cli/cmd/compose/push.go
+++ b/cli/cmd/compose/push.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 )
 
 type pushOptions struct {
@@ -54,9 +53,7 @@ func runPush(ctx context.Context, backend compose.Service, opts pushOptions, ser
 		return err
 	}
 
-	return progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Push(ctx, project, compose.PushOptions{
-			IgnoreFailures: opts.Ignorefailures,
-		})
+	return backend.Push(ctx, project, compose.PushOptions{
+		IgnoreFailures: opts.Ignorefailures,
 	})
 }

--- a/cli/cmd/compose/remove.go
+++ b/cli/cmd/compose/remove.go
@@ -18,13 +18,8 @@ package compose
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
-	"github.com/docker/compose-cli/utils/prompt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -69,46 +64,12 @@ func runRemove(ctx context.Context, backend compose.Service, opts removeOptions,
 	}
 
 	if opts.stop {
-		err = progress.Run(ctx, func(ctx context.Context) error {
-			return backend.Stop(ctx, project, compose.StopOptions{
-				Services: services,
-			})
+		return backend.Stop(ctx, project, compose.StopOptions{
+			Services: services,
 		})
-		if err != nil {
-			return err
-		}
 	}
 
-	resources, err := backend.Remove(ctx, project, compose.RemoveOptions{
-		DryRun:   true,
+	return backend.Remove(ctx, project, compose.RemoveOptions{
 		Services: services,
-	})
-	if err != nil {
-		return err
-	}
-
-	if len(resources) == 0 {
-		fmt.Println("No stopped containers")
-		return nil
-	}
-	msg := fmt.Sprintf("Going to remove %s", strings.Join(resources, ", "))
-	if opts.force {
-		fmt.Println(msg)
-	} else {
-		confirm, err := prompt.User{}.Confirm(msg, false)
-		if err != nil {
-			return err
-		}
-		if !confirm {
-			return nil
-		}
-	}
-
-	return progress.Run(ctx, func(ctx context.Context) error {
-		_, err := backend.Remove(ctx, project, compose.RemoveOptions{
-			Volumes: opts.volumes,
-			Force:   opts.force,
-		})
-		return err
 	})
 }

--- a/cli/cmd/compose/restart.go
+++ b/cli/cmd/compose/restart.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 )
 
 type restartOptions struct {
@@ -55,10 +54,8 @@ func runRestart(ctx context.Context, backend compose.Service, opts restartOption
 	}
 
 	timeout := time.Duration(opts.timeout) * time.Second
-	return progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Restart(ctx, project, compose.RestartOptions{
-			Timeout:  &timeout,
-			Services: services,
-		})
+	return backend.Restart(ctx, project, compose.RestartOptions{
+		Timeout:  &timeout,
+		Services: services,
 	})
 }

--- a/cli/cmd/compose/start.go
+++ b/cli/cmd/compose/start.go
@@ -20,8 +20,6 @@ import (
 	"context"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
-
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +47,5 @@ func runStart(ctx context.Context, backend compose.Service, opts startOptions, s
 		return err
 	}
 
-	return progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Start(ctx, project, compose.StartOptions{})
-	})
+	return backend.Start(ctx, project, compose.StartOptions{})
 }

--- a/cli/cmd/compose/stop.go
+++ b/cli/cmd/compose/stop.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/progress"
 )
 
 type stopOptions struct {
@@ -63,10 +62,8 @@ func runStop(ctx context.Context, backend compose.Service, opts stopOptions, ser
 		timeoutValue := time.Duration(opts.timeout) * time.Second
 		timeout = &timeoutValue
 	}
-	return progress.Run(ctx, func(ctx context.Context) error {
-		return backend.Stop(ctx, project, compose.StopOptions{
-			Timeout:  timeout,
-			Services: services,
-		})
+	return backend.Stop(ctx, project, compose.StopOptions{
+		Timeout:  timeout,
+		Services: services,
 	})
 }

--- a/ecs/local/compose.go
+++ b/ecs/local/compose.go
@@ -180,7 +180,7 @@ func (e ecsLocalSimulation) RunOneOffContainer(ctx context.Context, project *typ
 	return 0, errors.Wrap(errdefs.ErrNotImplemented, "use docker-compose run")
 }
 
-func (e ecsLocalSimulation) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) ([]string, error) {
+func (e ecsLocalSimulation) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) error {
 	return e.compose.Remove(ctx, project, options)
 }
 

--- a/ecs/run.go
+++ b/ecs/run.go
@@ -29,6 +29,6 @@ func (b *ecsAPIService) RunOneOffContainer(ctx context.Context, project *types.P
 	return 0, errdefs.ErrNotImplemented
 }
 
-func (b *ecsAPIService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) ([]string, error) {
-	return nil, errdefs.ErrNotImplemented
+func (b *ecsAPIService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) error {
+	return errdefs.ErrNotImplemented
 }

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -248,8 +248,8 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 	return 0, errdefs.ErrNotImplemented
 }
 
-func (s *composeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) ([]string, error) {
-	return nil, errdefs.ErrNotImplemented
+func (s *composeService) Remove(ctx context.Context, project *types.Project, options compose.RemoveOptions) error {
+	return errdefs.ErrNotImplemented
 }
 
 // Exec executes a command in a running service container

--- a/local/compose/pause.go
+++ b/local/compose/pause.go
@@ -27,6 +27,12 @@ import (
 )
 
 func (s *composeService) Pause(ctx context.Context, project string, options compose.PauseOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.pause(ctx, project, options)
+	})
+}
+
+func (s *composeService) pause(ctx context.Context, project string, options compose.PauseOptions) error {
 	containers, err := s.getContainers(ctx, project, oneOffExclude, true, options.Services...)
 	if err != nil {
 		return err
@@ -49,6 +55,12 @@ func (s *composeService) Pause(ctx context.Context, project string, options comp
 }
 
 func (s *composeService) UnPause(ctx context.Context, project string, options compose.PauseOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.unPause(ctx, project, options)
+	})
+}
+
+func (s *composeService) unPause(ctx context.Context, project string, options compose.PauseOptions) error {
 	containers, err := s.getContainers(ctx, project, oneOffExclude, true, options.Services...)
 	if err != nil {
 		return err

--- a/local/compose/pull.go
+++ b/local/compose/pull.go
@@ -38,6 +38,15 @@ import (
 )
 
 func (s *composeService) Pull(ctx context.Context, project *types.Project, opts compose.PullOptions) error {
+	if opts.Quiet {
+		return s.pull(ctx, project, opts)
+	}
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.pull(ctx, project, opts)
+	})
+}
+
+func (s *composeService) pull(ctx context.Context, project *types.Project, opts compose.PullOptions) error {
 	info, err := s.apiClient.Info(ctx)
 	if err != nil {
 		return err

--- a/local/compose/push.go
+++ b/local/compose/push.go
@@ -39,6 +39,12 @@ import (
 )
 
 func (s *composeService) Push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.push(ctx, project, options)
+	})
+}
+
+func (s *composeService) push(ctx context.Context, project *types.Project, options compose.PushOptions) error {
 	configFile, err := cliconfig.Load(config.Dir())
 	if err != nil {
 		return err

--- a/local/compose/restart.go
+++ b/local/compose/restart.go
@@ -20,12 +20,19 @@ import (
 	"context"
 
 	"github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/utils"
 
 	"github.com/compose-spec/compose-go/types"
 )
 
 func (s *composeService) Restart(ctx context.Context, project *types.Project, options compose.RestartOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.restart(ctx, project, options)
+	})
+}
+
+func (s *composeService) restart(ctx context.Context, project *types.Project, options compose.RestartOptions) error {
 	ctx, err := s.getUpdatedContainersStateContext(ctx, project.Name)
 	if err != nil {
 		return err

--- a/local/compose/start.go
+++ b/local/compose/start.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/api/progress"
 	"github.com/docker/compose-cli/utils"
 
 	"github.com/compose-spec/compose-go/types"
@@ -29,6 +30,12 @@ import (
 )
 
 func (s *composeService) Start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.start(ctx, project, options)
+	})
+}
+
+func (s *composeService) start(ctx context.Context, project *types.Project, options compose.StartOptions) error {
 	listener := options.Attach
 	if len(options.Services) == 0 {
 		options.Services = project.ServiceNames()

--- a/local/compose/stop.go
+++ b/local/compose/stop.go
@@ -26,6 +26,12 @@ import (
 )
 
 func (s *composeService) Stop(ctx context.Context, project *types.Project, options compose.StopOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.stop(ctx, project, options)
+	})
+}
+
+func (s *composeService) stop(ctx context.Context, project *types.Project, options compose.StopOptions) error {
 	w := progress.ContextWriter(ctx)
 
 	services := options.Services


### PR DESCRIPTION
**What I did**
moved `progress.Run` to the backends, to offer more flexibility
(long term plan is to get `Up` implemented by local backend)

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/120641495-f2e04800-c473-11eb-9461-b5f75d2cba35.png)
