### PR TITLE
move progress to backend on "down"

### DIFF
--- a/cli/cmd/compose/compose.go
+++ b/cli/cmd/compose/compose.go
@@ -218,7 +218,7 @@ func RootCommand(contextType string, backend compose.Service) *cobra.Command {
 
 	command.AddCommand(
 		upCommand(&opts, contextType, backend),
-		downCommand(&opts, contextType, backend),
+		downCommand(&opts, backend),
 		startCommand(&opts, backend),
 		restartCommand(&opts, backend),
 		stopCommand(&opts, backend),

--- a/ecs/down.go
+++ b/ecs/down.go
@@ -19,12 +19,26 @@ package ecs
 import (
 	"context"
 
-	"github.com/docker/compose-cli/api/compose"
+	"github.com/pkg/errors"
 
+	"github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/api/errdefs"
 	"github.com/docker/compose-cli/api/progress"
 )
 
 func (b *ecsAPIService) Down(ctx context.Context, projectName string, options compose.DownOptions) error {
+	if options.Volumes {
+		return errors.Wrap(errdefs.ErrNotImplemented, "--volumes option is not supported on ECS")
+	}
+	if options.Images != "" {
+		return errors.Wrap(errdefs.ErrNotImplemented, "--rmi option is not supported on ECS")
+	}
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return b.down(ctx, projectName)
+	})
+}
+
+func (b *ecsAPIService) down(ctx context.Context, projectName string) error {
 	resources, err := b.aws.ListStackResources(ctx, projectName)
 	if err != nil {
 		return err

--- a/local/compose/down.go
+++ b/local/compose/down.go
@@ -36,6 +36,12 @@ import (
 type downOp func() error
 
 func (s *composeService) Down(ctx context.Context, projectName string, options compose.DownOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.down(ctx, projectName, options)
+	})
+}
+
+func (s *composeService) down(ctx context.Context, projectName string, options compose.DownOptions) error {
 	w := progress.ContextWriter(ctx)
 	resourceToRemove := false
 


### PR DESCRIPTION
**What I did**
Moved progress rendering to backend
Moved check for supported options to backend

this makes `down` CLI command way simpler and independent from backend.
