### PR TITLE
mobycli: ignore SIGURG on Linux and Darwin

### DIFF
--- a/cli/mobycli/exec_unix.go
+++ b/cli/mobycli/exec_unix.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mobycli
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func isRuntimeSig(s os.Signal) bool {
+	return s == unix.SIGURG
+}

--- a/cli/mobycli/exec_windows.go
+++ b/cli/mobycli/exec_windows.go
@@ -1,0 +1,23 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mobycli
+
+import "os"
+
+func isRuntimeSig(s os.Signal) bool {
+	return false
+}


### PR DESCRIPTION
Equivalent of https://github.com/docker/cli/commit/fff164c22e8dc904291fecb62307312fd4ca153e
and https://github.com/docker/cli/commit/cedaf44ea2e8b25b5298bac5f432d90033e5ad6a

In go1.14+, SIGURG is used by the runtime to handle preemtable system calls.
In practice this signal is caught *frequently*.

For reference:

https://go.googlesource.com/proposal/+/master/design/24543-non-cooperative-preemption.md
golang/go#37942


**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
