### PR TITLE
move up logic from CLI into local backend

### DIFF
--- a/aci/compose.go
+++ b/aci/compose.go
@@ -87,6 +87,12 @@ func (cs *aciComposeService) Copy(ctx context.Context, project *types.Project, o
 }
 
 func (cs *aciComposeService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return cs.up(ctx, project)
+	})
+}
+
+func (cs *aciComposeService) up(ctx context.Context, project *types.Project) error {
 	logrus.Debugf("Up on project with name %q", project.Name)
 
 	if err := autocreateFileshares(ctx, project); err != nil {

--- a/api/compose/api.go
+++ b/api/compose/api.go
@@ -112,10 +112,14 @@ type CreateOptions struct {
 
 // StartOptions group options of the Start API
 type StartOptions struct {
-	// Attach will attach to service containers and send container logs and events
-	Attach ContainerEventListener
-	// Services passed in the command line to be started
-	Services []string
+	// Attach to container and forward logs if not nil
+	Attach LogConsumer
+	// AttachTo set the services to attach to
+	AttachTo []string
+	// CascadeStop stops the application when a container stops
+	CascadeStop bool
+	// ExitCodeFrom return exit code from specified service
+	ExitCodeFrom string
 }
 
 // RestartOptions group options of the Restart API
@@ -136,10 +140,8 @@ type StopOptions struct {
 
 // UpOptions group options of the Up API
 type UpOptions struct {
-	// Detach will create services and return immediately
-	Detach bool
-	// QuietPull makes the pulling process quiet
-	QuietPull bool
+	Create CreateOptions
+	Start  StartOptions
 }
 
 // DownOptions group options of the Down API

--- a/cli/cmd/compose/kill.go
+++ b/cli/cmd/compose/kill.go
@@ -18,7 +18,6 @@ package compose
 
 import (
 	"context"
-	"os"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/spf13/cobra"
@@ -31,7 +30,7 @@ func killCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kill [options] [SERVICE...]",
 		Short: "Force stop service containers.",
-		RunE: p.WithServices(os.Args, func(ctx context.Context, project *types.Project) error {
+		RunE: p.WithProject(func(ctx context.Context, project *types.Project) error {
 			return backend.Kill(ctx, project, opts)
 		}),
 	}

--- a/cli/cmd/compose/run.go
+++ b/cli/cmd/compose/run.go
@@ -120,7 +120,11 @@ func runCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 			return nil
 		}),
 		RunE: Adapt(func(ctx context.Context, args []string) error {
-			return runRun(ctx, backend, opts)
+			project, err := p.toProject([]string{opts.Service})
+			if err != nil {
+				return err
+			}
+			return runRun(ctx, backend, project, opts)
 		}),
 	}
 	flags := cmd.Flags()
@@ -143,13 +147,8 @@ func runCommand(p *projectOptions, backend compose.Service) *cobra.Command {
 	return cmd
 }
 
-func runRun(ctx context.Context, backend compose.Service, opts runOptions) error {
-	project, err := setup(*opts.composeOptions, []string{opts.Service})
-	if err != nil {
-		return err
-	}
-
-	err = opts.apply(project)
+func runRun(ctx context.Context, backend compose.Service, project *types.Project, opts runOptions) error {
+	err := opts.apply(project)
 	if err != nil {
 		return err
 	}

--- a/ecs/up.go
+++ b/ecs/up.go
@@ -23,12 +23,12 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/sirupsen/logrus"
 
 	"github.com/docker/compose-cli/api/compose"
 	"github.com/docker/compose-cli/api/errdefs"
-
-	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/compose-cli/api/progress"
 )
 
 func (b *ecsAPIService) Build(ctx context.Context, project *types.Project, options compose.BuildOptions) error {
@@ -80,6 +80,12 @@ func (b *ecsAPIService) Copy(ctx context.Context, project *types.Project, option
 }
 
 func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return b.up(ctx, project, options)
+	})
+}
+
+func (b *ecsAPIService) up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
 	logrus.Debugf("deploying on AWS with region=%q", b.Region)
 	err := b.aws.CheckRequirements(ctx, b.Region)
 	if err != nil {
@@ -124,7 +130,7 @@ func (b *ecsAPIService) Up(ctx context.Context, project *types.Project, options 
 			return err
 		}
 	}
-	if options.Detach {
+	if options.Start.Attach == nil {
 		return nil
 	}
 	signalChan := make(chan os.Signal, 1)

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -72,6 +72,12 @@ func NewComposeService() (compose.Service, error) {
 
 // Up executes the equivalent to a `compose up`
 func (s *composeService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.up(ctx, project)
+	})
+}
+
+func (s *composeService) up(ctx context.Context, project *types.Project) error {
 	w := progress.ContextWriter(ctx)
 
 	eventName := "Convert to Helm charts"

--- a/local/compose/compose.go
+++ b/local/compose/compose.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/docker/compose-cli/api/compose"
-	"github.com/docker/compose-cli/api/errdefs"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/docker/cli/cli/config/configfile"
@@ -43,10 +42,6 @@ func NewComposeService(apiClient client.APIClient, configFile *configfile.Config
 type composeService struct {
 	apiClient  client.APIClient
 	configFile *configfile.ConfigFile
-}
-
-func (s *composeService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
-	return errdefs.ErrNotImplemented
 }
 
 func getCanonicalContainerName(c moby.Container) string {

--- a/local/compose/kill.go
+++ b/local/compose/kill.go
@@ -28,6 +28,12 @@ import (
 )
 
 func (s *composeService) Kill(ctx context.Context, project *types.Project, options compose.KillOptions) error {
+	return progress.Run(ctx, func(ctx context.Context) error {
+		return s.kill(ctx, project, options)
+	})
+}
+
+func (s *composeService) kill(ctx context.Context, project *types.Project, options compose.KillOptions) error {
 	w := progress.ContextWriter(ctx)
 
 	var containers Containers

--- a/local/compose/kill_test.go
+++ b/local/compose/kill_test.go
@@ -50,7 +50,7 @@ func TestKillAll(t *testing.T) {
 	api.EXPECT().ContainerKill(anyCancellableContext(), "456", "").Return(nil)
 	api.EXPECT().ContainerKill(anyCancellableContext(), "789", "").Return(nil)
 
-	err := tested.Kill(ctx, &project, compose.KillOptions{})
+	err := tested.kill(ctx, &project, compose.KillOptions{})
 	assert.NilError(t, err)
 }
 
@@ -66,7 +66,7 @@ func TestKillSignal(t *testing.T) {
 	api.EXPECT().ContainerList(ctx, projectFilterListOpt()).Return([]apitypes.Container{testContainer("service1", "123")}, nil)
 	api.EXPECT().ContainerKill(anyCancellableContext(), "123", "SIGTERM").Return(nil)
 
-	err := tested.Kill(ctx, &project, compose.KillOptions{Signal: "SIGTERM"})
+	err := tested.kill(ctx, &project, compose.KillOptions{Signal: "SIGTERM"})
 	assert.NilError(t, err)
 }
 

--- a/local/compose/up.go
+++ b/local/compose/up.go
@@ -1,0 +1,95 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/docker/compose-cli/api/compose"
+	"github.com/docker/compose-cli/api/progress"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/docker/cli/cli"
+	"golang.org/x/sync/errgroup"
+)
+
+func (s *composeService) Up(ctx context.Context, project *types.Project, options compose.UpOptions) error {
+	err := progress.Run(ctx, func(ctx context.Context) error {
+		err := s.create(ctx, project, options.Create)
+		if err != nil {
+			return err
+		}
+		return s.start(ctx, project, options.Start, nil)
+	})
+	if err != nil {
+		return err
+	}
+
+	if options.Start.Attach == nil {
+		return err
+	}
+
+	printer := compose.NewLogPrinter(options.Start.Attach)
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+
+	stopFunc := func() error {
+		ctx := context.Background()
+		return progress.Run(ctx, func(ctx context.Context) error {
+			go func() {
+				<-signalChan
+				s.Kill(ctx, project, compose.KillOptions{}) // nolint:errcheck
+			}()
+
+			return s.Stop(ctx, project, compose.StopOptions{})
+		})
+	}
+	go func() {
+		<-signalChan
+		printer.Cancel()
+		fmt.Println("Gracefully stopping... (press Ctrl+C again to force)")
+		stopFunc() // nolint:errcheck
+	}()
+
+	var exitCode int
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		code, err := printer.Run(options.Start.CascadeStop, options.Start.ExitCodeFrom, stopFunc)
+		exitCode = code
+		return err
+	})
+
+	err = s.start(ctx, project, options.Start, printer.HandleEvent)
+	if err != nil {
+		return err
+	}
+
+	err = eg.Wait()
+	if exitCode != 0 {
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		return cli.StatusError{StatusCode: exitCode, Status: errMsg}
+	}
+	return err
+}


### PR DESCRIPTION
**What I did**
move `up` command logic on backend so that local backend do implement `compose.API#Up`

this removes reference to context type from `cli` package, so that this code is now independent from ACI/ECS/Kube backends