### PR TITLE
code cleanup: splitWriter does not use service/container name

### DIFF
--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -96,8 +96,8 @@ func (kc *KubeClient) GetLogs(ctx context.Context, projectName string, consumer 
 	for _, pod := range pods.Items {
 		request := kc.client.CoreV1().Pods(kc.namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Follow: follow})
 		service := pod.Labels[compose.ServiceTag]
-		w := utils.GetWriter(pod.Name, service, func(event compose.ContainerEvent) {
-			consumer.Log(event.Container, event.Service, event.Line)
+		w := utils.GetWriter(func(line string) {
+			consumer.Log(pod.Name, service, line)
 		})
 
 		eg.Go(func() error {

--- a/local/compose/logs.go
+++ b/local/compose/logs.go
@@ -57,8 +57,8 @@ func (s *composeService) Logs(ctx context.Context, projectName string, consumer 
 			defer r.Close() // nolint errcheck
 
 			name := getContainerNameWithoutProject(c)
-			w := utils.GetWriter(name, service, func(event compose.ContainerEvent) {
-				consumer.Log(name, service, event.Line)
+			w := utils.GetWriter(func(line string) {
+				consumer.Log(name, service, line)
 			})
 			if container.Config.Tty {
 				_, err = io.Copy(w, r)

--- a/utils/writer.go
+++ b/utils/writer.go
@@ -1,0 +1,62 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"io"
+)
+
+// GetWriter creates a io.Writer that will actually split by line and format by LogConsumer
+func GetWriter(consumer func(string)) io.WriteCloser {
+	return &splitWriter{
+		buffer:   bytes.Buffer{},
+		consumer: consumer,
+	}
+}
+
+type splitWriter struct {
+	buffer   bytes.Buffer
+	consumer func(string)
+}
+
+// Write implements io.Writer. joins all input, splits on the separator and yields each chunk
+func (s *splitWriter) Write(b []byte) (int, error) {
+	n, err := s.buffer.Write(b)
+	if err != nil {
+		return n, err
+	}
+	for {
+		b = s.buffer.Bytes()
+		index := bytes.Index(b, []byte{'\n'})
+		if index < 0 {
+			break
+		}
+		line := s.buffer.Next(index + 1)
+		s.consumer(string(line[:len(line)-1]))
+	}
+	return n, nil
+}
+
+func (s *splitWriter) Close() error {
+	b := s.buffer.Bytes()
+	if len(b) == 0 {
+		return nil
+	}
+	s.consumer(string(b))
+	return nil
+}

--- a/utils/writer_test.go
+++ b/utils/writer_test.go
@@ -20,14 +20,12 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	"github.com/docker/compose-cli/api/compose"
 )
 
 func TestSplitWriter(t *testing.T) {
 	var lines []string
-	w := GetWriter("container", "service", func(event compose.ContainerEvent) {
-		lines = append(lines, event.Line)
+	w := GetWriter(func(line string) {
+		lines = append(lines, line)
 	})
 	w.Write([]byte("h"))        //nolint: errcheck
 	w.Write([]byte("e"))        //nolint: errcheck


### PR DESCRIPTION
**What I did**
moved (and renamed) splitWriter into it's own go file
removed reference to container and service names which aren't used anymore.
