### PR TITLE
LogPrinter should not be part of the API

### DIFF
--- a/local/compose/up.go
+++ b/local/compose/up.go
@@ -47,7 +47,7 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		return err
 	}
 
-	printer := compose.NewLogPrinter(options.Start.Attach)
+	printer := newLogPrinter(options.Start.Attach)
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
**What I did**
Made `logPrinter` private in local backend, not relevant anymore on the API
Made  `watchContainers` more flexible with `onStart` func which is responsible to get just-started container log stream

