### PR TITLE
`compose down -v` also removes anonymous volumes

### DIFF
--- a/local/compose/build.go
+++ b/local/compose/build.go
@@ -232,7 +232,7 @@ func (s *composeService) doBuild(ctx context.Context, project *types.Project, op
 	for _, c := range observedState {
 		for imageName := range opts {
 			if c.Image == imageName {
-				err = s.removeContainers(ctx, cw, []moby.Container{c}, nil)
+				err = s.removeContainers(ctx, cw, []moby.Container{c}, nil, false)
 				if err != nil {
 					return nil, err
 				}

--- a/local/compose/create.go
+++ b/local/compose/create.go
@@ -92,7 +92,7 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 	if len(orphans) > 0 {
 		if options.RemoveOrphans {
 			w := progress.ContextWriter(ctx)
-			err := s.removeContainers(ctx, w, orphans, nil)
+			err := s.removeContainers(ctx, w, orphans, nil, false)
 			if err != nil {
 				return err
 			}

--- a/local/compose/down_test.go
+++ b/local/compose/down_test.go
@@ -90,7 +90,7 @@ func TestDownRemoveVolumes(t *testing.T) {
 		[]apitypes.Container{testContainer("service1", "123")}, nil)
 
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
-	api.EXPECT().ContainerRemove(gomock.Any(), "123", apitypes.ContainerRemoveOptions{Force: true}).Return(nil)
+	api.EXPECT().ContainerRemove(gomock.Any(), "123", apitypes.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
 
 	api.EXPECT().NetworkList(gomock.Any(), apitypes.NetworkListOptions{Filters: filters.NewArgs(projectFilter(testProject))}).Return(nil, nil)
 


### PR DESCRIPTION
**What I did**
Pass `volume` option to `ContainerRemove` on `compose down` to also drop anonymous volumes

**Related issue**
close https://github.com/docker/compose-cli/issues/1755

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
