### PR TITLE
better interoperability with docker-compose on version label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-uuid v1.0.2
+	github.com/hashicorp/go-version v1.3.0
 	github.com/iancoleman/strcase v0.1.2
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/pty v1.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -759,6 +759,8 @@ github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2I
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -16,6 +16,14 @@
 
 package api
 
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+
+	"github.com/docker/compose-cli/internal"
+)
+
 const (
 	// ProjectLabel allow to track resource related to a compose project
 	ProjectLabel = "com.docker.compose.project"
@@ -42,3 +50,15 @@ const (
 	// VersionLabel stores the compose tool version used to run application
 	VersionLabel = "com.docker.compose.version"
 )
+
+var ComposeVersion string
+
+func init() {
+	v, err := version.NewVersion(internal.Version)
+	if err == nil {
+		segments := v.Segments()
+		if len(segments) > 2 {
+			ComposeVersion = fmt.Sprintf("%d.%d.%d", segments[0], segments[1], segments[2])
+		}
+	}
+}

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -38,7 +38,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/docker/compose-cli/internal"
 	"github.com/docker/compose-cli/pkg/api"
 	"github.com/docker/compose-cli/pkg/progress"
 	"github.com/docker/compose-cli/pkg/utils"
@@ -141,7 +140,7 @@ func prepareNetworks(project *types.Project) {
 	for k, network := range project.Networks {
 		network.Labels = network.Labels.Add(api.NetworkLabel, k)
 		network.Labels = network.Labels.Add(api.ProjectLabel, project.Name)
-		network.Labels = network.Labels.Add(api.VersionLabel, internal.Version)
+		network.Labels = network.Labels.Add(api.VersionLabel, api.ComposeVersion)
 		project.Networks[k] = network
 	}
 }
@@ -184,7 +183,7 @@ func (s *composeService) ensureProjectVolumes(ctx context.Context, project *type
 	for k, volume := range project.Volumes {
 		volume.Labels = volume.Labels.Add(api.VolumeLabel, k)
 		volume.Labels = volume.Labels.Add(api.ProjectLabel, project.Name)
-		volume.Labels = volume.Labels.Add(api.VersionLabel, internal.Version)
+		volume.Labels = volume.Labels.Add(api.VersionLabel, api.ComposeVersion)
 		err := s.ensureVolume(ctx, volume)
 		if err != nil {
 			return err
@@ -216,7 +215,7 @@ func (s *composeService) getCreateOptions(ctx context.Context, p *types.Project,
 
 	labels[api.ProjectLabel] = p.Name
 	labels[api.ServiceLabel] = service.Name
-	labels[api.VersionLabel] = internal.Version
+	labels[api.VersionLabel] = api.ComposeVersion
 	if _, ok := service.Labels[api.OneoffLabel]; !ok {
 		labels[api.OneoffLabel] = "False"
 	}

--- a/pkg/compose/create_test.go
+++ b/pkg/compose/create_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/compose-cli/internal"
+	"github.com/docker/compose-cli/pkg/api"
 
 	"github.com/compose-spec/compose-go/types"
 	composetypes "github.com/compose-spec/compose-go/types"
@@ -78,6 +78,6 @@ func TestPrepareNetworkLabels(t *testing.T) {
 	assert.DeepEqual(t, project.Networks["skynet"].Labels, types.Labels(map[string]string{
 		"com.docker.compose.network": "skynet",
 		"com.docker.compose.project": "myProject",
-		"com.docker.compose.version": internal.Version,
+		"com.docker.compose.version": api.ComposeVersion,
 	}))
 }


### PR DESCRIPTION
**What I did**
Set compose.version label as `<int>.<int>.<int>` for interoperability with docker-compose (python distutils.LooseVersion)

**Related issue**
close https://github.com/docker/compose-cli/issues/1802

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
