### PR TITLE
Don't apply restart_policy on `compose run`

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -470,6 +470,7 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 		Filters: filters.NewArgs(
 			projectFilter(project.Name),
 			serviceFilter(service.Name),
+			oneOffFilter(false),
 		),
 		All: true,
 	})

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -50,6 +50,10 @@ func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.
 	}
 	service.Scale = 1
 	service.StdinOpen = true
+	service.Restart = ""
+	if service.Deploy != nil {
+		service.Deploy.RestartPolicy = nil
+	}
 	service.Labels = service.Labels.Add(api.SlugLabel, slug)
 	service.Labels = service.Labels.Add(api.OneoffLabel, "True")
 


### PR DESCRIPTION
Compose run is used to execute a "one off" container, restart_policy doesn't make sense in this context (should only apply to long running services)
This also fix incompatibility with auto-remove HostConfig option

Also fix earlier one-off containers being started by `compose up`

**Related issue**
close https://github.com/docker/compose-cli/issues/1694

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/122716553-afa31900-d26a-11eb-90d1-8cc26ffd683e.png)
