### PR TITLE
add --verbose option for compatibility

### DIFF
--- a/cmd/compose/compose.go
+++ b/cmd/compose/compose.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	dockercli "github.com/docker/cli/cli"
@@ -196,8 +198,11 @@ func (o *projectOptions) toProjectOptions(po ...cli.ProjectOptionsFn) (*cli.Proj
 // RootCommand returns the compose command with its child commands
 func RootCommand(contextType string, backend api.Service) *cobra.Command {
 	opts := projectOptions{}
-	var ansi string
-	var noAnsi bool
+	var (
+		ansi    string
+		noAnsi  bool
+		verbose bool
+	)
 	command := &cobra.Command{
 		Short:            "Docker Compose",
 		Use:              "compose",
@@ -228,6 +233,9 @@ func RootCommand(contextType string, backend api.Service) *cobra.Command {
 				}
 				ansi = "never"
 				fmt.Fprint(os.Stderr, aec.Apply("option '--no-ansi' is DEPRECATED ! Please use '--ansi' instead.\n", aec.RedF))
+			}
+			if verbose {
+				logrus.SetLevel(logrus.TraceLevel)
 			}
 			formatter.SetANSIMode(ansi)
 			if opts.WorkDir != "" {
@@ -282,5 +290,7 @@ func RootCommand(contextType string, backend api.Service) *cobra.Command {
 	command.Flags().StringVar(&ansi, "ansi", "auto", `Control when to print ANSI control characters ("never"|"always"|"auto")`)
 	command.Flags().BoolVar(&noAnsi, "no-ansi", false, `Do not print ANSI control characters (DEPRECATED)`)
 	command.Flags().MarkHidden("no-ansi") //nolint:errcheck
+	command.Flags().BoolVar(&verbose, "verbose", false, "Show more output")
+	command.Flags().MarkHidden("verbose") //nolint:errcheck
 	return command
 }


### PR DESCRIPTION
**What I did**
Introduced `--verbose` command line option to enforce command line compatibility with `docker-compose`.
This just set logging to TRACE level
full compatibility would require to tweak the Docker API client so it dump API calls on console, but AFAIK this is not feasible within a CLI plugin as this would have to apply during client setup.

**Related issue**
close https://github.com/docker/compose-cli/issues/1253

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
