### PR TITLE
automation to remove pending label on new comment

### DIFF
--- a/.github/workflows/pending_answered.yml
+++ b/.github/workflows/pending_answered.yml
@@ -1,0 +1,17 @@
+name: Continuous integration
+
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  pending:
+    if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'pending') }}
+    name: Remove pending label
+    runs-on: ubuntu-latest
+    steps:
+      - name: removelabel
+        uses: siegerts/pending-response@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pending-response-label: pending


### PR DESCRIPTION
Adds automation to remove issues `pending` label as a new comment is created.
This allows to use this label for issues where we need reporter to provide more details, and exclude them from triage using `-label:pending` as issue search filter.
As user create a new label providing more details, `pending` label will be removed, so this issue will come back under our radar