### PR TITLE
add support for detach keys on compose run|exec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nakedret


### PR DESCRIPTION
**What I did**
introduced support for detach keys on `compose run` and `compose exec`

**Related issue**
close https://github.com/docker/compose-cli/issues/1709

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
