### PR TITLE
Do not strip "v" prefix from version when printing

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -57,17 +57,16 @@ func runVersion(cmd *cobra.Command) error {
 	var versionString string
 	var err error
 	format := strings.ToLower(strings.ReplaceAll(cmd.Flag(formatOpt).Value.String(), " ", ""))
-	displayedVersion := strings.TrimPrefix(internal.Version, "v")
 	// Replace is preferred in this case to keep the order.
 	switch format {
 	case formatter.PRETTY, "":
 		versionString, err = getOutFromMoby(cmd, fixedPrettyArgs(os.Args[1:])...)
 		versionString = strings.Replace(versionString,
-			"\n Version:", "\n Cloud integration: "+displayedVersion+"\n Version:", 1)
+			"\n Version:", "\n Cloud integration: "+internal.Version+"\n Version:", 1)
 	case formatter.JSON, formatter.TemplateLegacyJSON: // Try to catch full JSON formats
 		versionString, err = getOutFromMoby(cmd, fixedJSONArgs(os.Args[1:])...)
 		versionString = strings.Replace(versionString,
-			`"Version":`, fmt.Sprintf(`"CloudIntegration":%q,"Version":`, displayedVersion), 1)
+			`"Version":`, fmt.Sprintf(`"CloudIntegration":%q,"Version":`, internal.Version), 1)
 	default:
 		versionString, err = getOutFromMoby(cmd)
 	}

--- a/cmd/compose/version.go
+++ b/cmd/compose/version.go
@@ -18,7 +18,6 @@ package compose
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -52,14 +51,13 @@ func versionCommand() *cobra.Command {
 }
 
 func runVersion(opts versionOptions) {
-	displayedVersion := strings.TrimPrefix(internal.Version, "v")
 	if opts.short {
-		fmt.Println(displayedVersion)
+		fmt.Println(internal.Version)
 		return
 	}
 	if opts.format == formatter.JSON {
-		fmt.Printf(`{"version":"%s"}\n`, displayedVersion)
+		fmt.Printf(`{"version":%q}\n`, internal.Version)
 		return
 	}
-	fmt.Printf("Docker Compose version %s\n", displayedVersion)
+	fmt.Println("Docker Compose version", internal.Version)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"strings"
-
 	dockercli "github.com/docker/cli/cli"
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/plugin"
@@ -58,6 +56,6 @@ func main() {
 		manager.Metadata{
 			SchemaVersion: "0.1.0",
 			Vendor:        "Docker Inc.",
-			Version:       strings.TrimPrefix(internal.Version, "v"),
+			Version:       internal.Version,
 		})
 }


### PR DESCRIPTION
I noticed this when building the binary (see https://github.com/docker/docker-ce-packaging/pull/553); `internal.Version` is set to `v2.0.0-beta.4`, to match the tag.

```bash
GIT_TAG=v2.0.0-beta.4
make COMPOSE_BINARY=bin/docker-compose -f builder.Makefile compose-plugin \
    GOOS=linux \
    GOARCH=amd64 \
    CGO_ENABLED=0 \
    go build \
        -trimpath \
        -ldflags="-s -w -X github.com/docker/compose-cli/internal.Version=v2.0.0-beta.4" \
        -o bin/docker-compose \
        ./cmd
```

However, the binary has the `v` prefix stripped (which caused a check to fail
when packaging):

```bash
/root/rpmbuild/BUILDROOT/docker-compose-plugin-2.0.0.beta.4-0.fc34.x86_64/usr/libexec/docker/cli-plugins/docker-compose docker-cli-plugin-metadata
++ awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }'
+ ver=2.0.0-beta.4
+ test 2.0.0-beta.4 = v2.0.0-beta.4
FAIL: docker-compose version (2.0.0-beta.4) did not match
```

This also looks inconsistent with other binaries and plugins we ship:

```bash
docker info --format '{{json .ClientInfo.Plugins}}' | jq .
[
  {
    "SchemaVersion": "0.1.0",
    "Vendor": "Docker Inc.",
    "Version": "v0.5.1-docker",
    "ShortDescription": "Build with BuildKit",
    "Name": "buildx",
    "Path": "/usr/libexec/docker/cli-plugins/docker-buildx"
  },
  {
    "SchemaVersion": "0.1.0",
    "Vendor": "Docker Inc.",
    "Version": "2.0.0-beta.4",
    "ShortDescription": "Docker Compose",
    "Name": "compose",
    "Path": "/usr/libexec/docker/cli-plugins/docker-compose"
  },
  {
    "SchemaVersion": "0.1.0",
    "Vendor": "Docker Inc.",
    "Version": "v0.8.0",
    "ShortDescription": "Docker Scan",
    "Name": "scan",
    "Path": "/usr/libexec/docker/cli-plugins/docker-scan"
  }
]
```

Perhaps there was a specific reason for this, but thought I'd open this PR for
discussion (if the v-prefix should not be there, perhaps we should isntead strip
it when setting the version).

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
