### PR TITLE
Add dry run workflow to test release

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,11 +1,17 @@
 name: Releaser
 
 on:
-  push:
-    tags:
-      - "v1*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release Tag'
+        required: true
+      dry-run:
+        description: 'Dry run'
+        required: false
+        default: 'true'
 jobs:
-  upload-release:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.16
@@ -36,7 +42,9 @@ jobs:
         run: cp packaging/* bin/
 
       - uses: ncipollo/release-action@v1
+        if: ${{ github.event.inputs.dry-run != 'true' }}
         with:
           artifacts: "bin/*"
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Signed-off-by: Lorena Rangel <lorena.rangel@docker.com>

**What I did**

Added workflow dispatch to be able to run the release process from GitHub UI. It also has a dry-run check to be able to test the release, without doing an actual release.

**Related issue**
closes #349 

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
