### PR TITLE
Fix help text when for context create and kube backend

### DIFF
--- a/cli/cmd/context/create_kube.go
+++ b/cli/cmd/context/create_kube.go
@@ -31,8 +31,8 @@ func init() {
 	extraCommands = append(extraCommands, createKubeCommand)
 	extraHelp = append(extraHelp, `
 Create a Kubernetes context:
-$ docker context create k8s CONTEXT [flags]
-(see docker context create k8s --help)
+$ docker context create kubernetes CONTEXT [flags]
+(see docker context create kubernetes --help)
 `)
 }
 


### PR DESCRIPTION

**What I did**

Small fix to the CLI help text to align with the commands actually being used. Took me a while to figure out why it wasn't working! 😆 

