### PR TITLE
Fix container name used in kube log output

### DIFF
--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -210,10 +210,11 @@ func (kc *KubeClient) GetLogs(ctx context.Context, projectName string, consumer 
 	}
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, pod := range pods.Items {
-		request := kc.client.CoreV1().Pods(kc.namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Follow: follow})
+		podName := pod.Name
+		request := kc.client.CoreV1().Pods(kc.namespace).GetLogs(podName, &corev1.PodLogOptions{Follow: follow})
 		service := pod.Labels[api.ServiceLabel]
 		w := utils.GetWriter(func(line string) {
-			consumer.Log(pod.Name, service, line)
+			consumer.Log(podName, service, line)
 		})
 
 		eg.Go(func() error {


### PR DESCRIPTION
**What I did**

I'll admit I'm a relatively noob when it comes to Go, but if I had a service with multiple replicas, the log names were always the last pod. Looking at the code, it looks like the variable `pod` is a reference to the next item in the range, which changes each time the range runs. So, the callback in the `utils.GetWriter` references the last pod in the range. I would see output like this (with two nginx replicas running)...

```
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
app-7fd76968d9-zwmwq  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
app-7fd76968d9-zwmwq  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-configure.sh
app-7fd76968d9-zwmwq  | app-7fd76968d9-zwmwq
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Configuration complete; ready for start up
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: using the "epoll" event method
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: nginx/1.21.0
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1)
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: OS: Linux 5.10.25-linuxkit
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker processes
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 34
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 35
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 36
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 37
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 38
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 39
app-7fd76968d9-zwmwq  | 127.0.0.1 - - [09/Jul/2021:02:02:38 +0000] "GET / HTTP/1.1" 200 334 "-" "curl/7.76.1" "-"
app-7fd76968d9-zwmwq  | 127.0.0.1 - - [09/Jul/2021:02:02:39 +0000] "GET / HTTP/1.1" 200 334 "-" "curl/7.76.1" "-"
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
app-7fd76968d9-zwmwq  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
app-7fd76968d9-zwmwq  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-configure.sh
app-7fd76968d9-zwmwq  | app-7fd76968d9-6kdcs
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Configuration complete; ready for start up
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: using the "epoll" event method
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: nginx/1.21.0
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1)
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: OS: Linux 5.10.25-linuxkit
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker processes
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 34
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 35
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 36
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 37
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 38
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 39
```

Notice all of the same container names in the output. With this MR, it now becomes...

```
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
app-7fd76968d9-6kdcs  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
app-7fd76968d9-zwmwq  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
app-7fd76968d9-6kdcs  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
app-7fd76968d9-zwmwq  | 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-configure.sh
app-7fd76968d9-6kdcs  | app-7fd76968d9-6kdcs
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
app-7fd76968d9-6kdcs  | /docker-entrypoint.sh: Configuration complete; ready for start up
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: using the "epoll" event method
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-configure.sh
app-7fd76968d9-zwmwq  | app-7fd76968d9-zwmwq
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
app-7fd76968d9-zwmwq  | /docker-entrypoint.sh: Configuration complete; ready for start up
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: using the "epoll" event method
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: nginx/1.21.0
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: nginx/1.21.0
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1)
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: OS: Linux 5.10.25-linuxkit
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker processes
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 34
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 35
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 36
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 37
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 38
app-7fd76968d9-6kdcs  | 2021/07/09 01:23:53 [notice] 1#1: start worker process 39
app-7fd76968d9-6kdcs  | 127.0.0.1 - - [09/Jul/2021:02:02:30 +0000] "GET / HTTP/1.1" 200 334 "-" "curl/7.76.1" "-"
app-7fd76968d9-6kdcs  | 127.0.0.1 - - [09/Jul/2021:02:02:32 +0000] "GET / HTTP/1.1" 200 334 "-" "curl/7.76.1" "-"
app-7fd76968d9-6kdcs  | 127.0.0.1 - - [09/Jul/2021:02:02:42 +0000] "GET / HTTP/1.1" 200 334 "-" "curl/7.76.1" "-"
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: built by gcc 10.2.1 20201203 (Alpine 10.2.1_pre1)
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: OS: Linux 5.10.25-linuxkit
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker processes
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 34
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 35
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 36
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 37
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 38
app-7fd76968d9-zwmwq  | 2021/07/09 01:23:57 [notice] 1#1: start worker process 39
```

And if I'm wrong about how the bug was working, just let me know. Still learning how Go works! 😄 