### PR TITLE
report error when there's no container to start

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -556,6 +556,10 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 		return err
 	}
 
+	if len(containers) == 0 {
+		return fmt.Errorf("no containers to start")
+	}
+
 	w := progress.ContextWriter(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, container := range containers {


### PR DESCRIPTION
**What I did**
`start` command to report error when there's no container to start

**Related issue**
close https://github.com/docker/compose-cli/issues/1905