### PR TITLE
run -v should not remove configured volumes

### DIFF
--- a/cmd/compose/run.go
+++ b/cmd/compose/run.go
@@ -72,7 +72,6 @@ func (opts runOptions) apply(project *types.Project) error {
 		}
 	}
 	if len(opts.volumes) > 0 {
-		target.Volumes = []types.ServiceVolumeConfig{}
 		for _, v := range opts.volumes {
 			volume, err := loader.ParseVolume(v)
 			if err != nil {


### PR DESCRIPTION
**What I did**
`compose run -v` defines additional volumes mount, but does not drop the configured ones

**Related issue**
close https://github.com/docker/compose-cli/issues/1899
