### PR TITLE
Allow unspecified protocol on exposed port in kube backend

### DIFF
--- a/kube/resources/kube.go
+++ b/kube/resources/kube.go
@@ -92,12 +92,13 @@ func mapToService(project *types.Project, service types.ServiceConfig) *core.Ser
 		if p.Published != 0 {
 			serviceType = core.ServiceTypeLoadBalancer
 		}
+		protocol := toProtocol(p.Protocol)
 		ports = append(ports,
 			core.ServicePort{
-				Name:       fmt.Sprintf("%d-%s", p.Published, strings.ToLower(p.Protocol)),
+				Name:       fmt.Sprintf("%d-%s", p.Published, strings.ToLower(string(protocol))),
 				Port:       int32(p.Published),
 				TargetPort: intstr.FromInt(int(p.Target)),
-				Protocol:   toProtocol(p.Protocol),
+				Protocol:   protocol,
 			})
 	}
 	if len(ports) == 0 { // headless service


### PR DESCRIPTION
The Compose spec doesn't provide a default value, but the code
was defaulting to TCP in the service protocol, just not in the
name. If no protocol was specified, it would cause an invalid
service name (eg, "80-")

**What I did**

I updated the service name to use the same `toProtocol` function to remove the option for an invalid service name.

