### PR TITLE
allow for 0 scale/replicas

### DIFF
--- a/pkg/compose/convergence.go
+++ b/pkg/compose/convergence.go
@@ -111,6 +111,9 @@ var mu sync.Mutex
 // updateProject updates project after service converged, so dependent services relying on `service:xx` can refer to actual containers.
 func (c *convergence) updateProject(project *types.Project, service string) {
 	containers := c.getObservedState(service)
+	if len(containers) == 0 {
+		return
+	}
 	container := containers[0]
 
 	// operation is protected by a Mutex so that we can safely update project.Services while running concurrent convergence on services
@@ -557,6 +560,9 @@ func (s *composeService) startService(ctx context.Context, project *types.Projec
 	}
 
 	if len(containers) == 0 {
+		if scale, err := getScale(service); err != nil && scale == 0 {
+			return nil
+		}
 		return fmt.Errorf("no containers to start")
 	}
 


### PR DESCRIPTION
**What I did**
Add check for 0 length containers list, and remove explicit error return for no running services (this is expected).

I'm not familiar enough with the internals of this program to know what far-reaching consequences changing `updateProject` and `startService` in this way will have, but I hope the automated tests in CI will catch anything untoward.

**Related issue**
fixes #1909

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![scaly snake in shape of 0](https://user-images.githubusercontent.com/175189/126392265-109271a4-22b9-43e8-8e9e-013c8d5579d0.png)
