### PR TITLE
Print services in dependency order

### DIFF
--- a/cmd/compose/convert.go
+++ b/cmd/compose/convert.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cnabio/cnab-to-oci/remotes"
 	"github.com/compose-spec/compose-go/cli"
+	"github.com/compose-spec/compose-go/types"
 	"github.com/distribution/distribution/v3/reference"
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/opencontainers/go-digest"
@@ -153,10 +154,10 @@ func runServices(opts convertOptions) error {
 	if err != nil {
 		return err
 	}
-	for _, s := range project.Services {
+	return project.WithServices(project.ServiceNames(), func(s types.ServiceConfig) error {
 		fmt.Println(s.Name)
-	}
-	return nil
+		return nil
+	})
 }
 
 func runVolumes(opts convertOptions) error {


### PR DESCRIPTION
**What I did**
Currently, `compose config --services` outputs the services in
a random/non-deterministic order.

In Compose v1, this was implicitly topologically sorted because
the project services were pre-sorted. With `compose-go`, the
services are unordered, and the `WithServices()` helper can be
used to iterate in dependency order.

**Tests**
There wasn't a great way to unit test this without further refactoring
as `runServices` uses `convertOptions::toProject()` which will
attempt to load a real Compose file. (AFAICT there aren't really any
existing CLI unit tests.)

If desirable, I can split the function in two so that the project
conversion from opts is separate from the actual logic which can
just take a `*types.Project` and so would be trivially testable.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/841263/126512539-8732e83d-21d3-4fff-80fd-dfdf773929b2.png)
