### PR TITLE
Post-login msg: Ignore if password is empty

### DIFF
--- a/cli/mobycli/pat_suggest.go
+++ b/cli/mobycli/pat_suggest.go
@@ -65,6 +65,9 @@ func isUsingDefaultRegistry(cmdArgs []string) bool {
 }
 
 func isUsingPassword(pass string) bool {
+	if pass == "" { // ignore if no password (or SSO)
+		return false
+	}
 	if _, err := uuid.ParseUUID(pass); err == nil {
 		return false
 	}

--- a/cli/mobycli/pat_suggest_test.go
+++ b/cli/mobycli/pat_suggest_test.go
@@ -75,6 +75,11 @@ func TestIsUsingPassword(t *testing.T) {
 			true,
 		},
 		{
+			"no password or sso",
+			"",
+			false,
+		},
+		{
 			"personal access token",
 			"1508b8bd-b80c-452d-9a7a-ee5607c41bcd",
 			false,


### PR DESCRIPTION
Signed-off-by: Amine Chouki <amine.chouki@docker.com>

**What I did**
Do not display the post-login message (to promote Personal Access Tokens) if the password is empty. This is more of a future proof check in case we introduce SSO or equivalent.