### PR TITLE
Fix issue `docker compose rm -s` not removing containers

### DIFF
--- a/cmd/compose/remove.go
+++ b/cmd/compose/remove.go
@@ -65,9 +65,12 @@ func runRemove(ctx context.Context, backend api.Service, opts removeOptions, ser
 	}
 
 	if opts.stop {
-		return backend.Stop(ctx, project, api.StopOptions{
+		err := backend.Stop(ctx, project, api.StopOptions{
 			Services: services,
 		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return backend.Remove(ctx, project, api.RemoveOptions{


### PR DESCRIPTION
**What I did**

When `docker compose rm` is run with `-s` (`--stop`), it actually does not remove containers, just stops them.
This PR fixes this issue.

