### PR TITLE
include exposed ports in container ports config

### DIFF
--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -527,6 +527,10 @@ func setBlkio(blkio *types.BlkioConfig, resources *container.Resources) {
 
 func buildContainerPorts(s types.ServiceConfig) nat.PortSet {
 	ports := nat.PortSet{}
+	for _, s := range s.Expose {
+		p := nat.Port(s)
+		ports[p] = struct{}{}
+	}
 	for _, p := range s.Ports {
 		p := nat.Port(fmt.Sprintf("%d/%s", p.Target, p.Protocol))
 		ports[p] = struct{}{}


### PR DESCRIPTION
**What I did**
added support for `expose` config as we compute container ports

**Related issue**
close https://github.com/docker/compose-cli/issues/1950