### PR TITLE
[scripts/install] Add beta release download support

### DIFF
--- a/scripts/install/install_linux.sh
+++ b/scripts/install/install_linux.sh
@@ -16,9 +16,16 @@
 
 # Script to install the Docker Compose CLI on Ubuntu (Beta).
 
+set -e
+
+if [ ! -z "$1" ]; then
+	RELEASE_URL="https://api.github.com/repos/docker/compose-cli/releases/tags/$1"
+else
+	RELEASE_URL="https://api.github.com/repos/docker/compose-cli/releases/latest"
+fi
+
 set -eu
 
-RELEASE_URL=https://api.github.com/repos/docker/compose-cli/releases/latest
 LINK_NAME="${LINK_NAME:-com.docker.cli}"
 DRY_RUN="${DRY_RUN:-}"
 
@@ -107,11 +114,11 @@ if ! [ "$(command -v curl)" ]; then
 fi
 
 if [ "$(uname -m)" = "aarch64" ]; then
-	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-arm64" | cut -d : -f 2,3)}
+	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker.*linux-arm64" | cut -d : -f 2,3)}
 elif [ "$(uname -m)" = "s390x" ]; then
-	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-s390x" | cut -d : -f 2,3)}
+	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker.*linux-s390x" | cut -d : -f 2,3)}
 else
-	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-amd64" | cut -d : -f 2,3)}
+	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker.*linux-amd64" | cut -d : -f 2,3)}
 fi
 
 # Check if the Compose CLI is already installed


### PR DESCRIPTION
**What I did**
* Add support to optional shell parameter to download a specific tag.
E.g :
```shell
curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh -s v2.0.0-beta.6
```
will install the beta.6 release while
```shell
curl -L https://raw.githubusercontent.com/docker/compose-cli/main/scripts/install/install_linux.sh | sh
```
will still install the latest release (e.g v1.0.17).
* Handle both current `docker-[os]-[arch]` and new beta `docker-compose-[os]-[arch]` binaries via updated grep query

**Related issue**
Fixes #1874 
Possibly related to https://github.com/docker/docker.github.io/issues/13101 (If this PR is merged, the doc will need some changes)

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![24ccd88f96dca14fe16834502b7e3d3c](https://user-images.githubusercontent.com/7818904/127850740-db8f0be9-8cc7-4b67-a2a4-d47df0a6f64f.gif)
