### PR TITLE
Fix slack link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ don't get discouraged! Our contributor's guide explains
   <tr>
     <td>Community Slack</td>
     <td>
-      The Docker Community has a dedicated Slack chat to discuss features and issues.  You can sign-up <a href="https://community.docker.com/registrations/groups/4316" target="_blank">with this link</a>.
+      The Docker Community has a dedicated Slack chat to discuss features and issues.  You can sign-up <a href="https://dockercommunity.slack.com/ssb/redirect" target="_blank">with this link</a>.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
**What I did**
I'm getting the `NET::ERR_CERT_COMMON_NAME_INVALID` error when accessing the link to Docker Community Slack.
So I fixed the link.