### PR TITLE
ignore one-off container events

### DIFF
--- a/pkg/compose/events.go
+++ b/pkg/compose/events.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/compose-cli/pkg/api"
 	moby "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/docker/compose-cli/pkg/api"
 
 	"github.com/docker/compose-cli/pkg/utils"
 )
@@ -40,6 +41,11 @@ func (s *composeService) Events(ctx context.Context, project string, options api
 				continue
 			}
 
+			oneOff := event.Actor.Attributes[api.OneoffLabel]
+			if oneOff == "True" {
+				// ignore
+				continue
+			}
 			service := event.Actor.Attributes[api.ServiceLabel]
 			if len(options.Services) > 0 && !utils.StringContains(options.Services, service) {
 				continue


### PR DESCRIPTION
**What I did**
Filter-out one-off container watching events. This prevents `up` to consider a one-off container to be part of the app and attach to it, then exit when container stops

**Related issue**
close https://github.com/docker/compose-cli/issues/1955

