### PR TITLE
Fix formatting bug in ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -49,7 +49,8 @@ Briefly describe the problem you are having in a few paragraphs.
 
 **Additional information you deem important (e.g. issue happens only occasionally):**
 
-**Output of `docker-compose --version`: ***
+**Output of `docker-compose --version`:**
+
 ```
 (paste your output here)
 ```


### PR DESCRIPTION
1. There was a trailing asterisk in one of the headers, preventing the formatting from being applied.
2. There needs to be a blank line between the bold header and the code block in order for formatting to be applied to the header.

**What I did**

Fixed formatting bug in ISSUE_TEMPLATE.md

**Related issue**

N/A

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

```
/\/\/\o
```