### PR TITLE
introduce ImageDigestLabel to track image built for service

### DIFF
--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -47,6 +47,8 @@ const (
 	OneoffLabel = "com.docker.compose.oneoff"
 	// SlugLabel stores unique slug used for one-off container identity
 	SlugLabel = "com.docker.compose.slug"
+	// ImageDigestLabel stores digest of the container image used to run service
+	ImageDigestLabel = "com.docker.compose.image"
 	// VersionLabel stores the compose tool version used to run application
 	VersionLabel = "com.docker.compose.version"
 )

--- a/pkg/compose/build.go
+++ b/pkg/compose/build.go
@@ -111,7 +111,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 	if quietPull {
 		mode = xprogress.PrinterModeQuiet
 	}
-	opts, imagesToBuild, err := s.getBuildOptions(project, images)
+	opts, err := s.getBuildOptions(project, images)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 		return err
 	}
 
-	if len(imagesToBuild) > 0 {
+	if len(builtImages) > 0 {
 		utils.DisplayScanSuggestMsg()
 	}
 	for name, digest := range builtImages {
@@ -130,18 +130,17 @@ func (s *composeService) ensureImagesExists(ctx context.Context, project *types.
 	for i, service := range project.Services {
 		digest, ok := images[getImageName(service, project.Name)]
 		if ok {
-			project.Services[i].Image = digest
+			project.Services[i].Labels[api.ImageDigestLabel] = digest
 		}
 	}
 	return nil
 }
 
-func (s *composeService) getBuildOptions(project *types.Project, images map[string]string) (map[string]build.Options, []string, error) {
+func (s *composeService) getBuildOptions(project *types.Project, images map[string]string) (map[string]build.Options, error) {
 	opts := map[string]build.Options{}
-	imagesToBuild := []string{}
 	for _, service := range project.Services {
 		if service.Image == "" && service.Build == nil {
-			return nil, nil, fmt.Errorf("invalid service %q. Must specify either image or build", service.Name)
+			return nil, fmt.Errorf("invalid service %q. Must specify either image or build", service.Name)
 		}
 		imageName := getImageName(service, project.Name)
 		_, localImagePresent := images[imageName]
@@ -150,16 +149,15 @@ func (s *composeService) getBuildOptions(project *types.Project, images map[stri
 			if localImagePresent && service.PullPolicy != types.PullPolicyBuild {
 				continue
 			}
-			imagesToBuild = append(imagesToBuild, imageName)
 			opt, err := s.toBuildOptions(project, service, imageName)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			opts[imageName] = opt
 			continue
 		}
 	}
-	return opts, imagesToBuild, nil
+	return opts, nil
 
 }
 


### PR DESCRIPTION
**What I did**
don't override service.image with local digest, better use a new label to track the image used to create service, and detect service need to be re-created after image has been re-built

**Related issue**
fix https://github.com/docker/compose-cli/issues/1983