### PR TITLE
Revert "introduce ImageDigestLabel to track image built for service"

### DIFF
--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -47,8 +47,6 @@ const (
 	OneoffLabel = "com.docker.compose.oneoff"
 	// SlugLabel stores unique slug used for one-off container identity
 	SlugLabel = "com.docker.compose.slug"
-	// ImageDigestLabel stores digest of the container image used to run service
-	ImageDigestLabel = "com.docker.compose.image"
 	// VersionLabel stores the compose tool version used to run application
 	VersionLabel = "com.docker.compose.version"
 )


### PR DESCRIPTION
Reverts docker/compose-cli#1997 as it wasn’t actually passing CI.