### PR TITLE
Lowercase project name for "compose down"

### DIFF
--- a/pkg/compose/down.go
+++ b/pkg/compose/down.go
@@ -37,7 +37,7 @@ type downOp func() error
 
 func (s *composeService) Down(ctx context.Context, projectName string, options api.DownOptions) error {
 	return progress.Run(ctx, func(ctx context.Context) error {
-		return s.down(ctx, projectName, options)
+		return s.down(ctx, strings.ToLower(projectName), options)
 	})
 }
 

--- a/pkg/compose/down_test.go
+++ b/pkg/compose/down_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	compose "github.com/docker/compose-cli/pkg/api"
@@ -47,11 +48,12 @@ func TestDown(t *testing.T) {
 	api.EXPECT().ContainerRemove(gomock.Any(), "456", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "789", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(testProject))}).Return([]moby.NetworkResource{{ID: "myProject_default"}}, nil)
+	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).Return([]moby.NetworkResource{{ID: "myProject_default"}},
+		nil)
 
 	api.EXPECT().NetworkRemove(gomock.Any(), "myProject_default").Return(nil)
 
-	err := tested.Down(context.Background(), testProject, compose.DownOptions{})
+	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{})
 	assert.NilError(t, err)
 }
 
@@ -72,11 +74,12 @@ func TestDownRemoveOrphans(t *testing.T) {
 	api.EXPECT().ContainerRemove(gomock.Any(), "789", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "321", moby.ContainerRemoveOptions{Force: true}).Return(nil)
 
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(testProject))}).Return([]moby.NetworkResource{{ID: "myProject_default"}}, nil)
+	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).Return([]moby.NetworkResource{{ID: "myProject_default"}},
+		nil)
 
 	api.EXPECT().NetworkRemove(gomock.Any(), "myProject_default").Return(nil)
 
-	err := tested.Down(context.Background(), testProject, compose.DownOptions{RemoveOrphans: true})
+	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{RemoveOrphans: true})
 	assert.NilError(t, err)
 }
 
@@ -92,11 +95,11 @@ func TestDownRemoveVolumes(t *testing.T) {
 	api.EXPECT().ContainerStop(gomock.Any(), "123", nil).Return(nil)
 	api.EXPECT().ContainerRemove(gomock.Any(), "123", moby.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
 
-	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(testProject))}).Return(nil, nil)
+	api.EXPECT().NetworkList(gomock.Any(), moby.NetworkListOptions{Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject)))}).Return(nil, nil)
 
-	api.EXPECT().VolumeList(gomock.Any(), filters.NewArgs(projectFilter(testProject))).Return(volume.VolumeListOKBody{Volumes: []*moby.Volume{{Name: "myProject_volume"}}}, nil)
+	api.EXPECT().VolumeList(gomock.Any(), filters.NewArgs(projectFilter(strings.ToLower(testProject)))).Return(volume.VolumeListOKBody{Volumes: []*moby.Volume{{Name: "myProject_volume"}}}, nil)
 	api.EXPECT().VolumeRemove(gomock.Any(), "myProject_volume", true).Return(nil)
 
-	err := tested.Down(context.Background(), testProject, compose.DownOptions{Volumes: true})
+	err := tested.Down(context.Background(), strings.ToLower(testProject), compose.DownOptions{Volumes: true})
 	assert.NilError(t, err)
 }

--- a/pkg/compose/kill_test.go
+++ b/pkg/compose/kill_test.go
@@ -19,6 +19,7 @@ package compose
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -41,7 +42,7 @@ func TestKillAll(t *testing.T) {
 	api := mocks.NewMockAPIClient(mockCtrl)
 	tested.apiClient = api
 
-	project := types.Project{Name: testProject, Services: []types.ServiceConfig{testService("service1"), testService("service2")}}
+	project := types.Project{Name: strings.ToLower(testProject), Services: []types.ServiceConfig{testService("service1"), testService("service2")}}
 
 	ctx := context.Background()
 	api.EXPECT().ContainerList(ctx, projectFilterListOpt()).Return(
@@ -60,7 +61,7 @@ func TestKillSignal(t *testing.T) {
 	api := mocks.NewMockAPIClient(mockCtrl)
 	tested.apiClient = api
 
-	project := types.Project{Name: testProject, Services: []types.ServiceConfig{testService("service1")}}
+	project := types.Project{Name: strings.ToLower(testProject), Services: []types.ServiceConfig{testService("service1")}}
 
 	ctx := context.Background()
 	api.EXPECT().ContainerList(ctx, projectFilterListOpt()).Return([]moby.Container{testContainer("service1", "123")}, nil)
@@ -89,7 +90,7 @@ func containerLabels(service string) map[string]string {
 		compose.ServiceLabel:     service,
 		compose.ConfigFilesLabel: composefile,
 		compose.WorkingDirLabel:  workingdir,
-		compose.ProjectLabel:     testProject}
+		compose.ProjectLabel:     strings.ToLower(testProject)}
 }
 
 func anyCancellableContext() gomock.Matcher {
@@ -100,7 +101,7 @@ func anyCancellableContext() gomock.Matcher {
 
 func projectFilterListOpt() moby.ContainerListOptions {
 	return moby.ContainerListOptions{
-		Filters: filters.NewArgs(projectFilter(testProject)),
+		Filters: filters.NewArgs(projectFilter(strings.ToLower(testProject))),
 		All:     true,
 	}
 }

--- a/pkg/compose/ps_test.go
+++ b/pkg/compose/ps_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -37,7 +38,7 @@ func TestPs(t *testing.T) {
 	tested.apiClient = api
 
 	ctx := context.Background()
-	args := filters.NewArgs(projectFilter(testProject))
+	args := filters.NewArgs(projectFilter(strings.ToLower(testProject)))
 	args.Add("label", "com.docker.compose.oneoff=False")
 	listOpts := moby.ContainerListOptions{Filters: args, All: true}
 	c1, inspect1 := containerDetails("service1", "123", "running", "healthy", 0)
@@ -49,12 +50,13 @@ func TestPs(t *testing.T) {
 	api.EXPECT().ContainerInspect(anyCancellableContext(), "456").Return(inspect2, nil)
 	api.EXPECT().ContainerInspect(anyCancellableContext(), "789").Return(inspect3, nil)
 
-	containers, err := tested.Ps(ctx, testProject, compose.PsOptions{})
+	containers, err := tested.Ps(ctx, strings.ToLower(testProject), compose.PsOptions{})
 
 	expected := []compose.ContainerSummary{
-		{ID: "123", Name: "123", Project: testProject, Service: "service1", State: "running", Health: "healthy", Publishers: nil},
-		{ID: "456", Name: "456", Project: testProject, Service: "service1", State: "running", Health: "", Publishers: []compose.PortPublisher{{URL: "localhost:80", TargetPort: 90, PublishedPort: 80}}},
-		{ID: "789", Name: "789", Project: testProject, Service: "service2", State: "exited", Health: "", ExitCode: 130, Publishers: nil},
+		{ID: "123", Name: "123", Project: strings.ToLower(testProject), Service: "service1", State: "running", Health: "healthy", Publishers: nil},
+		{ID: "456", Name: "456", Project: strings.ToLower(testProject), Service: "service1", State: "running", Health: "", Publishers: []compose.PortPublisher{{URL: "localhost:80", TargetPort: 90,
+			PublishedPort: 80}}},
+		{ID: "789", Name: "789", Project: strings.ToLower(testProject), Service: "service2", State: "exited", Health: "", ExitCode: 130, Publishers: nil},
 	}
 	assert.NilError(t, err)
 	assert.DeepEqual(t, containers, expected)

--- a/pkg/compose/stop_test.go
+++ b/pkg/compose/stop_test.go
@@ -18,6 +18,7 @@ package compose
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestStopTimeout(t *testing.T) {
 	api.EXPECT().ContainerStop(gomock.Any(), "789", &timeout).Return(nil)
 
 	err := tested.Stop(ctx, &types.Project{
-		Name: testProject,
+		Name: strings.ToLower(testProject),
 		Services: []types.ServiceConfig{
 			{Name: "service1"},
 			{Name: "service2"},

--- a/pkg/e2e/compose_test.go
+++ b/pkg/e2e/compose_test.go
@@ -62,7 +62,10 @@ func TestLocalComposeUp(t *testing.T) {
 	t.Run("top", func(t *testing.T) {
 		res := c.RunDockerCmd("compose", "-p", projectName, "top")
 		output := res.Stdout()
-		assert.Assert(t, strings.Contains(output, `UID    PID     PPID    C    STIME   TTY   TIME       CMD`), output)
+		head := []string{"UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"}
+		for _, h := range head {
+			assert.Assert(t, strings.Contains(output, h), output)
+		}
 		assert.Assert(t, strings.Contains(output, `java -Xmx8m -Xms8m -jar /app/words.jar`), output)
 		assert.Assert(t, strings.Contains(output, `/dispatcher`), output)
 	})
@@ -139,7 +142,7 @@ func TestDownComposefileInParentFolder(t *testing.T) {
 
 	tmpFolder, err := ioutil.TempDir("fixtures/simple-composefile", "test-tmp")
 	assert.NilError(t, err)
-	defer os.Remove(tmpFolder) //nolint: errcheck
+	defer os.Remove(tmpFolder) // nolint: errcheck
 	projectName := filepath.Base(tmpFolder)
 
 	res := c.RunDockerCmd("compose", "--project-directory", tmpFolder, "up", "-d")


### PR DESCRIPTION
**What I did**
Use strings.ToLower(projectName)

**Related issue**
Resolves https://github.com/docker/compose-cli/issues/2023

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
