### PR TITLE
introduce ImageDigestLabel to track image built for service

### DIFF
--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -47,6 +47,8 @@ const (
 	OneoffLabel = "com.docker.compose.oneoff"
 	// SlugLabel stores unique slug used for one-off container identity
 	SlugLabel = "com.docker.compose.slug"
+	// ImageDigestLabel stores digest of the container image used to run service
+	ImageDigestLabel = "com.docker.compose.image"
 	// VersionLabel stores the compose tool version used to run application
 	VersionLabel = "com.docker.compose.version"
 )

--- a/pkg/compose/create.go
+++ b/pkg/compose/create.go
@@ -60,7 +60,7 @@ func (s *composeService) create(ctx context.Context, project *types.Project, opt
 		return err
 	}
 
-	err = s.ensureImagesExists(ctx, project, observedState, options.QuietPull)
+	err = s.ensureImagesExists(ctx, project, options.QuietPull)
 	if err != nil {
 		return err
 	}

--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -33,12 +33,7 @@ import (
 )
 
 func (s *composeService) RunOneOffContainer(ctx context.Context, project *types.Project, opts api.RunOptions) (int, error) {
-	observedState, err := s.getContainers(ctx, project.Name, oneOffInclude, true)
-	if err != nil {
-		return 0, err
-	}
-
-	containerID, err := s.prepareRun(ctx, project, observedState, opts)
+	containerID, err := s.prepareRun(ctx, project, opts)
 	if err != nil {
 		return 0, err
 	}
@@ -131,7 +126,7 @@ func (s *composeService) runInteractive(ctx context.Context, containerID string,
 	}
 }
 
-func (s *composeService) prepareRun(ctx context.Context, project *types.Project, observedState Containers, opts api.RunOptions) (string, error) {
+func (s *composeService) prepareRun(ctx context.Context, project *types.Project, opts api.RunOptions) (string, error) {
 	service, err := project.GetService(opts.Service)
 	if err != nil {
 		return "", err
@@ -152,7 +147,7 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	service.Labels = service.Labels.Add(api.SlugLabel, slug)
 	service.Labels = service.Labels.Add(api.OneoffLabel, "True")
 
-	if err := s.ensureImagesExists(ctx, project, observedState, false); err != nil { // all dependencies already checked, but might miss service img
+	if err := s.ensureImagesExists(ctx, project, false); err != nil { // all dependencies already checked, but might miss service img
 		return "", err
 	}
 	if err := s.waitDependencies(ctx, project, service); err != nil {

--- a/pkg/compose/up.go
+++ b/pkg/compose/up.go
@@ -37,7 +37,10 @@ func (s *composeService) Up(ctx context.Context, project *types.Project, options
 		if err != nil {
 			return err
 		}
-		return s.start(ctx, project, options.Start, nil)
+		if options.Start.Attach == nil {
+			return s.start(ctx, project, options.Start, nil)
+		}
+		return nil
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**What I did**
don't override service.image with local digest, better use a new label to track the image used to create service, and detect service need to be re-created after image has been re-built

**Related issue**
fix #1983