### PR TITLE
prepare volume for service set by `run`

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -146,6 +146,9 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	}
 	service.Labels = service.Labels.Add(api.SlugLabel, slug)
 	service.Labels = service.Labels.Add(api.OneoffLabel, "True")
+	if err := prepareVolumes(project); err != nil { // all dependencies already checked, but might miss service img
+		return "", err
+	}
 
 	if err := s.ensureImagesExists(ctx, project, false); err != nil { // all dependencies already checked, but might miss service img
 		return "", err


### PR DESCRIPTION
**What I did**
invoke `prepareVolumes` on service targetted by `run` 
as the global prepare logic is only applied to dependencies by the `run` execution flow

**Related issue**
close https://github.com/docker/compose-cli/issues/2021