### PR TITLE
Update doc for ACI token renewal

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,7 +75,7 @@ and have created a service principal. You can create a service principle using
 the Azure CLI after you have done a `docker login azure`:
 
 ```console
-$ docker login azure
+$ az login # az login is not synced with docker azure login, need az login for next step
 $ az ad sp create-for-rbac --name 'MyTestServicePrincipal' --sdk-auth
 ```
 
@@ -108,6 +108,11 @@ You can then use the `e2e-ecs` target:
 ```console
 TEST_AWS_PROFILE=myProfile TEST_AWS_REGION=eu-west-3 make e2e-ecs
 ```
+
+## ACI CI
+
+ACI CI runs E2E tests and needs the same credentials as described above to run these. 3 secrets are defined in github settings, and accessed by the CI job.
+To rotate these secrets, run the same `az ad sp create-for-rbac` command and update 3 github secrets with the resulting new service provide info.
 
 ## Releases
 


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

minor updates to ACI token generation and renewal for CI

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
