### PR TITLE
update project's volumes_from before retrieving service

### DIFF
--- a/pkg/compose/run.go
+++ b/pkg/compose/run.go
@@ -127,6 +127,9 @@ func (s *composeService) runInteractive(ctx context.Context, containerID string,
 }
 
 func (s *composeService) prepareRun(ctx context.Context, project *types.Project, opts api.RunOptions) (string, error) {
+	if err := prepareVolumes(project); err != nil { // all dependencies already checked, but might miss service img
+		return "", err
+	}
 	service, err := project.GetService(opts.Service)
 	if err != nil {
 		return "", err
@@ -146,9 +149,6 @@ func (s *composeService) prepareRun(ctx context.Context, project *types.Project,
 	}
 	service.Labels = service.Labels.Add(api.SlugLabel, slug)
 	service.Labels = service.Labels.Add(api.OneoffLabel, "True")
-	if err := prepareVolumes(project); err != nil { // all dependencies already checked, but might miss service img
-		return "", err
-	}
 
 	if err := s.ensureImagesExists(ctx, project, false); err != nil { // all dependencies already checked, but might miss service img
 		return "", err


### PR DESCRIPTION
`prepareVolumes` MUST be ran _before_ we retrieve a `ServiceConfig` reference otherwise the copy we get isn't up-to-date with `volumes_from` set to actual container

**Related issue**

#fix https://github.com/docker/compose-cli/issues/2035
also require https://github.com/compose-spec/compose-go/pull/177