### PR TITLE
Don't exit with code != 0 on `compose ps` empty result

### DIFF
--- a/cmd/compose/ps.go
+++ b/cmd/compose/ps.go
@@ -124,10 +124,6 @@ SERVICES:
 		return fmt.Errorf("no such service: %s", s)
 	}
 
-	if len(containers) == 0 {
-		return api.ErrNotFound
-	}
-
 	if opts.Status != "" {
 		containers = filterByStatus(containers, opts.Status)
 	}

--- a/pkg/e2e/compose_run_test.go
+++ b/pkg/e2e/compose_run_test.go
@@ -68,7 +68,7 @@ func TestLocalComposeRun(t *testing.T) {
 	})
 
 	t.Run("compose run --rm", func(t *testing.T) {
-		res := c.RunDockerCmd("compose", "-f", "./fixtures/run-test/compose.yaml", "run", "--rm", "back", "/bin/sh", "-c", "echo Hello again")
+		res := c.RunDockerCmd("compose", "-f", "./fixtures/run-test/compose.yaml", "run", "--rm", "back", "echo", "Hello again")
 		lines := Lines(res.Stdout())
 		assert.Equal(t, lines[len(lines)-1], "Hello again", res.Stdout())
 


### PR DESCRIPTION
Don't exit with code != 0 when we succeed listing container but just none match compose project
Also includes a fix to e2e test flackyness

**Related issue**
close https://github.com/docker/compose-cli/issues/2057