### PR TITLE
fix release project to build with GIT_TAG

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Build
-        run: make -f builder.Makefile cross
+        run: make GIT_TAG=${{ github.event.inputs.tag }} -f builder.Makefile cross
 
       - name: License
         run: cp packaging/* bin/


### PR DESCRIPTION
**What I did**
fixed release workflow, to procude binary with GIT_TAG as internal.version