### PR TITLE
redirect compose v2 users to github.com/docker/compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,21 @@
-# Docker Compose CLI
+# Docker Compose "Cloud Integrations"
 
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Continuous%20integration/badge.svg)](https://github.com/docker/compose-cli/actions)
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Windows%20CI/badge.svg)](https://github.com/docker/compose-cli/actions)
 
-This Compose CLI tool makes it easy to run Docker containers and Docker Compose applications:
-* locally as a command in the docker CLI, using `docker compose ...` comands.
-* in the cloud using either Amazon Elastic Container Service
+This Compose CLI tool makes it easy to run Docker containers and Docker Compose applications in the cloud using either :
+- Amazon Elastic Container Service
 ([ECS](https://aws.amazon.com/ecs))
-or Microsoft Azure Container Instances
+- Microsoft Azure Container Instances
 ([ACI](https://azure.microsoft.com/services/container-instances))
-using the Docker commands you already know.
+- Kubernetes (Work in progress)
+
+...using the Docker commands you already know.
   
-**Note: Compose CLI is released under the 1.x tag, until "Compose v2" gets a new home**
+## :warning: Compose v2 (a.k.a "Local Docker Compose") has Moved
 
-## Compose v2 (a.k.a "Local Docker Compose")
-
-The `docker compose` local command is the next major version for docker-compose, and it supports the same commands and flags, in order to be used as a drop-in replacement.
-[Here](https://github.com/docker/compose-cli/issues/1283) is a checklist of docker-compose commands and flags that are implemented in `docker compose`.
-
-This `docker compose` local command :
-* has a better integration with the rest of the docker ecosystem (being written in go, it's easier to share functionality with the Docker CLI and other Docker libraries)
-* is quicker and uses more parallelism to run multiple tasks in parallel. It also uses buildkit by default
-* includes additional commands, like `docker compose ls` to list current compose projects
-
-**Note: Compose v2 is released under the 2.x tag, until "Compose v2" gets a new home**
-
-Compose v2 can be installed manually as a CLI plugin, by downloading latest v2.x release from https://github.com/docker/compose-cli/releases for your architecture and move into `~/.docker/cli-plugins/docker-compose`
+This repository is about "Cloud Integrations", the Docker Compose v2
+code has moved to [github.com/docker/compose](https://github.com/docker/compose/tree/v2) 
 
 ## Getting started
 


### PR DESCRIPTION
**What I did**

Document Compose V2 code has moved to github.com/docker/compose