### PR TITLE
Add support for manually-defined k8s deployment

### DIFF
--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -315,3 +315,23 @@ func (kc KubeClient) MapPortsToLocalhost(ctx context.Context, opts PortMappingOp
 	}
 	return eg.Wait()
 }
+
+func (kc KubeClient) GetManualReleases(ctx context.Context) ([]api.Stack, error) {
+	configMaps, err := kc.client.CoreV1().ConfigMaps(kc.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s,%s=%s", api.ProjectLabel, "com.docker.compose.manual", "true"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := []api.Stack{}
+	for _, configMap := range configMaps.Items {
+		result = append(result, api.Stack{
+			ID:     configMap.ObjectMeta.Labels[api.ProjectLabel],
+			Name:   configMap.ObjectMeta.Labels[api.ProjectLabel],
+			Status: "unknown",
+		})
+	}
+
+	return result, nil
+}

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -193,7 +193,18 @@ func (s *composeService) down(ctx context.Context, projectName string, options a
 
 // List executes the equivalent to a `docker stack ls`
 func (s *composeService) List(ctx context.Context, opts api.ListOptions) ([]api.Stack, error) {
-	return s.sdk.ListReleases()
+	manualReleases, err := s.client.GetManualReleases(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	helmReleases, err := s.sdk.ListReleases()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(manualReleases, helmReleases...), nil
 }
 
 // Build executes the equivalent to a `compose build`


### PR DESCRIPTION
**What I did**

I updated the kube backend to find projects using two different methods:

- Listing all Helm releases (which it currently does)
- Looking for ConfigMaps with a `com.docker.compose.manual` label on it

The idea here being that I can use my platform-preferred method to deploy the app itself (Flux/Argo, Kompose, other Compose tools, pipelines that push manifests, etc.), yet still allow the app teams to use the Compose tooling to view their application, access logs, exec into pods, etc.

As a note, for these "manual" deployments, I set the Stack status to `unknown`, as the Compose tooling has no indications of its health.

**Questions before merging**

I recognize that this PR might open up quite a few different ways to use Compose, so deserves adequate criticism/feedback. Some of the immediate questions I've already identified are: 

- I created the `com.docker.compose.manual` label and inlined it in the code. I see all other locations where labels are being used are referencing the name from the main compose project (eg `api.ProjectLabel`). Should this label be psuedo-standardized there? What should the label name actually be?
- Does it makes sense to generalize the idea of "who launched this stack?" I could see this feature being useful for the ECS and ACI backends as well. So, does it make sense to simply have a property on the Stack itself to indicate whether it's Compose-managed or not? That way, if I try to "down" a stack that's not Compose-managed, appropriate errors can be provided (right now, it just says "release not found").

**Related issue**

PoC implementation for #2040.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

A sloth... just because we like sloths...

![image](https://user-images.githubusercontent.com/746837/133491384-a2204539-9d77-4236-b42b-ed09b04a8dff.png)

