### PR TITLE
Allow compose exec to accept a specific instance in kube backend

### DIFF
--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -85,15 +85,21 @@ func (kc KubeClient) GetPod(ctx context.Context, projectName, serviceName string
 	if pods == nil {
 		return nil, nil
 	}
-	var pod corev1.Pod
+
+	for _, p := range pods.Items {
+		if p.Name == serviceName {
+			return &p, nil
+		}
+	}
+
 	for _, p := range pods.Items {
 		service := p.Labels[api.ServiceLabel]
 		if service == serviceName {
-			pod = p
-			break
+			return &p, nil
 		}
 	}
-	return &pod, nil
+
+	return nil, nil
 }
 
 // Exec executes a command in a container


### PR DESCRIPTION
**What I did**

This PR provides the ability to perform a `docker compose exec <pod-name|service-name>` in the kube context and serves as an implementation of #1920. It looks at the requested name to see if it matches a pod name and exec's to it if a match is found. Otherwise, it falls back to the current implementation where it finds a matching pod by service.

The big reason to do this is to allow teams to stay within the compose tooling and exec into specific instances. In a normal Docker context, a user can simply use `docker exec`. But, that doesn't work in a kube context. They can look at logs to potentially find a problem, but have to switch to another tool to exec to the specific instance they want. And having to switch to `kubectl` and making sure you're in the right context/namespace... would be nice to just make it easier. 😄 

**Outstanding questions**

- I noticed that the ACI and ECS integrations currently don't support exec. No need to update those. But, does it make sense to update the Docker context exec as well to let you specify a specific instance you get from `docker compose ps`?
- What CLI/web docs can/should be updated, especially if the main context is to be updated.

**Related issue**

Issue #1920