### PR TITLE
Point to correct backend when switching context

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -35,15 +35,14 @@ import (
 func New(ctx context.Context) (*Client, error) {
 	currentContext := apicontext.Current()
 	s := store.Instance()
-
 	cc, err := s.Get(currentContext)
 	if err != nil {
 		return nil, err
 	}
 
-	service := backend.Current()
-	if service == nil {
-		return nil, api.ErrNotFound
+	service, err := backend.Get(cc.Type())
+	if err != nil {
+		return nil, err
 	}
 
 	client := NewClient(cc.Type(), service)

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -20,6 +20,9 @@ var current string
 
 // WithCurrentContext sets the name of the current docker context
 func WithCurrentContext(contextName string) {
+	if contextName == "" {
+		contextName = "default"
+	}
 	current = contextName
 }
 

--- a/cli/server/interceptor.go
+++ b/cli/server/interceptor.go
@@ -101,7 +101,6 @@ func getIncomingContext(ctx context.Context) (string, error) {
 // needs: the context store and the api client
 func configureContext(ctx context.Context, currentContext string, method string) (context.Context, error) {
 	configDir := config.Dir()
-
 	apicontext.WithCurrentContext(currentContext)
 
 	// The contexts service doesn't need the client
@@ -111,6 +110,7 @@ func configureContext(ctx context.Context, currentContext string, method string)
 			return nil, err
 		}
 
+		ctx = context.WithValue(ctx, config.ContextTypeKey, c.ContextType())
 		ctx = proxy.WithClient(ctx, c)
 	}
 

--- a/cli/server/proxy/containers.go
+++ b/cli/server/proxy/containers.go
@@ -130,6 +130,21 @@ func (p *proxy) Logs(request *containersv1.LogsRequest, stream containersv1.Cont
 }
 
 func toGrpcContainer(c containers.Container) *containersv1.Container {
+	var hostConfig *containersv1.HostConfig
+	if c.HostConfig != nil {
+		hostConfig = &containersv1.HostConfig{
+			MemoryReservation: c.HostConfig.MemoryReservation,
+			MemoryLimit:       c.HostConfig.MemoryLimit,
+			CpuReservation:    uint64(c.HostConfig.CPUReservation),
+			CpuLimit:          uint64(c.HostConfig.CPULimit),
+			RestartPolicy:     c.HostConfig.RestartPolicy,
+			AutoRemove:        c.HostConfig.AutoRemove,
+		}
+	}
+	var labels []string
+	if c.Config != nil {
+		labels = c.Config.Labels
+	}
 	return &containersv1.Container{
 		Id:          c.ID,
 		Image:       c.Image,
@@ -140,16 +155,9 @@ func toGrpcContainer(c containers.Container) *containersv1.Container {
 		Platform:    c.Platform,
 		PidsCurrent: c.PidsCurrent,
 		PidsLimit:   c.PidsLimit,
-		Labels:      c.Config.Labels,
+		Labels:      labels,
 		Ports:       portsToGrpc(c.Ports),
-		HostConfig: &containersv1.HostConfig{
-			MemoryReservation: c.HostConfig.MemoryReservation,
-			MemoryLimit:       c.HostConfig.MemoryLimit,
-			CpuReservation:    uint64(c.HostConfig.CPUReservation),
-			CpuLimit:          uint64(c.HostConfig.CPULimit),
-			RestartPolicy:     c.HostConfig.RestartPolicy,
-			AutoRemove:        c.HostConfig.AutoRemove,
-		},
+		HostConfig:  hostConfig,
 		Healthcheck: &containersv1.Healthcheck{
 			Disable:  c.Healthcheck.Disable,
 			Test:     c.Healthcheck.Test,


### PR DESCRIPTION
Signed-off-by: Lorena Rangel <lorena.rangel@docker.com>

**What I did**
- Register the local backend as any other backend so it can be used when setting the backend service.
- When initializing the client, point to the actual backend used.


/test-aci

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests

* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![image](https://user-images.githubusercontent.com/9054169/137694626-9ebfbbf5-f828-401f-937c-203ae6f61089.png)
