### PR TITLE
Fix plugin command delegation for version

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -101,10 +101,14 @@ func isContextAgnosticCommand(cmd *cobra.Command) bool {
 	if cmd == nil {
 		return false
 	}
-	if _, ok := contextAgnosticCommands[cmd.Name()]; ok {
+	if _, ok := contextAgnosticCommands[cmd.Name()]; ok && isFirstLevelCommand(cmd) {
 		return true
 	}
 	return isContextAgnosticCommand(cmd.Parent())
+}
+
+func isFirstLevelCommand(cmd *cobra.Command) bool {
+	return !cmd.HasParent() || !cmd.Parent().HasParent()
 }
 
 func main() {


### PR DESCRIPTION
**What I did**
This makes the distinction between version command in "docker version" and "docker compose version"
In the second case it needs to delegate to the plugin.

Maybe another approach would be better. For example, with the full command chain as command identifier.
I just don't know if that's worth for now... Cases like this should remain very rare.