### PR TITLE
[ECS] Add support for passing in docker labels.

### DIFF
--- a/ecs/compatibility.go
+++ b/ecs/compatibility.go
@@ -84,6 +84,7 @@ var compatibleComposeAttributes = []string{
 	"services.healthcheck.timeout",
 	"services.image",
 	"services.init",
+	"services.labels",
 	"services.logging",
 	"services.logging.options",
 	"services.networks",

--- a/ecs/convert.go
+++ b/ecs/convert.go
@@ -115,6 +115,7 @@ func (b *ecsAPIService) createTaskDefinition(project *types.Project, service typ
 		DependsOnProp:          dependencies,
 		DnsSearchDomains:       service.DNSSearch,
 		DnsServers:             service.DNS,
+		DockerLabels:           service.Labels,
 		DockerSecurityOptions:  service.SecurityOpt,
 		EntryPoint:             service.Entrypoint,
 		Environment:            pairs,


### PR DESCRIPTION
**What I did**
I added support for passing docker labels into the provided ECS DockerLabels in cloud-formation.

**Related issue**
closes #2110 

