### PR TITLE
fix: panic with ec2 source less volumes

### DIFF
--- a/ecs/autoscaling_test.go
+++ b/ecs/autoscaling_test.go
@@ -32,7 +32,7 @@ services:
       x-aws-autoscaling: 
         cpu: 75
         max: 10
-`, useDefaultVPC)
+`, nil, useDefaultVPC)
 	target := template.Resources["FooScalableTarget"].(*autoscaling.ScalableTarget)
 	assert.Check(t, target != nil)            //nolint:staticcheck
 	assert.Check(t, target.MaxCapacity == 10) //nolint:staticcheck

--- a/ecs/ec2_test.go
+++ b/ecs/ec2_test.go
@@ -42,7 +42,7 @@ services:
             - discrete_resource_spec:
                 kind: gpus
                 value: 1                    
-`, useDefaultVPC)
+`, nil, useDefaultVPC)
 	lc := template.Resources["LaunchConfiguration"].(*autoscaling.LaunchConfiguration)
 	assert.Check(t, lc.ImageId == "ami123456789")
 	assert.Check(t, lc.InstanceType == "t0.femto")


### PR DESCRIPTION
**What I did**

I implemented a solution to check if a docker compose volume is with `source` field valid to avoid a panic on ec2 template creation.

**Related issue**
Use `docker compose up` with a 'wrong' compose file like this:
```
services:
  my-mongo:
    image: mongo
    volumes:
      - mongodata # here is the panic cause
volumes:
  mongodata:
```

Generates a panic:
```
goroutine 39 [running]:
github.com/docker/compose-cli/ecs.(*ecsAPIService).createTaskRole(0xc000400540, 0xc0009b6e60, 0xc000556240, 0x16, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3dd7288, ...)
	github.com/docker/compose-cli/ecs/cloudformation.go:465 +0x34a
github.com/docker/compose-cli/ecs.(*ecsAPIService).createService(0xc000400540, 0xc0009b6e60, 0xc000556240, 0x16, 0x0, 0x0, 0x0, 0x0, 0x0, 0x3dd7288, ...)
	github.com/docker/compose-cli/ecs/cloudformation.go:174 +0x118
github.com/docker/compose-cli/ecs.(*ecsAPIService).convert(0xc000400540, 0x2b9cec8, 0xc0009b9650, 0xc0009b6e60, 0x0, 0x0, 0xc00070c0f8)
	github.com/docker/compose-cli/ecs/cloudformation.go:153 +0x638
github.com/docker/compose-cli/ecs.(*ecsAPIService).Convert(0xc000400540, 0x2b9cec8, 0xc0009b9650, 0xc0009b6e60, 0x27a8987, 0x4, 0x0, 0x0, 0x0, 0x0, ...)
	github.com/docker/compose-cli/ecs/cloudformation.go:60 +0xb5
github.com/docker/compose-cli/ecs.(*ecsAPIService).Up(0xc000400540, 0x2b9cec8, 0xc0009b9650, 0xc0009b6e60, 0x0, 0x0, 0x0)
	github.com/docker/compose-cli/ecs/up.go:89 +0x17b
github.com/docker/compose-cli/api/compose.(*ServiceProxy).Up(0xc000562000, 0x2b9cec8, 0xc0009b9650, 0xc0009b6e60, 0x0, 0x0, 0x0)
	github.com/docker/compose-cli/api/compose/proxy.go:186 +0xd0
github.com/docker/compose-cli/cli/cmd/compose.runUp.func1(0x2b9cec8, 0xc0009b9650, 0x0, 0x0)
	github.com/docker/compose-cli/cli/cmd/compose/up.go:218 +0x63
github.com/docker/compose-cli/api/progress.Run.func1(0x2b9cec8, 0xc0009b9650, 0x0, 0x0, 0x0, 0x0)
	github.com/docker/compose-cli/api/progress/writer.go:60 +0x39
github.com/docker/compose-cli/api/progress.RunWithStatus.func2(0x0, 0x0)
	github.com/docker/compose-cli/api/progress/writer.go:81 +0x79
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0009b95f0, 0xc000469000)
	golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x66
```

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
*capivara* :brazil:  because YES

![capivara](https://static.mundoeducacao.uol.com.br/mundoeducacao/conteudo_legenda/cb208be7dd3f15c6831d98c1a36b441c.jpg)
