### PR TITLE
Support for armv7l (Raspberry).

### DIFF
--- a/scripts/install/install_linux.sh
+++ b/scripts/install/install_linux.sh
@@ -110,6 +110,8 @@ if [ "$(uname -m)" = "aarch64" ]; then
 	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-arm64" | cut -d : -f 2,3)}
 elif [ "$(uname -m)" = "s390x" ]; then
 	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-s390x" | cut -d : -f 2,3)}
+elif [ "$(uname -m)" = "armv7l" ]; then
+	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-armv7" | cut -d : -f 2,3)}
 else
 	DOWNLOAD_URL=${DOWNLOAD_URL:-$(curl -s ${RELEASE_URL} | grep "browser_download_url.*docker-linux-amd64" | cut -d : -f 2,3)}
 fi


### PR DESCRIPTION
**What I did**
[Compose Switch](https://docs.docker.com/compose/cli-command/#compose-switch) can now be automatically installed on `armv7l` (Raspberry).

Tested on my system, and I got it running successfully:
```
Running checks...
Warning: This script has been tested on Ubuntu and may not work on other distributions
Checks passed!
Downloading CLI...
Downloaded CLI!
Installing CLI...
Done!
```

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
