### PR TITLE
Remove the call to com.docker.cli to get the default context

### DIFF
--- a/api/context/store/store.go
+++ b/api/context/store/store.go
@@ -123,9 +123,6 @@ func New(rootDir string) (Store, error) {
 
 // Get returns the context with the given name
 func (s *store) Get(name string) (*DockerContext, error) {
-	if name == "default" {
-		return dockerDefaultContext()
-	}
 	meta := filepath.Join(s.root, contextsDir, metadataDir, contextDirOf(name), metaFile)
 	m, err := read(meta)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
**What I did**

Removed the call to com.docker.cli to get the default context that was [added here](https://github.com/docker/compose-cli/pull/401). This is no longer needed since the `docker compose` command was moved to a cli plugin for moby contexts

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/99933/151072867-987d4b69-f24e-425f-b6fd-9e75a51ccb69.png)
