### PR TITLE
Fix default behaviour for ecs flag `--tail` in log command

### DIFF
--- a/ecs/logs.go
+++ b/ecs/logs.go
@@ -42,7 +42,7 @@ func checkUnsupportedLogOptions(ctx context.Context, o api.LogOptions) error {
 		option            string
 	}{
 		{o.Since, "", "since"},
-		{o.Tail, "", "tail"},
+		{o.Tail, "all", "tail"},
 		{o.Timestamps, false, "timestamps"},
 		{o.Until, "", "until"},
 	}


### PR DESCRIPTION
**What I did**
Fix default behaviour for ecs flag `--tail`  in log command

**Related issue**
Resolves https://github.com/docker/compose/issues/9126

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
