### PR TITLE
metrics: fix unexpected usage output shown on cli

### DIFF
--- a/cli/metrics/metadata/build.go
+++ b/cli/metrics/metadata/build.go
@@ -174,14 +174,10 @@ func buildxDriver(dockercfg *configfile.ConfigFile, buildArgs []string) string {
 // buildxBuilder returns the builder being used in the build command
 func buildxBuilder(buildArgs []string) string {
 	var builder string
-	fset := pflag.NewFlagSet("buildx", pflag.ContinueOnError)
-	fset.String("builder", "", "")
-	_ = fset.ParseAll(buildArgs, func(flag *pflag.Flag, value string) error {
-		if flag.Name == "builder" {
-			builder = value
-		}
-		return nil
-	})
+	flags := pflag.NewFlagSet("buildx", pflag.ContinueOnError)
+	flags.Usage = func() {}
+	flags.StringVar(&builder, "builder", "", "")
+	_ = flags.Parse(buildArgs)
 	if len(builder) == 0 {
 		builder = os.Getenv("BUILDX_BUILDER")
 	}


### PR DESCRIPTION
**What I did**

Got a hard time to pinpoint this issue but finally found it comes from the cli proxy while parsing args with pflags for build metrics:

```
$ docker buildx inspect --help

Usage:  docker buildx inspect [NAME]

Inspect current builder instance

Options:
      --bootstrap        Ensure builder has booted before inspecting
      --builder string   Override the configured builder instance
Usage of buildx:
      --builder string
```

Now with flag set usage silenced:

```
$ docker buildx inspect --help

Usage:  docker buildx inspect [NAME]

Inspect current builder instance

Options:
      --bootstrap        Ensure builder has booted before inspecting
      --builder string   Override the configured builder instance
```

cc @tonistiigi

**Related issue**

* https://github.com/docker/buildx/issues/990

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>