### PR TITLE
Fix typo: change "cpu" to "cpus" in resources

### DIFF
--- a/docs/ecs-compose-features.md
+++ b/docs/ecs-compose-features.md
@@ -176,6 +176,6 @@ services:
         deploy:
           resources:
             limits:
-              cpu: '0.5'
+              cpus: '0.5'
               memory: 2Gb
 ```


### PR DESCRIPTION
Signed-off-by: Nahuel Soldevilla <nahuel@leafnode.io>

**What I did**
Fix typo: change "cpu" to "cpus" in resources example

**Related issue**
Fixes #2152
