### PR TITLE
Go 1.18

### DIFF
--- a/.github/workflows/aci-tests.yml
+++ b/.github/workflows/aci-tests.yml
@@ -29,23 +29,19 @@ jobs:
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-aci == 'true'
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Build for ACI e2e tests
         run: make -f builder.Makefile cli

--- a/.github/workflows/aci-tests.yml
+++ b/.github/workflows/aci-tests.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  GO_VERSION: 1.18
+
 jobs:
   check-optional-tests:
     name: Check if needs to run ACI tests
@@ -23,16 +26,13 @@ jobs:
   aci-tests:
     name: ACI e2e tests
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-aci == 'true'
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup docker CLI
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,18 @@ on:
       - main
   pull_request:
 
+env:
+  GO_VERSION: 1.18
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         env:
           BUILD_TAGS: kube,e2e
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin/ v1.39.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin/ v1.45.2
           make -f builder.Makefile lint
 
   # only on main branch, costs too much for the gain on every PR
@@ -37,14 +37,11 @@ jobs:
     name: Validate cross build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    env:
-      GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
@@ -62,18 +59,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Set up gosum
         run: |
-          go get -u gotest.tools/gotestsum
+          go install gotest.tools/gotestsum@latest
 
       - name: Setup docker CLI
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
+          cache: true
 
       - name: Validate go-mod is up-to-date and license headers
         run: make validate
@@ -38,18 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
+          cache: true
 
       # Ensure we don't discover cross platform build issues at release time.
       # Time used to build linux here is gained back in the build for local E2E step
@@ -60,10 +57,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Set up gosum
         run: |
@@ -73,14 +74,6 @@ jobs:
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Test
         env:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -18,25 +18,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Build
         run: make GIT_TAG=${{ github.event.inputs.tag }} -f builder.Makefile cross

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -10,15 +10,18 @@ on:
         description: 'Dry run'
         required: false
         default: 'true'
+
+env:
+  GO_VERSION: 1.18
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup docker CLI
         run: |

--- a/.github/workflows/ecs-tests.yml
+++ b/.github/workflows/ecs-tests.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  GO_VERSION: 1.18
+
 jobs:
   check-optional-tests:
     name: Check if needs to run ECS tests
@@ -20,20 +23,16 @@ jobs:
         with:
           trigger: '/test-ecs'
 
-
   ecs-tests:
     name: ECS e2e tests
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-ecs == 'true'
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup docker CLI
         run: |

--- a/.github/workflows/ecs-tests.yml
+++ b/.github/workflows/ecs-tests.yml
@@ -29,23 +29,19 @@ jobs:
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-ecs == 'true'
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
           curl https://download.docker.com/linux/static/stable/x86_64/docker-20.10.3.tgz | tar xz
           sudo cp ./docker/docker /usr/bin/ && rm -rf docker && docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Build for ECS e2e tests
         run: make -f builder.Makefile cli

--- a/.github/workflows/kube-tests.yml
+++ b/.github/workflows/kube-tests.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  GO_VERSION: 1.18
+
 jobs:
   check-optional-tests:
     name: Check if needs to run Kube tests
@@ -20,20 +23,16 @@ jobs:
         with:
           trigger: '/test-kube'
 
-
   kube-tests:
     name: Kube e2e tests
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: "on"
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-kube == 'true'
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup docker CLI
         run: |

--- a/.github/workflows/kube-tests.yml
+++ b/.github/workflows/kube-tests.yml
@@ -29,10 +29,14 @@ jobs:
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-kube == 'true'
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
@@ -44,14 +48,6 @@ jobs:
           sudo apt-get install jq && jq --version
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/bin/ && kind version
           curl -LO "https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl" && sudo mv kubectl /usr/bin/ && kubectl version --client
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Build for Kube e2e tests
         env:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  GO_VERSION: 1.18
+
 jobs:
   check-optional-tests:
     name: Check if needs to run Windows build and tests
@@ -20,7 +23,6 @@ jobs:
         with:
           trigger: '/test-windows'
 
-
   windows-build:
     name: Windows Build
     runs-on: windows-latest
@@ -29,11 +31,10 @@ jobs:
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-windows == 'true'
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
-        id: go
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup docker CLI
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -31,10 +31,14 @@ jobs:
     needs: check-optional-tests
     if: github.ref == 'refs/heads/main' || needs.check-optional-tests.outputs.trigger-windows == 'true'
     steps:
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Setup docker CLI
         run: |
@@ -42,14 +46,6 @@ jobs:
           curl -L -o docker.exe https://github.com/StefanScherer/docker-cli-builder/releases/download/20.10.5/docker.exe
           mv -Force ./docker.exe "C:\Program Files\Docker\"
           docker version
-
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ hashFiles('**/go.sum') }}
 
       - name: Test
         run: make -f builder.Makefile test

--- a/aci/convert/secrets.go
+++ b/aci/convert/secrets.go
@@ -136,7 +136,7 @@ func validateMountPathCollisions(vms []containerinstance.VolumeMount) error {
 				}
 			}
 			if isPrefixed {
-				return errors.Errorf("mount paths %q and %q collide. A volume mount cannot include another one.", *vm1.MountPath, *vm2.MountPath)
+				return errors.Errorf("mount paths %q and %q collide. A volume mount cannot include another one", *vm1.MountPath, *vm2.MountPath)
 			}
 		}
 	}

--- a/aci/convert/secrets_test.go
+++ b/aci/convert/secrets_test.go
@@ -149,7 +149,7 @@ func TestConvertSecrets(t *testing.T) {
 
 		_, err := service.getAciSecretsVolumeMounts()
 		assert.Equal(t, err.Error(),
-			fmt.Sprintf(`mount paths %q and %q collide. A volume mount cannot include another one.`,
+			fmt.Sprintf(`mount paths %q and %q collide. A volume mount cannot include another one`,
 				path.Dir(targetName1), path.Dir(targetName2)))
 	})
 
@@ -173,7 +173,7 @@ func TestConvertSecrets(t *testing.T) {
 
 		_, err := service.getAciSecretsVolumeMounts()
 		assert.Equal(t, err.Error(),
-			fmt.Sprintf(`mount paths %q and %q collide. A volume mount cannot include another one.`,
+			fmt.Sprintf(`mount paths %q and %q collide. A volume mount cannot include another one`,
 				path.Dir(targetName1), path.Dir(targetName2)))
 	})
 }

--- a/aci/e2e/aci-demo/web/Dockerfile
+++ b/aci/e2e/aci-demo/web/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 # BUILD
-FROM golang:1.16-alpine AS build
+FROM golang:1.18-alpine AS build
 COPY dispatcher.go .
 RUN mkdir -p /out && go build -o /out/dispatcher dispatcher.go
 

--- a/aci/e2e/aci_secrets_resources/web/Dockerfile
+++ b/aci/e2e/aci_secrets_resources/web/Dockerfile
@@ -15,7 +15,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.16-alpine AS build
+FROM golang:1.18-alpine AS build
 COPY main.go .
 RUN --mount=type=cache,target=/go/pkg/mod \
     go build -trimpath -ldflags="-s -w" -o server main.go

--- a/aci/etchosts/Dockerfile
+++ b/aci/etchosts/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.16 AS builder
+FROM golang:1.18 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/aci/etchosts
 COPY . .
 RUN GO111MODULE=auto CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/hosts main/main.go

--- a/aci/login/login.go
+++ b/aci/login/login.go
@@ -289,12 +289,12 @@ func (login *azureLoginService) GetValidToken() (oauth2.Token, string, error) {
 
 	ce, err := login.cloudEnvironmentSvc.Get(loginInfo.CloudEnvironment)
 	if err != nil {
-		return oauth2.Token{}, "", errors.Wrap(err, "access token request failed--cloud environment could not be determined.")
+		return oauth2.Token{}, "", errors.Wrap(err, "access token request failed--cloud environment could not be determined")
 	}
 
 	token, err = login.refreshToken(token.RefreshToken, tenantID, ce)
 	if err != nil {
-		return oauth2.Token{}, "", errors.Wrap(err, "access token request failed. Maybe you need to login to Azure again.")
+		return oauth2.Token{}, "", errors.Wrap(err, "access token request failed. Maybe you need to login to Azure again")
 	}
 	err = login.tokenStore.writeLoginInfo(TokenInfo{TenantID: tenantID, Token: token, CloudEnvironment: ce.Name})
 	if err != nil {

--- a/cli/cmd/context/create_kube.go
+++ b/cli/cmd/context/create_kube.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/cli/metrics/conn_other.go
+++ b/cli/metrics/conn_other.go
@@ -1,4 +1,4 @@
-//go:build !windows,!darwin
+//go:build !windows && !darwin
 // +build !windows,!darwin
 
 /*

--- a/cli/mobycli/exec_unix.go
+++ b/cli/mobycli/exec_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cli/mobycli/resolvepath/lp_unix.go
+++ b/cli/mobycli/resolvepath/lp_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cli/server/socket_unix.go
+++ b/cli/server/socket_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cli/server/socket_windows.go
+++ b/cli/server/socket_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/ecs/resolv/Dockerfile
+++ b/ecs/resolv/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.16 AS builder
+FROM golang:1.18 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/resolv
 COPY . .
 RUN GO111MODULE=auto CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/resolv main/main.go

--- a/ecs/secrets/Dockerfile
+++ b/ecs/secrets/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.16 AS builder
+FROM golang:1.18 AS builder
 WORKDIR $GOPATH/src/github.com/docker/compose-cli/ecs/secrets
 COPY . .
 RUN GO111MODULE=auto CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/secrets main/main.go

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/docker/compose-cli
 
-go 1.16
+go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.3
-	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
 	github.com/Azure/azure-sdk-for-go v48.2.0+incompatible
 	github.com/Azure/azure-storage-file-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.11.12
@@ -13,7 +12,6 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/Azure/go-autorest/autorest/to v0.4.0
-	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/Microsoft/go-winio v0.4.17
 	github.com/aws/aws-sdk-go v1.35.33
 	github.com/awslabs/goformation/v4 v4.15.6
@@ -28,9 +26,6 @@ require (
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
-	github.com/fatih/color v1.9.0 // indirect
-	github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee // indirect
-	github.com/gobwas/pool v0.2.0 // indirect
 	github.com/gobwas/ws v1.0.4
 	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.5.2
@@ -40,21 +35,16 @@ require (
 	github.com/iancoleman/strcase v0.1.2
 	github.com/joho/godotenv v1.3.0
 	github.com/labstack/echo v3.3.10+incompatible
-	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/tsdb v0.10.0
-	github.com/rogpeppe/go-internal v1.5.2 // indirect
 	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
 	github.com/sirupsen/logrus v1.8.1
-	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/valyala/fasttemplate v1.2.1 // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
@@ -69,8 +59,164 @@ require (
 	k8s.io/apimachinery v0.21.0
 	k8s.io/cli-runtime v0.21.0
 	k8s.io/client-go v0.21.0
-	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.10.15
+)
+
+require (
+	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
+	github.com/Masterminds/squirrel v1.5.0 // indirect
+	github.com/Microsoft/hcsshim v0.8.24 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cnabio/cnab-go v0.10.0-beta1 // indirect
+	github.com/compose-spec/godotenv v1.1.1 // indirect
+	github.com/containerd/cgroups v1.0.3 // indirect
+	github.com/containerd/continuity v0.1.0 // indirect
+	github.com/containerd/typeurl v1.0.2 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dimchansky/utfbom v1.1.0 // indirect
+	github.com/docker/buildx v0.5.2-0.20210422185057-908a856079fc // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.6.4-0.20210125172408-38bea2ce277a // indirect
+	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/fvbommel/sortorder v1.0.1 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee // indirect
+	github.com/gobwas/pool v0.2.0 // indirect
+	github.com/gofrs/flock v0.8.0 // indirect
+	github.com/gogo/googleapis v1.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gosuri/uitable v0.0.4 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/huandu/xstrings v1.3.1 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jmoiron/sqlx v1.3.1 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/klauspost/compress v1.11.13 // indirect
+	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/lib/pq v1.10.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-ieproxy v0.0.1 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-runewidth v0.0.7 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/miekg/pkcs11 v1.0.3 // indirect
+	github.com/mitchellh/copystructure v1.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/moby/buildkit v0.8.2-0.20210401015549-df49b648c8bf // indirect
+	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/moby/sys/mount v0.2.0 // indirect
+	github.com/moby/sys/mountinfo v0.4.1 // indirect
+	github.com/moby/sys/symlink v0.1.0 // indirect
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/opencontainers/runc v1.0.2 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/oras-project/oras-go v0.1.0 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.7.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/qri-io/jsonpointer v0.1.0 // indirect
+	github.com/qri-io/jsonschema v0.1.1 // indirect
+	github.com/rogpeppe/go-internal v1.5.2 // indirect
+	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351 // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/smartystreets/assertions v1.0.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/theupdateframework/notary v0.6.1 // indirect
+	github.com/tonistiigi/fsutil v0.0.0-20201103201449-0834f99b7b85 // indirect
+	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.1 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	gopkg.in/gorp.v1 v1.7.2 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/apiextensions-apiserver v0.21.0 // indirect
+	k8s.io/apiserver v0.21.0 // indirect
+	k8s.io/component-base v0.21.0 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/kubectl v0.21.0 // indirect
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	rsc.io/letsencrypt v0.0.3 // indirect
+	sigs.k8s.io/kustomize/api v0.8.5 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // (for buildx)

--- a/go.sum
+++ b/go.sum
@@ -129,7 +129,6 @@ github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg3
 github.com/Microsoft/hcsshim v0.8.14/go.mod h1:NtVKoYxQuTLx6gEq0L96c9Ju4JbRJ4nY2ow3VK6a9Lg=
 github.com/Microsoft/hcsshim v0.8.15/go.mod h1:x38A4YbHbdxJtc0sF6oIz+RG0npwSCAvn69iY6URG00=
 github.com/Microsoft/hcsshim v0.8.16/go.mod h1:o5/SZqmR7x9JNKsW3pu+nqHm0MF8vbA+VxGOoXdC600=
-github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.8.24 h1:jP+GMeRXIR1sH1kG4lJr9ShmSjVrua5jmFZDtfYGkn4=
 github.com/Microsoft/hcsshim v0.8.24/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
@@ -227,7 +226,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -304,7 +302,6 @@ github.com/containerd/containerd v1.5.0-beta.3/go.mod h1:/wr9AVtEM7x9c+n0+stptlo
 github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09ZvgqEq8EfBp/m3lcVZIvPHhI=
 github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoTJseu1FGOKuoA4nNb2s=
 github.com/containerd/containerd v1.5.0-rc.3/go.mod h1:kYiJ+LvywDUKzyax6+UKCk5xwQNCfcGR6KsSdShdg5U=
-github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/containerd v1.5.13 h1:XqvKw9i4P7/mFrC3TSM7yV5cwFZ9avXe6M3YANKnzEE=
 github.com/containerd/containerd v1.5.13/go.mod h1:3AlCrzKROjIuP3JALsY14n8YtntaUDBu7vek+rPN5Vc=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -423,9 +420,7 @@ github.com/docker/cli v20.10.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHv
 github.com/docker/cli v20.10.6+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.7+incompatible h1:pv/3NqibQKphWZiAskMzdz8w0PRbtTaEB+f6NwdU7Is=
 github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli-docs-tool v0.1.1/go.mod h1:oMzPNt1wC3TcxuY22GMnOODNOxkwGH51gV3AhqAjFQ4=
 github.com/docker/compose-on-kubernetes v0.4.19-0.20190128150448-356b2919c496/go.mod h1:iT2pYfi580XlpaV4KmK0T6+4/9+XoKmk/fhoDod1emE=
-github.com/docker/compose-switch v1.0.2/go.mod h1:uyPj8S3oH1O9rSZ5QVozw28OIjdNIflSSYElC2P0plQ=
 github.com/docker/compose/v2 v2.2.0 h1:tkkB4MCl1E+268dd6VpAwvUc8DQqGPgesbMb0Qngbc4=
 github.com/docker/compose/v2 v2.2.0/go.mod h1:gxNxC8jKXZHD0P9LC4TH981aggWeKMzb89RuRoBnEmY=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
@@ -891,7 +886,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8 h1:AkaSdXYQOWeaO3neb8EM634ahkXXe3jYbVh/F9lq+GI=
-github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -1990,7 +1984,6 @@ k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -2024,7 +2017,6 @@ sigs.k8s.io/kustomize/cmd/config v0.9.7/go.mod h1:MvXCpHs77cfyxRmCNUQjIqCmZyYsbn
 sigs.k8s.io/kustomize/kustomize/v4 v4.0.5/go.mod h1:C7rYla7sI8EnxHE/xEhRBSHMNfcL91fx0uKmUlUhrBk=
 sigs.k8s.io/kustomize/kyaml v0.10.15 h1:dSLgG78KyaxN4HylPXdK+7zB3k7sW6q3IcCmcfKA+aI=
 sigs.k8s.io/kustomize/kyaml v0.10.15/go.mod h1:mlQFagmkm1P+W4lZJbJ/yaxMd8PqMRSC4cPcfUVt5Hg=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/kube/backend.go
+++ b/kube/backend.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/client/client_test.go
+++ b/kube/client/client_test.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/client/utils.go
+++ b/kube/client/utils.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/compose.go
+++ b/kube/compose.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/context.go
+++ b/kube/context.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/context_test.go
+++ b/kube/context_test.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/helm/chart.go
+++ b/kube/helm/chart.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/helm/helm.go
+++ b/kube/helm/helm.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/context.go
+++ b/kube/resources/context.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/kube.go
+++ b/kube/resources/kube.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/kube_test.go
+++ b/kube/resources/kube_test.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/placement.go
+++ b/kube/resources/placement.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/placement_test.go
+++ b/kube/resources/placement_test.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/pod.go
+++ b/kube/resources/pod.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/pod_test.go
+++ b/kube/resources/pod_test.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/secrets.go
+++ b/kube/resources/secrets.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*

--- a/kube/resources/volumes.go
+++ b/kube/resources/volumes.go
@@ -1,3 +1,4 @@
+//go:build kube
 // +build kube
 
 /*


### PR DESCRIPTION
I plan to switch from shelling out to retrieve docker cli version by using the [`debug/buildinfo` module](https://pkg.go.dev/debug/buildinfo) in https://github.com/docker/compose-cli/pull/2151 that will give resp time <1ms but this package is available since Go 1.18: https://github.com/crazy-max/compose-cli/commit/ec18d50cfc97fb2a3163a0f0187e6e523a272b51

Also upgrading to Go 1.18 will slightly improve response time of the compose-cli itself:

```
CliVersionViaComposeCli/compose-cli-1.0.26-docker-20.10.17     70.8ms ± 0%
CliVersionViaComposeCli/compose-cli-go-1.18-docker-20.10.17    62.5ms ± 0%
```

cc @tonistiigi @glours @rumpl 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>