### PR TITLE
update gotest.tools to v3.3.0 which support golang 1.18

### DIFF
--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 type caze struct {

--- a/cli/mobycli/pat_suggest_test.go
+++ b/cli/mobycli/pat_suggest_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/registry"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestIsUsingDefaultRegistry(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,7 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/ini.v1 v1.62.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-	gotest.tools v2.2.0+incompatible
-	gotest.tools/v3 v3.0.3
+	gotest.tools/v3 v3.3.0
 	helm.sh/helm/v3 v3.6.1-0.20210722154129-5946457ce9ea
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1924,8 +1924,9 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
+gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
+gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 helm.sh/helm/v3 v3.6.1-0.20210722154129-5946457ce9ea h1:KDEGuai0v16xSO6Uh1DdpX5ws03r0/aS1VQxIF7cvfI=
 helm.sh/helm/v3 v3.6.1-0.20210722154129-5946457ce9ea/go.mod h1:dhTe384gzV1a7PMMBBF5M834+aY/ui4mar2udF0Kabs=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
**What I did**
Update `gotest.tools` to a version which support golang `1.18.x`

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/180755091-ff0caf53-18e6-44b2-9c44-9b25ba50e5f6.png)
