### PR TITLE
gofmt files with go 1.19

### DIFF
--- a/aci/login/login.go
+++ b/aci/login/login.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-//go login process, derived from code sample provided by MS at https://github.com/devigned/go-az-cli-stuff
+// go login process, derived from code sample provided by MS at https://github.com/devigned/go-az-cli-stuff
 const (
 	clientID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" // Azure CLI client id
 )

--- a/kube/client/client.go
+++ b/kube/client/client.go
@@ -285,7 +285,7 @@ func (kc KubeClient) WaitForPodState(ctx context.Context, opts WaitForStatusOpti
 	return nil
 }
 
-//MapPortsToLocalhost runs a port-forwarder daemon process
+// MapPortsToLocalhost runs a port-forwarder daemon process
 func (kc KubeClient) MapPortsToLocalhost(ctx context.Context, opts PortMappingOptions) error {
 	stopChannel := make(chan struct{}, 1)
 	readyChannel := make(chan struct{})

--- a/kube/helm/chart.go
+++ b/kube/helm/chart.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-//ConvertToChart convert Kube objects to helm chart
+// ConvertToChart convert Kube objects to helm chart
 func ConvertToChart(name string, objects map[string]runtime.Object) (*chart.Chart, error) {
 
 	files := []*loader.BufferedFile{

--- a/kube/resources/kube.go
+++ b/kube/resources/kube.go
@@ -39,7 +39,7 @@ const (
 	clusterIPHeadless = "None"
 )
 
-//MapToKubernetesObjects maps compose project to Kubernetes objects
+// MapToKubernetesObjects maps compose project to Kubernetes objects
 func MapToKubernetesObjects(project *types.Project) (map[string]runtime.Object, error) {
 	objects := map[string]runtime.Object{}
 

--- a/utils/e2e/framework.go
+++ b/utils/e2e/framework.go
@@ -286,7 +286,7 @@ func GoldenFile(name string) string {
 	return name + ".golden"
 }
 
-//Lines split output into lines
+// Lines split output into lines
 func Lines(output string) []string {
 	return strings.Split(strings.TrimSpace(output), "\n")
 }


### PR DESCRIPTION
Prepare for future updates of Go, which may result in some changes in
formatting in GoDoc comments.

**What I did**

Ran `gofmt -s -w .` with go 1.19rc2

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
