### PR TITLE
cli binary path handling

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"runtime"
 
 	"github.com/docker/compose/v2/pkg/compose"
 	"github.com/docker/compose/v2/pkg/utils"
@@ -38,7 +39,13 @@ import (
 var delegatedContextTypes = []string{store.DefaultContextType}
 
 // ComDockerCli name of the classic cli binary
-const ComDockerCli = "com.docker.cli"
+var ComDockerCli = "com.docker.cli"
+
+func init() {
+	if runtime.GOOS == "windows" {
+		ComDockerCli += ".exe"
+	}
+}
 
 // ExecIfDefaultCtxType delegates to com.docker.cli if on moby context
 func ExecIfDefaultCtxType(ctx context.Context, root *cobra.Command) {


### PR DESCRIPTION
**What I did**

Update the way we choose which `com.docker.cli` binary executable to use.

1. Use path from env variable `$DOCKER_COM_DOCKER_CLI` if defined and non-empty
2. Use path formed from parent directory of current process executable joined with
   `com.docker.cli`
3. Look for `com.docker.cli` on $PATH


**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![Butterfly](https://images.pexels.com/photos/462118/pexels-photo-462118.jpeg?auto=compress&w=720)
