### PR TITLE
Fix Windows e2e-local test

### DIFF
--- a/local/e2e/cli-only/e2e_test.go
+++ b/local/e2e/cli-only/e2e_test.go
@@ -30,6 +30,7 @@ import (
 	"gotest.tools/v3/golden"
 	"gotest.tools/v3/icmd"
 
+	"github.com/docker/compose-cli/cli/mobycli"
 	. "github.com/docker/compose-cli/utils/e2e"
 )
 
@@ -354,7 +355,7 @@ func TestMissingExistingCLI(t *testing.T) {
 	res := icmd.RunCmd(c)
 	res.Assert(t, icmd.Expected{
 		ExitCode: 1,
-		Err:      `"com.docker.cli": executable file not found`,
+		Err:      fmt.Sprintf(`"%s": executable file not found`, mobycli.ComDockerCli),
 	})
 }
 


### PR DESCRIPTION
**What I did**

Fix failing Windows test on main

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
