### PR TITLE
fix ecs docs reference to service.deployment

### DIFF
--- a/docs/ecs-compose-features.md
+++ b/docs/ecs-compose-features.md
@@ -35,7 +35,7 @@ __Legend:__
 | service.deploy.placement       | ✓ |  Used with EC2 support to select a machine type and AMI
 | service.deploy.update_config   | ✓ |
 | service.deploy.resources       | ✓ |  Fargate resource is selected with the lowest instance type for configured memory and cpu
-| service.deploy.restart_policy  | ✓ |
+| service.deploy.restart_policy  | x |
 | service.deploy.labels          | ✓ |
 | service.devices                | x |
 | service.depends_on             | ✓ |  Implemented using CloudFormation Depends_on
@@ -70,7 +70,7 @@ __Legend:__
 | service.ulimits                | ✓ |  Only support `nofile` ulimit due to Fargate limitations
 | service.userns_mode            | x |
 | service.volumes                | ✓ |  Mapped to EFS File Systems. See [Persistent volumes](#persistent-volumes).
-| service.restart                | x |  Replaced by service.deploy.restart_policy
+| service.restart                | x |
 |                                |   |
 | __Volume__                     | x |
 | driver                         | ✓ |  See [Persistent volumes](#persistent-volumes).

--- a/docs/ecs-compose-features.md
+++ b/docs/ecs-compose-features.md
@@ -70,7 +70,7 @@ __Legend:__
 | service.ulimits                | ✓ |  Only support `nofile` ulimit due to Fargate limitations
 | service.userns_mode            | x |
 | service.volumes                | ✓ |  Mapped to EFS File Systems. See [Persistent volumes](#persistent-volumes).
-| service.restart                | x |  Replaced by service.deployment.restart_policy
+| service.restart                | x |  Replaced by service.deploy.restart_policy
 |                                |   |
 | __Volume__                     | x |
 | driver                         | ✓ |  See [Persistent volumes](#persistent-volumes).


### PR DESCRIPTION
**What I did**
Changes an entry in the `docs/ecs-compose-features.md`'s "Compose fields mapping" table so that `service.deploy.restart_policy` is an `x` instead of a `✓` also removes a note from the `service.restart` item which is incorrect.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
fixes #2153
note: this pr was originally for bogus issue #2182

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

