### PR TITLE
docs: applies wording suggested in #2154

### DIFF
--- a/docs/aci-container-features.md
+++ b/docs/aci-container-features.md
@@ -6,7 +6,7 @@ keywords: Docker, Azure, Integration, ACI, container, cli, deploy, cloud
 # Azure Container Instances: running single containers
 
 Single containers can be executed on ACI with the `docker run` command.
-A single container is executed in its own ACI container group, that will container only one container.
+A single container is executed in its own ACI container group, which will contain a single container.
 
 Containers can be listed with the `docker ps` command, and stopped and removed with `docker stop <CONTAINER>` and `docker rm <CONTAINER>`.
 


### PR DESCRIPTION
**What I did**
I applied a wording fix to `docs/aci-container-features.md` suggested in #2154, wherein the sentence:

> A single container is executed in its own ACI container group, that will container only one container.

becomes:

> A single container is executed in its own ACI container group, which will contain a single container.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
closes #2154

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->