### PR TITLE
Added Linux/ARM64 to ECS sidecar builds fixes #2190 and #2115

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,16 +116,16 @@ publish-aci-sidecar: build-aci-sidecar ## build & publish aci sidecar image with
 	docker pull docker/aci-hostnames-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/aci-hostnames-sidecar:$(tag)
 
 build-ecs-search-sidecar:  ## build ecs search sidecar image locally and tag it with make build-ecs-search-sidecar tag=0.1
-	docker build -t docker/ecs-searchdomain-sidecar:$(tag) ecs/resolv
+	docker buildx build --platform linux/amd64,linux/arm64 -t docker/ecs-searchdomain-sidecar:$(tag) ecs/resolv
 
 publish-ecs-search-sidecar: build-ecs-search-sidecar ## build & publish ecs search sidecar image with make publish-ecs-search-sidecar tag=0.1
-	docker pull docker/ecs-searchdomain-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/ecs-searchdomain-sidecar:$(tag)
+	docker pull docker/ecs-searchdomain-sidecar:$(tag) && echo "Failure: Tag already exists" || docker buildx build --push --platform linux/amd64,linux/arm64 -t docker/ecs-searchdomain-sidecar:$(tag) ecs/resolv
 
 build-ecs-secrets-sidecar:  ## build ecs secrets sidecar image locally and tag it with make build-ecs-secrets-sidecar tag=0.1
-	docker build -t docker/ecs-secrets-sidecar:$(tag) ecs/secrets
+	docker buildx build --platform linux/amd64,linux/arm64 -t docker/ecs-secrets-sidecar:$(tag) ecs/secrets
 
 publish-ecs-secrets-sidecar: build-ecs-secrets-sidecar ## build & publish ecs secrets sidecar image with make publish-ecs-secrets-sidecar tag=0.1
-	docker pull docker/ecs-secrets-sidecar:$(tag) && echo "Failure: Tag already exists" || docker push docker/ecs-secrets-sidecar:$(tag)
+	docker pull docker/ecs-secrets-sidecar:$(tag) && echo "Failure: Tag already exists" || docker buildx build --push --platform linux/amd64,linux/arm64 -t docker/ecs-secrets-sidecar:$(tag) ecs/secrets
 
 clean-aci-e2e: ## Make sure no ACI tests are currently runnnig in the CI when invoking this. Delete ACI E2E tests resources that might have leaked when ctrl-C E2E tests.
 	@ echo "Will delete resource groups: "


### PR DESCRIPTION
**What I did**
Updated `Makefile` to use `docker buildx` to build the ECS sidecar images for both AMD64 and ARM64.

**Related issue**
ECS Fargate supports both AMD64 and ARM64.  Running `docker --context ecs compose up` introduces sidecar images which are only built for AMD64.  This results in all deployments to ARM64 failing. Publishing ARM64 images would fix issue #2190 and #2115.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/10965410/191945820-ea27730e-a22b-4f8c-a4b1-6ac003720903.png)
