### PR TITLE
stop using beta.kubernetes.io/os and beta.kubernetes.io/arch

### DIFF
--- a/kube/resources/placement.go
+++ b/kube/resources/placement.go
@@ -31,8 +31,8 @@ import (
 var constraintEquals = regexp.MustCompile(`([\w\.]*)\W*(==|!=)\W*([\w\.]*)`)
 
 const (
-	kubernetesOs       = "beta.kubernetes.io/os"
-	kubernetesArch     = "beta.kubernetes.io/arch"
+	kubernetesOs       = "kubernetes.io/os"
+	kubernetesArch     = "kubernetes.io/arch"
 	kubernetesHostname = "kubernetes.io/hostname"
 )
 


### PR DESCRIPTION
**What I did**
See https://github.com/kubernetes/kubernetes/issues/89477, https://github.com/kubernetes/kubernetes/issues/89477#issuecomment-603911496.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
