### PR TITLE
Ingress secgroup

### DIFF
--- a/ecs/cloudformation.go
+++ b/ecs/cloudformation.go
@@ -197,11 +197,10 @@ func (b *ecsAPIService) createService(project *types.Project, service types.Serv
 		dependsOn []string
 		serviceLB []ecs.Service_LoadBalancer
 	)
-	for _, port := range service.Ports {
-		for net := range service.Networks {
-			b.createIngress(service, net, port, template, resources)
-		}
 
+	for _, port := range service.Ports {
+		securityGroupName := serviceIngressSecGroupName(service.Name)
+		b.createIngress(service, securityGroupName, port, template, resources)
 		protocol := strings.ToUpper(port.Protocol)
 		if resources.loadBalancerType == elbv2.LoadBalancerTypeEnumApplication {
 			// we don't set Https as a certificate must be specified for HTTPS listeners
@@ -532,6 +531,10 @@ func (b *ecsAPIService) createPolicies(project *types.Project, service types.Ser
 
 func networkResourceName(network string) string {
 	return fmt.Sprintf("%sNetwork", normalizeResourceName(network))
+}
+
+func serviceIngressSecGroupName(service string) string {
+	return fmt.Sprintf("%sServiceIngressSecurityGroup", normalizeResourceName(service))
 }
 
 func serviceResourceName(service string) string {

--- a/ecs/cloudformation_test.go
+++ b/ecs/cloudformation_test.go
@@ -51,6 +51,17 @@ func TestSimpleConvert(t *testing.T) {
 	golden.Assert(t, result, expected)
 }
 
+func TestSlightlyComplexConvert(t *testing.T) {
+	bytes, err := ioutil.ReadFile("testdata/input/slightly-complex-service.yaml")
+	assert.NilError(t, err)
+	template := convertYaml(t, string(bytes), nil, useDefaultVPC)
+	resultAsJSON, err := marshall(template, "yaml")
+	assert.NilError(t, err)
+	result := fmt.Sprintf("%s\n", string(resultAsJSON))
+	expected := "slightly-complex-cloudformation-conversion.golden"
+	golden.Assert(t, result, expected)
+}
+
 func TestLogging(t *testing.T) {
 	template := convertYaml(t, `
 services:

--- a/ecs/testdata/input/slightly-complex-service.yaml
+++ b/ecs/testdata/input/slightly-complex-service.yaml
@@ -1,0 +1,8 @@
+services:
+  entrance:
+    image: nginx
+    ports:
+      - "80:80"
+
+  sensitive:
+    image: httpd

--- a/ecs/testdata/simple-cloudformation-conversion.golden
+++ b/ecs/testdata/simple-cloudformation-conversion.golden
@@ -13,16 +13,6 @@ Resources:
       - Key: com.docker.compose.project
         Value: TestSimpleConvert
     Type: AWS::ECS::Cluster
-  Default80Ingress:
-    Properties:
-      CidrIp: 0.0.0.0/0
-      Description: simple:80/tcp on default network
-      FromPort: 80
-      GroupId:
-        Ref: DefaultNetwork
-      IpProtocol: TCP
-      ToPort: 80
-    Type: AWS::EC2::SecurityGroupIngress
   DefaultNetwork:
     Properties:
       GroupDescription: TestSimpleConvert Security Group for default network
@@ -84,6 +74,7 @@ Resources:
           AssignPublicIp: ENABLED
           SecurityGroups:
           - Ref: DefaultNetwork
+          - Ref: SimpleServiceIngressSecurityGroup
           Subnets:
           - subnet1
           - subnet2
@@ -117,6 +108,26 @@ Resources:
       NamespaceId:
         Ref: CloudMap
     Type: AWS::ServiceDiscovery::Service
+  SimpleServiceIngressSecurityGroup:
+    Properties:
+      GroupDescription: TestSimpleConvert Security Group for service simple ingress
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSimpleConvert
+      - Key: com.docker.compose.service
+        Value: simple
+      VpcId: vpc-123
+    Type: AWS::EC2::SecurityGroup
+  SimpleServiceIngressSecurityGroup80Ingress:
+    Properties:
+      CidrIp: 0.0.0.0/0
+      Description: simple:80/tcp on SimpleServiceIngressSecurityGroup network
+      FromPort: 80
+      GroupId:
+        Ref: SimpleServiceIngressSecurityGroup
+      IpProtocol: TCP
+      ToPort: 80
+    Type: AWS::EC2::SecurityGroupIngress
   SimpleTCP80Listener:
     Properties:
       DefaultActions:

--- a/ecs/testdata/slightly-complex-cloudformation-conversion.golden
+++ b/ecs/testdata/slightly-complex-cloudformation-conversion.golden
@@ -13,16 +13,6 @@ Resources:
       - Key: com.docker.compose.project
         Value: TestSlightlyComplexConvert
     Type: AWS::ECS::Cluster
-  Default80Ingress:
-    Properties:
-      CidrIp: 0.0.0.0/0
-      Description: entrance:80/tcp on default network
-      FromPort: 80
-      GroupId:
-        Ref: DefaultNetwork
-      IpProtocol: TCP
-      ToPort: 80
-    Type: AWS::EC2::SecurityGroupIngress
   DefaultNetwork:
     Properties:
       GroupDescription: TestSlightlyComplexConvert Security Group for default network
@@ -67,6 +57,7 @@ Resources:
           AssignPublicIp: ENABLED
           SecurityGroups:
           - Ref: DefaultNetwork
+          - Ref: EntranceServiceIngressSecurityGroup
           Subnets:
           - subnet1
           - subnet2
@@ -100,6 +91,27 @@ Resources:
       NamespaceId:
         Ref: CloudMap
     Type: AWS::ServiceDiscovery::Service
+  EntranceServiceIngressSecurityGroup:
+    Properties:
+      GroupDescription: TestSlightlyComplexConvert Security Group for service entrance
+        ingress
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      - Key: com.docker.compose.service
+        Value: entrance
+      VpcId: vpc-123
+    Type: AWS::EC2::SecurityGroup
+  EntranceServiceIngressSecurityGroup80Ingress:
+    Properties:
+      CidrIp: 0.0.0.0/0
+      Description: entrance:80/tcp on EntranceServiceIngressSecurityGroup network
+      FromPort: 80
+      GroupId:
+        Ref: EntranceServiceIngressSecurityGroup
+      IpProtocol: TCP
+      ToPort: 80
+    Type: AWS::EC2::SecurityGroupIngress
   EntranceTCP80Listener:
     Properties:
       DefaultActions:

--- a/ecs/testdata/slightly-complex-cloudformation-conversion.golden
+++ b/ecs/testdata/slightly-complex-cloudformation-conversion.golden
@@ -1,0 +1,320 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  CloudMap:
+    Properties:
+      Description: Service Map for Docker Compose project TestSlightlyComplexConvert
+      Name: TestSlightlyComplexConvert.local
+      Vpc: vpc-123
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+  Cluster:
+    Properties:
+      ClusterName: TestSlightlyComplexConvert
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+    Type: AWS::ECS::Cluster
+  Default80Ingress:
+    Properties:
+      CidrIp: 0.0.0.0/0
+      Description: entrance:80/tcp on default network
+      FromPort: 80
+      GroupId:
+        Ref: DefaultNetwork
+      IpProtocol: TCP
+      ToPort: 80
+    Type: AWS::EC2::SecurityGroupIngress
+  DefaultNetwork:
+    Properties:
+      GroupDescription: TestSlightlyComplexConvert Security Group for default network
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      - Key: com.docker.compose.network
+        Value: TestSlightlyComplexConvert_default
+      VpcId: vpc-123
+    Type: AWS::EC2::SecurityGroup
+  DefaultNetworkIngress:
+    Properties:
+      Description: Allow communication within network default
+      GroupId:
+        Ref: DefaultNetwork
+      IpProtocol: "-1"
+      SourceSecurityGroupId:
+        Ref: DefaultNetwork
+    Type: AWS::EC2::SecurityGroupIngress
+  EntranceService:
+    DependsOn:
+    - EntranceTCP80Listener
+    Properties:
+      Cluster:
+        Fn::GetAtt:
+        - Cluster
+        - Arn
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DeploymentController:
+        Type: ECS
+      DesiredCount: 1
+      LaunchType: FARGATE
+      LoadBalancers:
+      - ContainerName: entrance
+        ContainerPort: 80
+        TargetGroupArn:
+          Ref: EntranceTCP80TargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+          - Ref: DefaultNetwork
+          Subnets:
+          - subnet1
+          - subnet2
+      PlatformVersion: 1.4.0
+      PropagateTags: SERVICE
+      SchedulingStrategy: REPLICA
+      ServiceRegistries:
+      - RegistryArn:
+          Fn::GetAtt:
+          - EntranceServiceDiscoveryEntry
+          - Arn
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      - Key: com.docker.compose.service
+        Value: entrance
+      TaskDefinition:
+        Ref: EntranceTaskDefinition
+    Type: AWS::ECS::Service
+  EntranceServiceDiscoveryEntry:
+    Properties:
+      Description: '"entrance" service discovery entry in Cloud Map'
+      DnsConfig:
+        DnsRecords:
+        - TTL: 60
+          Type: A
+        RoutingPolicy: MULTIVALUE
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: entrance
+      NamespaceId:
+        Ref: CloudMap
+    Type: AWS::ServiceDiscovery::Service
+  EntranceTCP80Listener:
+    Properties:
+      DefaultActions:
+      - ForwardConfig:
+          TargetGroups:
+          - TargetGroupArn:
+              Ref: EntranceTCP80TargetGroup
+        Type: forward
+      LoadBalancerArn:
+        Ref: LoadBalancer
+      Port: 80
+      Protocol: HTTP
+    Type: AWS::ElasticLoadBalancingV2::Listener
+  EntranceTCP80TargetGroup:
+    Properties:
+      Port: 80
+      Protocol: HTTP
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      TargetType: ip
+      VpcId: vpc-123
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+  EntranceTaskDefinition:
+    Properties:
+      ContainerDefinitions:
+      - Command:
+        - .compute.internal
+        - TestSlightlyComplexConvert.local
+        Essential: false
+        Image: docker/ecs-searchdomain-sidecar:1.0
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group:
+              Ref: LogGroup
+            awslogs-region:
+              Ref: AWS::Region
+            awslogs-stream-prefix: TestSlightlyComplexConvert
+        Name: Entrance_ResolvConf_InitContainer
+      - DependsOn:
+        - Condition: SUCCESS
+          ContainerName: Entrance_ResolvConf_InitContainer
+        Essential: true
+        Image: nginx
+        LinuxParameters: {}
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group:
+              Ref: LogGroup
+            awslogs-region:
+              Ref: AWS::Region
+            awslogs-stream-prefix: TestSlightlyComplexConvert
+        Name: entrance
+        PortMappings:
+        - ContainerPort: 80
+          HostPort: 80
+          Protocol: tcp
+      Cpu: "256"
+      ExecutionRoleArn:
+        Ref: EntranceTaskExecutionRole
+      Family: TestSlightlyComplexConvert-entrance
+      Memory: "512"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+      - FARGATE
+    Type: AWS::ECS::TaskDefinition
+  EntranceTaskExecutionRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Condition: {}
+          Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      - Key: com.docker.compose.service
+        Value: entrance
+    Type: AWS::IAM::Role
+  LoadBalancer:
+    Properties:
+      Scheme: internet-facing
+      SecurityGroups:
+      - Ref: DefaultNetwork
+      Subnets:
+      - subnet1
+      - subnet2
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      Type: application
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+  LogGroup:
+    Properties:
+      LogGroupName: /docker-compose/TestSlightlyComplexConvert
+    Type: AWS::Logs::LogGroup
+  SensitiveService:
+    Properties:
+      Cluster:
+        Fn::GetAtt:
+        - Cluster
+        - Arn
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DeploymentController:
+        Type: ECS
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+          - Ref: DefaultNetwork
+          Subnets:
+          - subnet1
+          - subnet2
+      PlatformVersion: 1.4.0
+      PropagateTags: SERVICE
+      SchedulingStrategy: REPLICA
+      ServiceRegistries:
+      - RegistryArn:
+          Fn::GetAtt:
+          - SensitiveServiceDiscoveryEntry
+          - Arn
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      - Key: com.docker.compose.service
+        Value: sensitive
+      TaskDefinition:
+        Ref: SensitiveTaskDefinition
+    Type: AWS::ECS::Service
+  SensitiveServiceDiscoveryEntry:
+    Properties:
+      Description: '"sensitive" service discovery entry in Cloud Map'
+      DnsConfig:
+        DnsRecords:
+        - TTL: 60
+          Type: A
+        RoutingPolicy: MULTIVALUE
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: sensitive
+      NamespaceId:
+        Ref: CloudMap
+    Type: AWS::ServiceDiscovery::Service
+  SensitiveTaskDefinition:
+    Properties:
+      ContainerDefinitions:
+      - Command:
+        - .compute.internal
+        - TestSlightlyComplexConvert.local
+        Essential: false
+        Image: docker/ecs-searchdomain-sidecar:1.0
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group:
+              Ref: LogGroup
+            awslogs-region:
+              Ref: AWS::Region
+            awslogs-stream-prefix: TestSlightlyComplexConvert
+        Name: Sensitive_ResolvConf_InitContainer
+      - DependsOn:
+        - Condition: SUCCESS
+          ContainerName: Sensitive_ResolvConf_InitContainer
+        Essential: true
+        Image: httpd
+        LinuxParameters: {}
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group:
+              Ref: LogGroup
+            awslogs-region:
+              Ref: AWS::Region
+            awslogs-stream-prefix: TestSlightlyComplexConvert
+        Name: sensitive
+      Cpu: "256"
+      ExecutionRoleArn:
+        Ref: SensitiveTaskExecutionRole
+      Family: TestSlightlyComplexConvert-sensitive
+      Memory: "512"
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+      - FARGATE
+    Type: AWS::ECS::TaskDefinition
+  SensitiveTaskExecutionRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - sts:AssumeRole
+          Condition: {}
+          Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      Tags:
+      - Key: com.docker.compose.project
+        Value: TestSlightlyComplexConvert
+      - Key: com.docker.compose.service
+        Value: sensitive
+    Type: AWS::IAM::Role
+


### PR DESCRIPTION
**What I did**
Previously, the ECS stack included an ingress rule to allow LB to reach the tasks.
However, it added this ingress rule toe very Docker network security group, meaning other tasks on the same Docker network, possibly sensitive, were accessible externally.
We now create a new security group for port assignments for every service that has ports, and attach that security group only to that service.
This prevents other tasks in the same Docker networks are not accessible externally.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
Solves #1783
<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->
**Manual testing**
A bit long:

Modify the slightyl-complex stack to have a real VPC and subnets, then create it:
```
set -eu
cd ecs
go test . -update
perl -pe 's/vpc-123/vpc-XXXXXXX/ ; s/subnet1/subnet-YYYYY/ ; s/subnet2/subnet-ZZZZZ' -i testdata/slightly-complex-cloudformation-conversion.golden
aws us-east-1 cloudformation delete-stack --stack-name slightly-complex
aws cloudformation create-stack --stack-name slighlty-complex --template-body file://$(realpath testdata/slightly-complex-cloudformation-conversion.golden) --capabilities CAPABILITY_IAM
```
Reminder, the Compose looks like this:
```
services:
  entrance:
    image: nginx
    ports:
      - "80:80"

  sensitive:
    image: httpd
```
So we should have an nginx "Entrance" service that is publicly accessible, and an httpd "Sensitive" one that isn't.
![image](https://user-images.githubusercontent.com/7194491/211927883-9ced4d48-acb9-4077-b152-879ebc9ea315.png)
```
$ curl 3.95.182.176 --head
HTTP/1.1 200 OK
Server: nginx/1.23.3
Date: Wed, 11 Jan 2023 22:06:09 GMT
Content-Type: text/html
Content-Length: 615
Last-Modified: Tue, 13 Dec 2022 15:53:53 GMT
Connection: keep-alive
ETag: "6398a011-267"
Accept-Ranges: bytes
```

![image](https://user-images.githubusercontent.com/7194491/211927746-01f6eb6f-7805-4be6-9d74-36479ad11418.png)
```
$ curl 44.204.80.70 --verbose
*   Trying 44.204.80.70:80...
```
Success, "entrance" is publicly accessible but "sensitive" is not.

Repeating the process without the commit renders "sensitive" publicly accessible, which is the problem, ensuring my commit solves the issue.

Lastly, ensuring that the LB works:
```

```
TODO FINISH

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
