### PR TITLE
Add share command (docker extension share) in metrics whitelist

### DIFF
--- a/cli/metrics/commands.go
+++ b/cli/metrics/commands.go
@@ -133,6 +133,7 @@ var commands = []string{
 	"search",
 	"services",
 	"set",
+	"share",
 	"show",
 	"sign",
 	"split",


### PR DESCRIPTION
Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>

**What I did**

Update metrics whitelist to get analytics on `docker extension share` 
Note that I did run `generatecommands/main.go, but it gave me a bunch of other changes in addition to the share command, I didn't want to include things I'm not sure about so I prefer to keep this PR short and easy to merge

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![](https://cdn.abcotvs.com/dip/images/2044413_052717ktrkzoolegos5img.jpg)