### PR TITLE
metrics: initial logic for command execution duration

### DIFF
--- a/cli/metrics/client.go
+++ b/cli/metrics/client.go
@@ -26,6 +26,15 @@ import (
 // specified file path.
 const EnvVarDebugMetricsPath = "DOCKER_METRICS_DEBUG_LOG"
 
+type CmdMeta struct {
+	ContextType string
+	Args        []string
+	Status      string
+	ExitCode    int
+	Start       time.Time
+	Duration    time.Duration
+}
+
 type client struct {
 	cliversion *cliversion
 	reporter   Reporter
@@ -62,7 +71,7 @@ type Client interface {
 	// Note that metric collection is best-effort, so any errors are ignored.
 	SendUsage(Command)
 	// Track creates an event for a command execution and reports it.
-	Track(context string, args []string, status string)
+	Track(cmd CmdMeta)
 }
 
 // NewClient returns a new metrics client that will send metrics using the

--- a/cli/metrics/client.go
+++ b/cli/metrics/client.go
@@ -57,11 +57,11 @@ type Client interface {
 	// WithCliVersionFunc sets the docker cli version func
 	// that returns the docker cli version (com.docker.cli)
 	WithCliVersionFunc(f func() string)
-	// Send sends the command to Docker Desktop. Note that the function doesn't
-	// return anything, not even an error, this is because we don't really care
-	// if the metrics were sent or not. We only fire and forget.
-	Send(Command)
-	// Track sends the tracking analytics to Docker Desktop
+	// SendUsage sends the command to Docker Desktop.
+	//
+	// Note that metric collection is best-effort, so any errors are ignored.
+	SendUsage(Command)
+	// Track creates an event for a command execution and reports it.
 	Track(context string, args []string, status string)
 }
 
@@ -98,7 +98,7 @@ func (c *client) WithCliVersionFunc(f func() string) {
 	c.cliversion.f = f
 }
 
-func (c *client) Send(command Command) {
+func (c *client) SendUsage(command Command) {
 	result := make(chan bool, 1)
 	go func() {
 		c.reporter.Heartbeat(command)

--- a/cli/metrics/event.go
+++ b/cli/metrics/event.go
@@ -1,0 +1,79 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metrics
+
+// FailureCategory struct regrouping metrics failure status and specific exit code
+type FailureCategory struct {
+	MetricsStatus string
+	ExitCode      int
+}
+
+const (
+	// APISource is sent for API metrics
+	APISource = "api"
+	// SuccessStatus command success
+	SuccessStatus = "success"
+	// FailureStatus command failure
+	FailureStatus = "failure"
+	// ComposeParseFailureStatus failure while parsing compose file
+	ComposeParseFailureStatus = "failure-compose-parse"
+	// FileNotFoundFailureStatus failure getting compose file
+	FileNotFoundFailureStatus = "failure-file-not-found"
+	// CommandSyntaxFailureStatus failure reading command
+	CommandSyntaxFailureStatus = "failure-cmd-syntax"
+	// BuildFailureStatus failure building imge
+	BuildFailureStatus = "failure-build"
+	// PullFailureStatus failure pulling imge
+	PullFailureStatus = "failure-pull"
+	// CanceledStatus command canceled
+	CanceledStatus = "canceled"
+)
+
+var (
+	// FileNotFoundFailure failure for compose file not found
+	FileNotFoundFailure = FailureCategory{MetricsStatus: FileNotFoundFailureStatus, ExitCode: 14}
+	// ComposeParseFailure failure for composefile parse error
+	ComposeParseFailure = FailureCategory{MetricsStatus: ComposeParseFailureStatus, ExitCode: 15}
+	// CommandSyntaxFailure failure for command line syntax
+	CommandSyntaxFailure = FailureCategory{MetricsStatus: CommandSyntaxFailureStatus, ExitCode: 16}
+	// BuildFailure failure while building images.
+	BuildFailure = FailureCategory{MetricsStatus: BuildFailureStatus, ExitCode: 17}
+	// PullFailure failure while pulling image
+	PullFailure = FailureCategory{MetricsStatus: PullFailureStatus, ExitCode: 18}
+)
+
+// FailureCategoryFromExitCode retrieve FailureCategory based on command exit code
+func FailureCategoryFromExitCode(exitCode int) FailureCategory {
+	switch exitCode {
+	case 0:
+		return FailureCategory{MetricsStatus: SuccessStatus, ExitCode: 0}
+	case 14:
+		return FileNotFoundFailure
+	case 15:
+		return ComposeParseFailure
+	case 16:
+		return CommandSyntaxFailure
+	case 17:
+		return BuildFailure
+	case 18:
+		return PullFailure
+	case 130:
+		return FailureCategory{MetricsStatus: CanceledStatus, ExitCode: exitCode}
+	default:
+		return FailureCategory{MetricsStatus: FailureStatus, ExitCode: exitCode}
+	}
+}

--- a/cli/metrics/metrics.go
+++ b/cli/metrics/metrics.go
@@ -25,17 +25,17 @@ import (
 	"github.com/docker/compose-cli/cli/metrics/metadata"
 )
 
-func (c *client) Track(context string, args []string, status string) {
+func (c *client) Track(cmd CmdMeta) {
 	if isInvokedAsCliBackend() {
 		return
 	}
-	command := GetCommand(args)
+	command := GetCommand(cmd.Args)
 	if command != "" {
 		c.SendUsage(Command{
 			Command: command,
-			Context: context,
-			Source:  c.getMetadata(CLISource, args),
-			Status:  status,
+			Context: cmd.ContextType,
+			Source:  c.getMetadata(CLISource, cmd.Args),
+			Status:  cmd.Status,
 		})
 	}
 }

--- a/cli/metrics/metrics.go
+++ b/cli/metrics/metrics.go
@@ -31,7 +31,7 @@ func (c *client) Track(context string, args []string, status string) {
 	}
 	command := GetCommand(args)
 	if command != "" {
-		c.Send(Command{
+		c.SendUsage(Command{
 			Command: command,
 			Context: context,
 			Source:  c.getMetadata(CLISource, args),

--- a/cli/server/metrics.go
+++ b/cli/server/metrics.go
@@ -19,7 +19,6 @@ package server
 import (
 	"context"
 
-	"github.com/docker/compose/v2/pkg/compose"
 	"google.golang.org/grpc"
 
 	"github.com/docker/compose-cli/cli/metrics"
@@ -61,16 +60,16 @@ func metricsServerInterceptor(client metrics.Client) grpc.UnaryServerInterceptor
 
 		data, err := handler(ctx, req)
 
-		status := compose.SuccessStatus
+		status := metrics.SuccessStatus
 		if err != nil {
-			status = compose.FailureStatus
+			status = metrics.FailureStatus
 		}
 		command := methodMapping[info.FullMethod]
 		if command != "" {
-			client.Send(metrics.Command{
+			client.SendUsage(metrics.Command{
 				Command: command,
 				Context: contextType,
-				Source:  compose.APISource,
+				Source:  metrics.APISource,
 				Status:  status,
 			})
 		}

--- a/cli/server/metrics_test.go
+++ b/cli/server/metrics_test.go
@@ -130,6 +130,6 @@ func (s *mockMetricsClient) SendUsage(command metrics.Command) {
 	s.Called(command)
 }
 
-func (s *mockMetricsClient) Track(context string, args []string, status string) {
-	s.Called(context, args, status)
+func (s *mockMetricsClient) Track(cmd metrics.CmdMeta) {
+	s.Called(cmd)
 }

--- a/cli/server/metrics_test.go
+++ b/cli/server/metrics_test.go
@@ -60,7 +60,7 @@ func TestAllMethodsHaveCorrespondingCliCommand(t *testing.T) {
 
 func TestTrackSuccess(t *testing.T) {
 	var mockMetrics = &mockMetricsClient{}
-	mockMetrics.On("Send", metrics.Command{Command: "ps", Context: "aci", Status: "success", Source: "api"}).Return()
+	mockMetrics.On("SendUsage", metrics.Command{Command: "ps", Context: "aci", Status: "success", Source: "api"}).Return()
 	newClient := client.NewClient("aci", noopService{})
 	interceptor := metricsServerInterceptor(mockMetrics)
 
@@ -126,7 +126,7 @@ func (s *mockMetricsClient) WithCliVersionFunc(f func() string) {
 	s.Called(f)
 }
 
-func (s *mockMetricsClient) Send(command metrics.Command) {
+func (s *mockMetricsClient) SendUsage(command metrics.Command) {
 	s.Called(command)
 }
 


### PR DESCRIPTION
Add a timer around command invocations to be reported with metrics.
This isn't actually sent anywhere currently, as it's meant for
evented data which is forthcoming. (We could report it with the
current events, but it's not clear that there's any value in doing
so.)

The signature for `Track()` has been changed to take an object with
all the fields. This is both for sanity to keep the method from
getting ridiculously long, and to make it easier to unify the usage
(heartbeat) and event code paths by ensuring we have all the data
for both.

(Replaces #2224 which I accidentally closed and can't re-open 😅)