### PR TITLE
Limit EFS volume creation to public subnets

### DIFF
--- a/ecs/awsResources.go
+++ b/ecs/awsResources.go
@@ -39,6 +39,7 @@ import (
 type awsResources struct {
 	vpc              string // shouldn't this also be an awsResource ?
 	subnets          []awsResource
+	pubSubnets		 []awsResource
 	cluster          awsResource
 	loadBalancer     awsResource
 	loadBalancerType string
@@ -221,6 +222,7 @@ func (b *ecsAPIService) parseVPCExtension(ctx context.Context, project *types.Pr
 
 	r.vpc = vpc
 	r.subnets = subNets
+	r.pubSubnets = publicSubNets
 	return nil
 }
 

--- a/ecs/sdk.go
+++ b/ecs/sdk.go
@@ -227,7 +227,10 @@ func (s sdk) IsPublicSubnet(ctx context.Context, subNetID string) (bool, error) 
 	if len(tables.RouteTables) == 0 {
 		// If a subnet is not explicitly associated with any route table, it is implicitly associated with the main route table.
 		// https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-route-tables.html
-		return true, nil
+		
+		// Normally main route tables are used for the private subnets, so this should be FALSE and not TRUE
+		// regular setup is 3 public subnets + N number of private subnets
+		return false, nil
 	}
 	for _, routeTable := range tables.RouteTables {
 		for _, route := range routeTable.Routes {

--- a/ecs/volumes.go
+++ b/ecs/volumes.go
@@ -31,12 +31,12 @@ import (
 
 func (b *ecsAPIService) createNFSMountTarget(project *types.Project, resources awsResources, template *cloudformation.Template) {
 	for volume := range project.Volumes {
-		for _, subnet := range resources.subnets {
-			name := fmt.Sprintf("%sNFSMountTargetOn%s", normalizeResourceName(volume), normalizeResourceName(subnet.ID()))
+		for _, pubSubnet := range resources.pubSubnets {
+			name := fmt.Sprintf("%sNFSMountTargetOn%s", normalizeResourceName(volume), normalizeResourceName(pubSubnet.ID()))
 			template.Resources[name] = &efs.MountTarget{
 				FileSystemId:   resources.filesystems[volume].ID(),
 				SecurityGroups: resources.allSecurityGroups(),
-				SubnetId:       subnet.ID(),
+				SubnetId:       pubSubnet.ID(),
 			}
 		}
 	}
@@ -44,8 +44,8 @@ func (b *ecsAPIService) createNFSMountTarget(project *types.Project, resources a
 
 func (b *ecsAPIService) mountTargets(volume string, resources awsResources) []string {
 	var refs []string
-	for _, subnet := range resources.subnets {
-		refs = append(refs, fmt.Sprintf("%sNFSMountTargetOn%s", normalizeResourceName(volume), normalizeResourceName(subnet.ID())))
+	for _, pubSubnet := range resources.pubSubnets {
+		refs = append(refs, fmt.Sprintf("%sNFSMountTargetOn%s", normalizeResourceName(volume), normalizeResourceName(pubSubnet.ID())))
 	}
 	return refs
 }


### PR DESCRIPTION
There is a problem with EFS volumes when you have a lot of subnets - they can't be created. Actually by now it can only work if you have a network with only 3 public subnets in the 3 AWS availability zones without any additional subnets.

fixes #2164 , helps #1739

This helps by identifying the public subnets, and creates mount targets only for them, it expects the following:

1. you have 3 public subnets and N number of additional
2. there routing table associated with the 3 public subnets, and separate routing table left as default for any number of other private subnets
3. private routing table is the main table

Since there is no proper way of setting the subnets used by the volumes, I am proposing this so at least it tries to create the EFS mounts properly when you have a lot of subnets.
