### PR TITLE
Update ecs-compose-features.md

### DIFF
--- a/docs/ecs-compose-features.md
+++ b/docs/ecs-compose-features.md
@@ -35,7 +35,7 @@ __Legend:__
 | service.deploy.placement       | ✓ |  Used with EC2 support to select a machine type and AMI
 | service.deploy.update_config   | ✓ |
 | service.deploy.resources       | ✓ |  Fargate resource is selected with the lowest instance type for configured memory and cpu
-| service.deploy.restart_policy  | ✓ |
+| service.deploy.restart_policy  | x |
 | service.deploy.labels          | ✓ |
 | service.devices                | x |
 | service.depends_on             | ✓ |  Implemented using CloudFormation Depends_on
@@ -70,7 +70,7 @@ __Legend:__
 | service.ulimits                | ✓ |  Only support `nofile` ulimit due to Fargate limitations
 | service.userns_mode            | x |
 | service.volumes                | ✓ |  Mapped to EFS File Systems. See [Persistent volumes](#persistent-volumes).
-| service.restart                | x |  Replaced by service.deployment.restart_policy
+| service.restart                | x |
 |                                |   |
 | __Volume__                     | x |
 | driver                         | ✓ |  See [Persistent volumes](#persistent-volumes).


### PR DESCRIPTION
ecs-compose supports neither `service.deploy.restart_policy` nor `service.restart`. (This is a re-submission of the accidentally-deleted, previously approved but unmerged PR #2184).

**What I did**

Changed `✓` to `x` for `service.deploy.restart_policy` and `service.restart`, deleted comment on `service.restart`

**Related issue**

closes #2153 
