### PR TITLE
cli: deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
+## :warning: "Cloud Integrations" is DEPRECATED
+
+Compose CLI a.k.a "Cloud Integrations" has been deprecated. Critical security fixes only will be considered for this repository. Compose CLI will be considered End of Live on January 1st 2024.
+
+ECS user should consider using https://github.com/docker/compose-ecs
+
+
 # Docker Compose "Cloud Integrations"
 
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Continuous%20integration/badge.svg)](https://github.com/docker/compose-cli/actions)
 [![Actions Status](https://github.com/docker/compose-cli/workflows/Windows%20CI/badge.svg)](https://github.com/docker/compose-cli/actions)
+
 
 This Compose CLI tool makes it easy to run Docker containers and Docker Compose applications in the cloud using either :
 - Amazon Elastic Container Service

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## :warning: "Cloud Integrations" is DEPRECATED
+## :warning: Retirement Date Pending
 
-Compose CLI a.k.a "Cloud Integrations" has been deprecated. Critical security fixes only will be considered for this repository. Compose CLI will be considered End of Live on January 1st 2024.
+Docker Compose's integration for ECS and ACI will be retired in November 2023. For now, our main priority in this repository are critical security fixes.
 
-ECS user should consider using https://github.com/docker/compose-ecs
+ECS users can consider using [compose-ecs](https://github.com/docker/compose-ecs).
 
 
 # Docker Compose "Cloud Integrations"

--- a/aci/backend.go
+++ b/aci/backend.go
@@ -69,7 +69,7 @@ func init() {
 }
 
 func service() (backend.Service, error) {
-	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/aci-integration/")
+	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
 	contextStore := store.Instance()
 	currentContext := apicontext.Current()
 	var aciContext store.AciContext

--- a/aci/backend.go
+++ b/aci/backend.go
@@ -17,6 +17,8 @@
 package aci
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
@@ -67,6 +69,7 @@ func init() {
 }
 
 func service() (backend.Service, error) {
+	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/aci-integration/")
 	contextStore := store.Instance()
 	currentContext := apicontext.Current()
 	var aciContext store.AciContext

--- a/aci/cloud.go
+++ b/aci/cloud.go
@@ -49,7 +49,7 @@ func (cs *aciCloudService) Logout(ctx context.Context) error {
 }
 
 func (cs *aciCloudService) CreateContextData(ctx context.Context, params interface{}) (interface{}, string, error) {
-	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/aci-integration/")
+	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
 	contextHelper := newContextCreateHelper()
 	createOpts := params.(ContextParams)
 	return contextHelper.createContextData(ctx, createOpts)

--- a/aci/cloud.go
+++ b/aci/cloud.go
@@ -18,6 +18,8 @@ package aci
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -47,6 +49,7 @@ func (cs *aciCloudService) Logout(ctx context.Context) error {
 }
 
 func (cs *aciCloudService) CreateContextData(ctx context.Context, params interface{}) (interface{}, string, error) {
+	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/aci-integration/")
 	contextHelper := newContextCreateHelper()
 	createOpts := params.(ContextParams)
 	return contextHelper.createContextData(ctx, createOpts)

--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -19,6 +19,7 @@ package ecs
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/cloud"
@@ -62,6 +63,7 @@ func init() {
 }
 
 func service() (backend.Service, error) {
+	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/ecs-integration/")
 	contextStore := store.Instance()
 	currentContext := apicontext.Current()
 	var ecsContext store.EcsContext
@@ -155,6 +157,7 @@ func (a ecsCloudService) Logout(ctx context.Context) error {
 }
 
 func (a ecsCloudService) CreateContextData(ctx context.Context, params interface{}) (interface{}, string, error) {
+	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/ecs-integration/")
 	contextHelper := newContextCreateHelper()
 	createOpts := params.(ContextParams)
 	return contextHelper.createContextData(ctx, createOpts)

--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func service() (backend.Service, error) {
-	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/ecs-integration/")
+	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
 	contextStore := store.Instance()
 	currentContext := apicontext.Current()
 	var ecsContext store.EcsContext
@@ -157,7 +157,7 @@ func (a ecsCloudService) Logout(ctx context.Context) error {
 }
 
 func (a ecsCloudService) CreateContextData(ctx context.Context, params interface{}) (interface{}, string, error) {
-	fmt.Fprintln(os.Stderr, "Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/ecs-integration/")
+	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
 	contextHelper := newContextCreateHelper()
 	createOpts := params.(ContextParams)
 	return contextHelper.createContextData(ctx, createOpts)


### PR DESCRIPTION
https://docker.atlassian.net/browse/ENV-189

**What I did**
added a deprecation notice when compose-cli is used with a non-default context type

```
$ docker context create ecs toto
Cloud integration is DEPRECATED. Read more on https://docs.docker.com/cloud/ecs-integration/
? Create a Docker context using:  [Use arrows to move, type to filter]
..
```

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
