### PR TITLE
cli: allow suppressing deprecation warning

### DIFF
--- a/aci/backend.go
+++ b/aci/backend.go
@@ -17,9 +17,10 @@
 package aci
 
 import (
-	"fmt"
 	"os"
 	"strings"
+
+	"github.com/docker/compose-cli/utils"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -69,7 +70,7 @@ func init() {
 }
 
 func service() (backend.Service, error) {
-	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
+	utils.ShowDeprecationWarning(os.Stderr)
 	contextStore := store.Instance()
 	currentContext := apicontext.Current()
 	var aciContext store.AciContext

--- a/aci/cloud.go
+++ b/aci/cloud.go
@@ -18,8 +18,9 @@ package aci
 
 import (
 	"context"
-	"fmt"
 	"os"
+
+	"github.com/docker/compose-cli/utils"
 
 	"github.com/pkg/errors"
 
@@ -49,7 +50,7 @@ func (cs *aciCloudService) Logout(ctx context.Context) error {
 }
 
 func (cs *aciCloudService) CreateContextData(ctx context.Context, params interface{}) (interface{}, string, error) {
-	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
+	utils.ShowDeprecationWarning(os.Stderr)
 	contextHelper := newContextCreateHelper()
 	createOpts := params.(ContextParams)
 	return contextHelper.createContextData(ctx, createOpts)

--- a/ecs/backend.go
+++ b/ecs/backend.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/compose-cli/utils"
+
 	"github.com/docker/compose-cli/api/backend"
 	"github.com/docker/compose-cli/api/cloud"
 	"github.com/docker/compose-cli/api/containers"
@@ -63,7 +65,7 @@ func init() {
 }
 
 func service() (backend.Service, error) {
-	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
+	utils.ShowDeprecationWarning(os.Stderr)
 	contextStore := store.Instance()
 	currentContext := apicontext.Current()
 	var ecsContext store.EcsContext
@@ -157,7 +159,7 @@ func (a ecsCloudService) Logout(ctx context.Context) error {
 }
 
 func (a ecsCloudService) CreateContextData(ctx context.Context, params interface{}) (interface{}, string, error) {
-	fmt.Fprintln(os.Stderr, "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/")
+	utils.ShowDeprecationWarning(os.Stderr)
 	contextHelper := newContextCreateHelper()
 	createOpts := params.(ContextParams)
 	return contextHelper.createContextData(ctx, createOpts)

--- a/utils/deprecation.go
+++ b/utils/deprecation.go
@@ -1,0 +1,38 @@
+/*
+   Copyright 2020 Docker Compose CLI authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+)
+
+const deprecationMessage = "Docker Compose's integration for ECS and ACI will be retired in November 2023. Learn more: https://docs.docker.com/go/compose-ecs-eol/"
+
+var warnOnce sync.Once
+
+func ShowDeprecationWarning(w io.Writer) {
+	warnOnce.Do(func() {
+		if quiet, _ := strconv.ParseBool(os.Getenv("COMPOSE_CLOUD_EOL_SILENT")); quiet {
+			return
+		}
+		_, _ = fmt.Fprintln(w, deprecationMessage)
+	})
+}


### PR DESCRIPTION
**What I did**
Added `COMPOSE_CLOUD_EOL_SILENT` env var, which will suppress the EOL message if set to a truthy value.

**Related issue**
#2245