### PR TITLE
metrics: include integer exit code on daily

### DIFF
--- a/cli/metrics/client.go
+++ b/cli/metrics/client.go
@@ -59,10 +59,11 @@ type cliversion struct {
 
 // CommandUsage reports a CLI invocation for aggregation.
 type CommandUsage struct {
-	Command string `json:"command"`
-	Context string `json:"context"`
-	Source  string `json:"source"`
-	Status  string `json:"status"`
+	Command  string `json:"command"`
+	Context  string `json:"context"`
+	Source   string `json:"source"`
+	Status   string `json:"status"`
+	ExitCode int    `json:"exit_code"`
 }
 
 // CLISource is sent for cli metrics

--- a/cli/metrics/metrics.go
+++ b/cli/metrics/metrics.go
@@ -132,8 +132,9 @@ func NewCommandUsage(cmd CmdResult) *CommandUsage {
 	}
 
 	return &CommandUsage{
-		Command: command,
-		Context: cmd.ContextType,
-		Status:  cmd.Status,
+		Command:  command,
+		Context:  cmd.ContextType,
+		Status:   cmd.Status,
+		ExitCode: cmd.ExitCode,
 	}
 }


### PR DESCRIPTION
**What I did**
Include the exit code itself. The status field (which a limited string enum inferred from some exit codes) remains to not break anything.