### PR TITLE
Removed arrays in the case statement of the isNil function

### DIFF
--- a/utils/units.go
+++ b/utils/units.go
@@ -53,12 +53,12 @@ func (m *MemBytes) Value() int64 {
 	return int64(*m)
 }
 
-func isNil(i interface{}) bool {
+func isNil(i any) bool {
 	if i == nil {
 		return true
 	}
 	switch reflect.TypeOf(i).Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Slice:
 		return reflect.ValueOf(i).IsNil()
 	}
 	return false

--- a/utils/units_test.go
+++ b/utils/units_test.go
@@ -30,6 +30,10 @@ const (
 	gb = 1024 * mb
 )
 
+var (
+	ch chan bool
+)
+
 func TestMemBytes(t *testing.T) {
 	var m MemBytes
 	assert.Assert(t, cmp.Nil(m.Set("42")))
@@ -57,4 +61,26 @@ func TestMemBytes(t *testing.T) {
 	assert.Equal(t, "42GiB", m.String())
 
 	assert.Error(t, m.Set("###"), "invalid size: '###'")
+}
+
+func TestIsNil(t *testing.T) {
+	testCases := []struct {
+		input    any
+		expected bool
+	}{
+		{nil, true},
+		{(*int)(nil), true},
+		{map[string]int(nil), true},
+		{[5]int{}, false},
+		{ch, true},
+		{[]int(nil), true},
+		{make(chan int), false},
+		{10, false},
+		{struct{ Name string }{"Test"}, false},
+	}
+
+	for _, tc := range testCases {
+		actual := isNil(tc.input)
+		assert.Equal(t, tc.expected, actual)
+	}
 }


### PR DESCRIPTION
**What I did**
The current isnil function was causing panic when an array was given as an argument, so this has been changed.
Also, interface{} was changed to any and test code was added.

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
