### PR TITLE
compose-cli: fix PAT detection for PAT suggestion

### DIFF
--- a/cli/mobycli/pat_suggest.go
+++ b/cli/mobycli/pat_suggest.go
@@ -30,9 +30,10 @@ const (
 	// patSuggestMsg is a message to suggest the use of PAT (personal access tokens).
 	patSuggestMsg = `Logging in with your password grants your terminal complete access to your account. 
 For better security, log in with a limited-privilege personal access token. Learn more at https://docs.docker.com/go/access-tokens/`
+)
 
-	// patPrefix represents a docker personal access token prefix.
-	patPrefix = "dckrp_"
+var (
+	patPrefixes = []string{"dckrp_", "dckr_pat_"}
 )
 
 // displayPATSuggestMsg displays a message suggesting users to use PATs instead of passwords to reduce scope.
@@ -71,8 +72,10 @@ func isUsingPassword(pass string) bool {
 	if _, err := uuid.ParseUUID(pass); err == nil {
 		return false
 	}
-	if strings.HasPrefix(pass, patPrefix) {
-		return false
+	for _, patPrefix := range patPrefixes {
+		if strings.HasPrefix(pass, patPrefix) {
+			return false
+		}
 	}
 	return true
 }

--- a/cli/mobycli/pat_suggest_test.go
+++ b/cli/mobycli/pat_suggest_test.go
@@ -89,6 +89,11 @@ func TestIsUsingPassword(t *testing.T) {
 			"dckrp_ee5607c41bcd",
 			false,
 		},
+		{
+			"prefixed personal access token",
+			"dckr_pat_ee5607c41bcd",
+			false,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
**What I did**

### Problem
When logging in with a PAT, `docker login` tells me... I should be using a PAT:
```
docker login
Authenticating with existing credentials...
Login Succeeded

Logging in with your password grants your terminal complete access to your account.
For better security, log in with a limited-privilege personal access token. Learn more at https://docs.docker.com/go/access-tokens/
```

compose-cli is looking for the prefix `dckrp_` but hub currently issues pats with the prefix `dckr_pat_`.

### Solution
Also check for the prefix `dckr_pat_`. (maybe we could just exclusively check for this prefix? I have not looked into the history of `dckrp_`)

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
