### PR TITLE
login: Remove the PAT message

### DIFF
--- a/cli/mobycli/exec.go
+++ b/cli/mobycli/exec.go
@@ -117,8 +117,6 @@ func Exec(_ *cobra.Command) {
 			displayScoutQuickViewSuggestMsgOnBuild(commandArgs)
 		case "pull":
 			displayScoutQuickViewSuggestMsgOnPull(commandArgs)
-		case "login":
-			displayPATSuggestMsg(commandArgs)
 		default:
 		}
 	}

--- a/cli/mobycli/pat_suggest.go
+++ b/cli/mobycli/pat_suggest.go
@@ -17,42 +17,15 @@
 package mobycli
 
 import (
-	"fmt"
-	"os"
 	"strings"
 
-	"github.com/docker/cli/cli/config"
 	"github.com/docker/docker/registry"
 	"github.com/hashicorp/go-uuid"
-)
-
-const (
-	// patSuggestMsg is a message to suggest the use of PAT (personal access tokens).
-	patSuggestMsg = `Logging in with your password grants your terminal complete access to your account. 
-For better security, log in with a limited-privilege personal access token. Learn more at https://docs.docker.com/go/access-tokens/`
 )
 
 var (
 	patPrefixes = []string{"dckrp_", "dckr_pat_"}
 )
-
-// displayPATSuggestMsg displays a message suggesting users to use PATs instead of passwords to reduce scope.
-func displayPATSuggestMsg(cmdArgs []string) {
-	if os.Getenv("DOCKER_PAT_SUGGEST") == "false" {
-		return
-	}
-	if !isUsingDefaultRegistry(cmdArgs) {
-		return
-	}
-	authCfg, err := config.LoadDefaultConfigFile(os.Stderr).GetAuthConfig(registry.IndexServer)
-	if err != nil {
-		return
-	}
-	if !isUsingPassword(authCfg.Password) {
-		return
-	}
-	fmt.Fprintf(os.Stderr, "\n"+patSuggestMsg+"\n")
-}
 
 func isUsingDefaultRegistry(cmdArgs []string) bool {
 	for i := 1; i < len(cmdArgs); i++ {


### PR DESCRIPTION
**What I did**

Removed the PAT message, we are moving this to docker/cli https://github.com/docker/cli/pull/4478

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

<!-- optional tests
You can add a / mention to run tests executed by default only on main branch :
* `test-kube` to run Kube E2E tests
* `test-aci` to run ACI E2E tests
* `test-ecs` to run ECS E2E tests
* `test-windows` to run tests & E2E tests on windows
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
