### PR TITLE
Fallback to user-provided cluster from metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 dist/
+/.idea/
 /.vscode/

--- a/ecs/aws.go
+++ b/ecs/aws.go
@@ -51,6 +51,7 @@ type API interface {
 	GetStackID(ctx context.Context, name string) (string, error)
 	ListStacks(ctx context.Context) ([]api.Stack, error)
 	GetStackClusterID(ctx context.Context, stack string) (string, error)
+	GetStackMetadataClusterID(ctx context.Context, stack string) (string, error)
 	GetServiceTaskDefinition(ctx context.Context, cluster string, serviceArns []string) (map[string]string, error)
 	ListStackServices(ctx context.Context, stack string) ([]string, error)
 	GetServiceTasks(ctx context.Context, cluster string, service string, stopped bool) ([]*ecs.Task, error)

--- a/ecs/list.go
+++ b/ecs/list.go
@@ -71,6 +71,12 @@ func (b *ecsAPIService) checkStackState(ctx context.Context, name string) error 
 			svcNames[r.ARN] = r.LogicalID
 		}
 	}
+	if len(cluster) == 0 {
+		cluster, err = b.aws.GetStackMetadataClusterID(ctx, name)
+		if err != nil {
+			return err
+		}
+	}
 	if len(svcArns) == 0 {
 		return nil
 	}

--- a/ecs/sdk.go
+++ b/ecs/sdk.go
@@ -505,6 +505,10 @@ func (s sdk) GetStackClusterID(ctx context.Context, stack string) (string, error
 		token = response.NextToken
 	}
 	// stack is using user-provided cluster
+	return s.GetStackMetadataClusterID(ctx, stack)
+}
+
+func (s sdk) GetStackMetadataClusterID(ctx context.Context, stack string) (string, error) {
 	res, err := s.CF.GetTemplateSummaryWithContext(ctx, &cloudformation.GetTemplateSummaryInput{
 		StackName: aws.String(stack),
 	})


### PR DESCRIPTION
Fixes: #1084, #2086

___

I'm aware that in light of the impending EOL per #2258, that this contribution will very likely not be accepted, however, I'm still opening this PR here in order to close the loop on #1084 and #2086 in this repository, and will then be opening a matching PR over in https://github.com/docker/compose-ecs to support docker/compose-ecs#7.